### PR TITLE
Phase 5: Example Project Files

### DIFF
--- a/examples/spring-boot-microservice/README.md
+++ b/examples/spring-boot-microservice/README.md
@@ -67,7 +67,7 @@ Tracks known shortcuts and issues. Customize:
 
 When using these in your project:
 
-```
+```text
 your-project/
 ├── .github/
 │   ├── copilot-instructions.md    # ← From this example

--- a/examples/spring-boot-microservice/TECH-DEBT.md
+++ b/examples/spring-boot-microservice/TECH-DEBT.md
@@ -133,7 +133,7 @@ When working on this codebase:
 
 ### Example Agent Workflow
 
-```
+```text
 1. Read TECH-DEBT.md before starting implementation
 2. If feature touches DEBT-002 area, consider fixing as part of work
 3. If time-constrained and introducing shortcut, document here

--- a/examples/spring-boot-microservice/architecture-rules.md
+++ b/examples/spring-boot-microservice/architecture-rules.md
@@ -2,6 +2,8 @@
 
 This document defines the architectural constraints for the Order Service microservice. All agents and developers must follow these rules.
 
+These rules are provided as an example baseline for a Spring Boot microservice; when adopting this template, adjust them to match your project's actual architecture and constraints.
+
 ## Layer Architecture
 
 ### Layer Definitions
@@ -18,7 +20,7 @@ This document defines the architectural constraints for the Order Service micros
 
 ### Layer Diagram
 
-```
+```text
                     ┌──────────────┐
                     │  Controller  │
                     └──────┬───────┘
@@ -27,9 +29,9 @@ This document defines the architectural constraints for the Order Service micros
           ┌─────────│   Service    │─────────┐
           │         └──────┬───────┘         │
           │                │                 │
-   ┌──────▼───────┐ ┌──────▼───────┐ ┌───────▼──────┐
-   │    Client    │ │  Repository  │ │    Mapper    │
-   └──────────────┘ └──────────────┘ └──────────────┘
+    ┌──────▼───────┐ ┌──────▼───────┐ ┌───────▼──────┐
+    │    Client    │ │  Repository  │ │    Mapper    │
+    └──────────────┘ └──────────────┘ └──────────────┘
 ```
 
 ## Dependency Rules
@@ -85,7 +87,7 @@ public class OrderService {
 
 ### Internal vs External
 
-```
+```text
 com.example.orderservice/
 ├── controller/          # @RestController classes only
 │   └── internal/        # Internal endpoints (not exposed)

--- a/examples/spring-boot-microservice/copilot-instructions.md
+++ b/examples/spring-boot-microservice/copilot-instructions.md
@@ -16,7 +16,7 @@ Microservice handling order processing for an e-commerce platform. This is an **
 
 Layered architecture following Domain-Driven Design principles:
 
-```
+```text
 ┌─────────────────────────────────────────────────┐
 │                  Controllers                     │
 │            (REST API / HTTP Handling)           │
@@ -34,7 +34,7 @@ Layered architecture following Domain-Driven Design principles:
 
 ## Package Structure
 
-```
+```text
 com.example.orderservice/
 ├── controller/          # REST endpoints
 ├── service/             # Business logic
@@ -50,11 +50,13 @@ com.example.orderservice/
 ## Key Conventions
 
 ### Dependency Injection
+
 - **Always** use constructor injection
 - Use `@RequiredArgsConstructor` from Lombok
 - Avoid `@Autowired` on fields
 
 ### Naming Conventions
+
 - Controllers: `*Controller` (e.g., `OrderController`)
 - Services: `*Service` (e.g., `OrderService`)
 - Repositories: `*Repository` (e.g., `OrderRepository`)
@@ -62,17 +64,20 @@ com.example.orderservice/
 - Entities: Business domain names (e.g., `Order`, `OrderItem`)
 
 ### Error Handling
+
 - Use `@ControllerAdvice` for global exception handling
 - Return `ProblemDetail` (RFC 7807) for error responses
 - Create domain-specific exceptions extending `RuntimeException`
 
 ### API Design
+
 - Follow REST conventions
 - Use `@Valid` for request validation
 - Return appropriate HTTP status codes
 - Document with OpenAPI/Swagger annotations
 
 ### Testing
+
 - Unit tests for services (mock dependencies)
 - Integration tests for repositories (TestContainers)
 - API tests for controllers (MockMvc)
@@ -88,6 +93,7 @@ com.example.orderservice/
 ## External Dependencies
 
 When interacting with external services:
+
 - Use `RestClient` (Spring 6.1+) or `WebClient` for HTTP calls
 - Implement circuit breakers with Resilience4j
 - Define response timeout configurations


### PR DESCRIPTION
Implements Phase 5 of issue #1 by adding Spring Boot microservice example files and polishing related documentation.\n\nKey changes:\n- Add example Spring Boot microservice configuration files under examples/spring-boot-microservice/\n- Provide copilot-instructions.md, architecture-rules.md, and TECH-DEBT.md templates\n- Add README explaining how to adapt and use these examples\n- Refine markdown code fences and clarify that architecture rules are example defaults to customize\n\nThis PR builds on the earlier work for the skills framework and completes the Example Project Files phase.