### PR TITLE
ci: notify .github-private sync on agent updates

### DIFF
--- a/.github/workflows/notify-agent-sync.yml
+++ b/.github/workflows/notify-agent-sync.yml
@@ -8,10 +8,11 @@ on:
       - .github/agents/**
 
 permissions:
-  contents: read
+  contents: none
 
 jobs:
   notify-sync:
+    if: ${{ github.repository == 'Grimblaz/workflow-template' }}
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch sync event to .github-private
@@ -22,9 +23,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          [ -n "${AGENT_SYNC_PAT:-}" ] || { echo "AGENT_SYNC_PAT is not set" >&2; exit 1; }
+
           curl --fail --silent --show-error \
             -X POST \
             -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${AGENT_SYNC_PAT}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/Grimblaz-and-Friends/.github-private/dispatches \


### PR DESCRIPTION
## Summary
- Add `.github/workflows/notify-agent-sync.yml`
- Trigger on pushes to `main` that touch `.github/agents/**`
- Dispatch `agent-sync` event to `Grimblaz-and-Friends/.github-private`
- Include source repo + SHA in `client_payload`

## Why
This enables near-real-time sync of template agent changes into `.github-private` while issue #8 also keeps a daily schedule fallback.

## Validation
- Workflow YAML created and reviewed
- Uses `curl --fail --silent --show-error` to fail on dispatch errors

## Required setup
- Add repository secret `AGENT_SYNC_PAT` in `Grimblaz/workflow-template` with permissions to dispatch to `Grimblaz-and-Friends/.github-private`

Related:
- Grimblaz-and-Friends/.github-private#8

## Summary by Sourcery

CI:
- Introduce a workflow that triggers on pushes to main affecting .github/agents/** and sends a repository_dispatch event with repo and SHA metadata to Grimblaz-and-Friends/.github-private.