### PR TITLE
fix(#40): prompt user to confirm branch cleanup at session start

### DIFF
--- a/.github/scripts/session-cleanup-detector.ps1
+++ b/.github/scripts/session-cleanup-detector.ps1
@@ -64,8 +64,8 @@ if ($currentBranch) {
         $upstreamRef = (git rev-parse --abbrev-ref '@{u}' 2>$null)
         if ($LASTEXITCODE -eq 0) {
             # Has upstream — check whether the remote branch still exists
-            $remoteName        = ($upstreamRef -split '/', 2)[0]
-            $remoteBranchName  = ($upstreamRef -split '/', 2)[1]
+            $remoteName = ($upstreamRef -split '/', 2)[0]
+            $remoteBranchName = ($upstreamRef -split '/', 2)[1]
             if ([string]::IsNullOrWhiteSpace($remoteBranchName)) { $remoteBranchName = $currentBranch }
             $remoteHeads = (git ls-remote --heads $remoteName $remoteBranchName 2>$null)
             if ($LASTEXITCODE -eq 0) {
@@ -194,7 +194,7 @@ function Get-TrackingCommands {
     return $out
 }
 
-$escaped        = if ($null -ne $staleBranch) { $staleBranch.BranchName -replace "'", "''" } else { $null }
+$escaped = if ($null -ne $staleBranch) { $staleBranch.BranchName -replace "'", "''" } else { $null }
 $escapedDefault = $defaultBranch -replace "'", "''"
 
 if ($null -ne $staleBranch -and $cleanupNeeded.Count -eq 0) {
@@ -213,7 +213,7 @@ if ($null -ne $staleBranch -and $cleanupNeeded.Count -eq 0) {
     }
     $lines += '```'
     $lines += ''
-    $lines += 'Or skip by continuing with your request.'
+    $lines += '**Agent instruction**: Before responding to the user''s request, use `ask_questions` to confirm: "You''re on a stale feature branch — run branch cleanup now? (yes / skip)". If confirmed, run the command above, then continue. If skipped, continue with the user''s request.'
 }
 elseif ($null -ne $staleBranch -and $cleanupNeeded.Count -gt 0) {
     $dedupedCleanup = @($cleanupNeeded | Where-Object { $_.IssueId -ne $staleBranch.IssueId })
@@ -244,7 +244,7 @@ elseif ($null -ne $staleBranch -and $cleanupNeeded.Count -gt 0) {
     }
     $lines += '```'
     $lines += ''
-    $lines += 'Or skip by continuing with your request.'
+    $lines += '**Agent instruction**: Before responding to the user''s request, use `ask_questions` to confirm: "You''re on a stale feature branch with leftover tracking files — run full cleanup now? (yes / skip)". If confirmed, run the commands above, then continue. If skipped, continue with the user''s request.'
 }
 else {
     # ── Tracking-files-only signal (existing behaviour) ───────────────────────
@@ -257,7 +257,7 @@ else {
     $lines += (Get-TrackingCommands -Items $cleanupNeeded)
     $lines += '```'
     $lines += ''
-    $lines += 'Or skip by continuing with your request.'
+    $lines += '**Agent instruction**: Before responding to the user''s request, use `ask_questions` to confirm: "Stale tracking files found from a merged branch — run tracking file cleanup now? (yes / skip)". If confirmed, run the commands above, then continue. If skipped, continue with the user''s request.'
 }
 
 $additionalContext = $lines -join "`n"

--- a/.github/scripts/test-session-cleanup-detector.ps1
+++ b/.github/scripts/test-session-cleanup-detector.ps1
@@ -15,7 +15,7 @@
 param([switch]$Verbose)
 
 $ErrorActionPreference = 'Stop'
-$scriptDir  = Split-Path -Parent $PSCommandPath
+$scriptDir = Split-Path -Parent $PSCommandPath
 $detectorPath = Join-Path $scriptDir 'session-cleanup-detector.ps1'
 
 $script:passed = 0
@@ -153,7 +153,7 @@ function Invoke-Scenario {
 
     $mockDir = New-MockGitDir -Config $GitConfig
     $oldPath = $env:PATH
-    $oldCwd  = (Get-Location).Path
+    $oldCwd = (Get-Location).Path
 
     try {
         # Prepend mock dir so our git.cmd wins over the real git
@@ -207,7 +207,7 @@ function Assert-HasCleanupContext {
     param([string]$Output, [string[]]$Contains)
     try {
         $json = $Output | ConvertFrom-Json -ErrorAction Stop
-        $ctx  = $json.hookSpecificOutput.additionalContext
+        $ctx = $json.hookSpecificOutput.additionalContext
         if (-not $ctx) {
             return @{ Pass = $false; Reason = "additionalContext absent or empty. Output: $Output" }
         }
@@ -227,12 +227,12 @@ function Assert-BranchFirstInContext {
     param([string]$Output, [string]$BranchContains, [string]$TrackingContains)
     try {
         $json = $Output | ConvertFrom-Json -ErrorAction Stop
-        $ctx  = $json.hookSpecificOutput.additionalContext
+        $ctx = $json.hookSpecificOutput.additionalContext
         if (-not $ctx) {
             return @{ Pass = $false; Reason = "No additionalContext. Output: $Output" }
         }
 
-        $branchIdx   = ([string]$ctx).IndexOf($BranchContains,   [System.StringComparison]::OrdinalIgnoreCase)
+        $branchIdx = ([string]$ctx).IndexOf($BranchContains, [System.StringComparison]::OrdinalIgnoreCase)
         $trackingIdx = ([string]$ctx).IndexOf($TrackingContains, [System.StringComparison]::OrdinalIgnoreCase)
 
         if ($branchIdx -lt 0) {
@@ -294,9 +294,9 @@ Write-Host "`nRunning session-cleanup-detector.ps1 verification (issue #40)`n"
 Invoke-Scenario `
     -Name 'S1: On main — no-op (fast exit, no tracking files)' `
     -GitConfig @{
-        'branch--show-current'    = 'main'
-        'symbolic-ref-origin-HEAD'= 'refs/remotes/origin/main'
-    } `
+    'branch--show-current'     = 'main'
+    'symbolic-ref-origin-HEAD' = 'refs/remotes/origin/main'
+} `
     -WorkDir $emptyWorkDir `
     -Assert { param($o) Assert-NoOp $o }
 
@@ -304,44 +304,44 @@ Invoke-Scenario `
 Invoke-Scenario `
     -Name 'S2: Stale branch feature/issue-36-stale (remote gone) → cleanup JSON' `
     -GitConfig @{
-        'branch--show-current'              = 'feature/issue-36-stale'
-        'symbolic-ref-origin-HEAD'          = 'refs/remotes/origin/main'
-        'rev-parse-exit'                    = 0
-        'rev-parse-upstream'                = 'origin/feature/issue-36-stale'
-        'ls-remote-feature/issue-36-stale'  = ''   # empty = remote gone
-        'ls-remote-feature/issue-36-*'      = ''
-        'branch-list-feature/issue-36-*'    = '  feature/issue-36-stale'
-    } `
+    'branch--show-current'             = 'feature/issue-36-stale'
+    'symbolic-ref-origin-HEAD'         = 'refs/remotes/origin/main'
+    'rev-parse-exit'                   = 0
+    'rev-parse-upstream'               = 'origin/feature/issue-36-stale'
+    'ls-remote-feature/issue-36-stale' = ''   # empty = remote gone
+    'ls-remote-feature/issue-36-*'     = ''
+    'branch-list-feature/issue-36-*'   = '  feature/issue-36-stale'
+} `
     -WorkDir $emptyWorkDir `
     -Assert {
-        param($o)
-        Assert-HasCleanupContext $o -Contains @('issue-36', 'post-merge-cleanup.ps1')
-    }
+    param($o)
+    Assert-HasCleanupContext $o -Contains @('issue-36', 'post-merge-cleanup.ps1')
+}
 
 # S3 — On my-experiment, upstream set, remote gone → cleanup JSON with git checkout fallback
 Invoke-Scenario `
     -Name 'S3: Stale branch my-experiment (no issue number, remote gone) → cleanup JSON with checkout fallback' `
     -GitConfig @{
-        'branch--show-current'          = 'my-experiment'
-        'symbolic-ref-origin-HEAD'      = 'refs/remotes/origin/main'
-        'rev-parse-exit'                = 0
-        'rev-parse-upstream'            = 'origin/my-experiment'
-        'ls-remote-my-experiment'       = ''   # remote gone
-    } `
+    'branch--show-current'     = 'my-experiment'
+    'symbolic-ref-origin-HEAD' = 'refs/remotes/origin/main'
+    'rev-parse-exit'           = 0
+    'rev-parse-upstream'       = 'origin/my-experiment'
+    'ls-remote-my-experiment'  = ''   # remote gone
+} `
     -WorkDir $emptyWorkDir `
     -Assert {
-        param($o)
-        # Expects cleanup context mentioning the branch and a checkout fallback (no issue number)
-        Assert-HasCleanupContext $o -Contains @('my-experiment', 'git checkout')
-    }
+    param($o)
+    # Expects cleanup context mentioning the branch and a checkout fallback (no issue number)
+    Assert-HasCleanupContext $o -Contains @('my-experiment', 'git checkout')
+}
 
 # S4 — Local branch with NO upstream tracking → no-op (never pushed)
 Invoke-Scenario `
     -Name 'S4: Local branch no-upstream → no-op (never pushed)' `
     -GitConfig @{
-        'branch--show-current'  = 'local-only-branch'
-        'rev-parse-exit'        = 128   # no upstream
-    } `
+    'branch--show-current' = 'local-only-branch'
+    'rev-parse-exit'       = 128   # no upstream
+} `
     -WorkDir $emptyWorkDir `
     -Assert { param($o) Assert-NoOp $o }
 
@@ -349,9 +349,9 @@ Invoke-Scenario `
 Invoke-Scenario `
     -Name 'S5: Detached HEAD (empty branch --show-current) → no-op' `
     -GitConfig @{
-        'branch--show-current'  = ''    # empty = detached HEAD
-        'rev-parse-exit'        = 128
-    } `
+    'branch--show-current' = ''    # empty = detached HEAD
+    'rev-parse-exit'       = 128
+} `
     -WorkDir $emptyWorkDir `
     -Assert { param($o) Assert-NoOp $o }
 
@@ -359,14 +359,14 @@ Invoke-Scenario `
 Invoke-Scenario `
     -Name 'S6: Active branch feature/issue-99-active (remote exists) → no-op' `
     -GitConfig @{
-        'branch--show-current'              = 'feature/issue-99-active'
-        'symbolic-ref-origin-HEAD'          = 'refs/remotes/origin/main'
-        'rev-parse-exit'                    = 0
-        'rev-parse-upstream'                = 'origin/feature/issue-99-active'
-        'ls-remote-feature/issue-99-active' = 'abc123def456 refs/heads/feature/issue-99-active'  # remote exists
-        'ls-remote-feature/issue-99-*'      = 'abc123def456 refs/heads/feature/issue-99-active'
-        'branch-list-feature/issue-99-*'    = '  feature/issue-99-active'
-    } `
+    'branch--show-current'              = 'feature/issue-99-active'
+    'symbolic-ref-origin-HEAD'          = 'refs/remotes/origin/main'
+    'rev-parse-exit'                    = 0
+    'rev-parse-upstream'                = 'origin/feature/issue-99-active'
+    'ls-remote-feature/issue-99-active' = 'abc123def456 refs/heads/feature/issue-99-active'  # remote exists
+    'ls-remote-feature/issue-99-*'      = 'abc123def456 refs/heads/feature/issue-99-active'
+    'branch-list-feature/issue-99-*'    = '  feature/issue-99-active'
+} `
     -WorkDir $emptyWorkDir `
     -Assert { param($o) Assert-NoOp $o }
 
@@ -375,72 +375,72 @@ Invoke-Scenario `
 Invoke-Scenario `
     -Name 'S7: Stale branch (issue-36) + tracking file (issue-40) → branch info first in cleanup JSON' `
     -GitConfig @{
-        'branch--show-current'                        = 'feature/issue-36-janitor-to-hook'
-        'symbolic-ref-origin-HEAD'                    = 'refs/remotes/origin/main'
-        'rev-parse-exit'                              = 0
-        'rev-parse-upstream'                          = 'origin/feature/issue-36-janitor-to-hook'
-        'ls-remote-feature/issue-36-janitor-to-hook'  = ''   # remote gone (branch stale)
-        'ls-remote-feature/issue-40-*'                = ''   # tracking file issue-40 also stale
-        'branch-list-feature/issue-40-*'              = '  feature/issue-40-stale-branch'
-    } `
+    'branch--show-current'                       = 'feature/issue-36-janitor-to-hook'
+    'symbolic-ref-origin-HEAD'                   = 'refs/remotes/origin/main'
+    'rev-parse-exit'                             = 0
+    'rev-parse-upstream'                         = 'origin/feature/issue-36-janitor-to-hook'
+    'ls-remote-feature/issue-36-janitor-to-hook' = ''   # remote gone (branch stale)
+    'ls-remote-feature/issue-40-*'               = ''   # tracking file issue-40 also stale
+    'branch-list-feature/issue-40-*'             = '  feature/issue-40-stale-branch'
+} `
     -WorkDir $s7WorkDir `
     -Assert {
-        param($o)
-        # Combined-signal header must be present, branch info before tracking section
-        Assert-BranchFirstInContext $o `
-            -BranchContains 'feature/issue-36-janitor-to-hook' `
-            -TrackingContains 'stale tracking artifacts also found'
-    }
+    param($o)
+    # Combined-signal header must be present, branch info before tracking section
+    Assert-BranchFirstInContext $o `
+        -BranchContains 'feature/issue-36-janitor-to-hook' `
+        -TrackingContains 'stale tracking artifacts also found'
+}
 
 # S8 — Master-branch repository: symbolic-ref fails, show-ref main fails, show-ref master succeeds
 # Branch has no issue number → fallback uses 'git checkout master'
 Invoke-Scenario `
     -Name 'S8: Master-branch repo (show-ref master) → cleanup uses master in fallback command' `
     -GitConfig @{
-        'branch--show-current'       = 'feature/my-experiment-master'
-        'show-ref-main-exitcode'     = 1    # main not found
-        'show-ref-master-exitcode'   = 0    # master found
-        'rev-parse-exit'             = 0
-        'rev-parse-upstream'         = 'origin/feature/my-experiment-master'
-        # ls-remote default = '' (empty = stale branch)
-    } `
+    'branch--show-current'     = 'feature/my-experiment-master'
+    'show-ref-main-exitcode'   = 1    # main not found
+    'show-ref-master-exitcode' = 0    # master found
+    'rev-parse-exit'           = 0
+    'rev-parse-upstream'       = 'origin/feature/my-experiment-master'
+    # ls-remote default = '' (empty = stale branch)
+} `
     -WorkDir $emptyWorkDir `
     -Assert {
-        param($o)
-        # Cleanup context must exist and reference 'master' in the fallback checkout command
-        Assert-HasCleanupContext $o -Contains @('my-experiment-master', 'master')
-    }
+    param($o)
+    # Cleanup context must exist and reference 'master' in the fallback checkout command
+    Assert-HasCleanupContext $o -Contains @('my-experiment-master', 'master')
+}
 
 # S9 — HEAD-fallback strategy: symbolic-ref origin/HEAD fails, both show-ref fail,
 # git symbolic-ref HEAD returns refs/heads/develop → default branch = develop
 Invoke-Scenario `
     -Name 'S9: HEAD-fallback (symbolic-ref HEAD) → stale branch still fires cleanup' `
     -GitConfig @{
-        'branch--show-current'       = 'feature/my-experiment-head-fallback'
-        'show-ref-main-exitcode'     = 1    # main not found
-        'show-ref-master-exitcode'   = 1    # master not found
-        'symbolic-ref-HEAD'          = 'refs/heads/develop'
-        'rev-parse-exit'             = 0
-        'rev-parse-upstream'         = 'origin/feature/my-experiment-head-fallback'
-        # ls-remote default = '' (empty = stale branch)
-    } `
+    'branch--show-current'     = 'feature/my-experiment-head-fallback'
+    'show-ref-main-exitcode'   = 1    # main not found
+    'show-ref-master-exitcode' = 1    # master not found
+    'symbolic-ref-HEAD'        = 'refs/heads/develop'
+    'rev-parse-exit'           = 0
+    'rev-parse-upstream'       = 'origin/feature/my-experiment-head-fallback'
+    # ls-remote default = '' (empty = stale branch)
+} `
     -WorkDir $emptyWorkDir `
     -Assert {
-        param($o)
-        # Cleanup context must be non-empty — branch detected as stale
-        Assert-HasCleanupContext $o -Contains @('my-experiment-head-fallback')
-    }
+    param($o)
+    # Cleanup context must be non-empty — branch detected as stale
+    Assert-HasCleanupContext $o -Contains @('my-experiment-head-fallback')
+}
 
 # S10 — ls-remote network failure → Assert-NoOp (PAT-4)
 Invoke-Scenario `
     -Name 'S10: ls-remote network failure (exit 1) → no-op (guard prevents false positive)' `
     -GitConfig @{
-        'branch--show-current'       = 'feature/issue-40-net-fail'
-        'symbolic-ref-origin-HEAD'   = 'refs/remotes/origin/main'
-        'rev-parse-exit'             = 0
-        'rev-parse-upstream'         = 'origin/feature/issue-40-net-fail'
-        'ls-remote-exitcode'         = 1    # network failure
-    } `
+    'branch--show-current'     = 'feature/issue-40-net-fail'
+    'symbolic-ref-origin-HEAD' = 'refs/remotes/origin/main'
+    'rev-parse-exit'           = 0
+    'rev-parse-upstream'       = 'origin/feature/issue-40-net-fail'
+    'ls-remote-exitcode'       = 1    # network failure
+} `
     -WorkDir $emptyWorkDir `
     -Assert { param($o) Assert-NoOp $o }
 
@@ -448,38 +448,38 @@ Invoke-Scenario `
 Invoke-Scenario `
     -Name 'S11: Same-issue dual-signal (issue-40 branch + tracking file) → single cleanup command, no tracking section' `
     -GitConfig @{
-        'branch--show-current'                     = 'feature/issue-40-stale-branch'
-        'symbolic-ref-origin-HEAD'                 = 'refs/remotes/origin/main'
-        'rev-parse-exit'                           = 0
-        'rev-parse-upstream'                       = 'origin/feature/issue-40-stale-branch'
-        'ls-remote-feature/issue-40-stale-branch'  = ''   # branch stale
-        'ls-remote-feature/issue-40-*'             = ''   # tracking file issue-40 also stale
-        'branch-list-feature/issue-40-*'           = '  feature/issue-40-stale-branch'
-    } `
+    'branch--show-current'                    = 'feature/issue-40-stale-branch'
+    'symbolic-ref-origin-HEAD'                = 'refs/remotes/origin/main'
+    'rev-parse-exit'                          = 0
+    'rev-parse-upstream'                      = 'origin/feature/issue-40-stale-branch'
+    'ls-remote-feature/issue-40-stale-branch' = ''   # branch stale
+    'ls-remote-feature/issue-40-*'            = ''   # tracking file issue-40 also stale
+    'branch-list-feature/issue-40-*'          = '  feature/issue-40-stale-branch'
+} `
     -WorkDir $s11WorkDir `
     -Assert {
-        param($o)
-        try {
-            $json = $o | ConvertFrom-Json -ErrorAction Stop
-            $ctx  = $json.hookSpecificOutput.additionalContext
-            if (-not $ctx) {
-                return @{ Pass = $false; Reason = "Expected cleanup context but additionalContext is empty. Output: $o" }
-            }
-            # Exactly one reference to post-merge-cleanup.ps1 (dedup removed the tracking entry)
-            $cmdMatches = ([regex]::Matches($ctx, 'post-merge-cleanup\.ps1')).Count
-            if ($cmdMatches -ne 1) {
-                return @{ Pass = $false; Reason = "Expected exactly 1 post-merge-cleanup.ps1 reference, found $cmdMatches. ctx=[$ctx]" }
-            }
-            # Tracking-file sub-section must be absent (deduplicated away)
-            if ($ctx -like '*stale tracking artifacts also found*') {
-                return @{ Pass = $false; Reason = "Tracking-file section should be absent after dedup but was found. ctx=[$ctx]" }
-            }
-            return @{ Pass = $true }
+    param($o)
+    try {
+        $json = $o | ConvertFrom-Json -ErrorAction Stop
+        $ctx = $json.hookSpecificOutput.additionalContext
+        if (-not $ctx) {
+            return @{ Pass = $false; Reason = "Expected cleanup context but additionalContext is empty. Output: $o" }
         }
-        catch {
-            return @{ Pass = $false; Reason = "JSON parse error: $_. Output: $o" }
+        # Exactly one reference to post-merge-cleanup.ps1 (dedup removed the tracking entry)
+        $cmdMatches = ([regex]::Matches($ctx, 'post-merge-cleanup\.ps1')).Count
+        if ($cmdMatches -ne 1) {
+            return @{ Pass = $false; Reason = "Expected exactly 1 post-merge-cleanup.ps1 reference, found $cmdMatches. ctx=[$ctx]" }
         }
+        # Tracking-file sub-section must be absent (deduplicated away)
+        if ($ctx -like '*stale tracking artifacts also found*') {
+            return @{ Pass = $false; Reason = "Tracking-file section should be absent after dedup but was found. ctx=[$ctx]" }
+        }
+        return @{ Pass = $true }
     }
+    catch {
+        return @{ Pass = $false; Reason = "JSON parse error: $_. Output: $o" }
+    }
+}
 
 # ---------------------------------------------------------------------------
 # Cleanup temp directories


### PR DESCRIPTION
## Summary

Follow-up to #41. The `additionalContext` injected by the SessionStart hook was passive ("Or skip by continuing with your request"), leaving it to the agent to decide whether to act. This changes all three signal branches to include an explicit agent directive that forces a `ask_questions` confirmation before proceeding.

## Changes

Three cleanup prompts in `session-cleanup-detector.ps1` updated from generic "Run cleanup now?" to context-specific questions:

| Signal | New prompt |
|--------|-----------|
| Branch-only | "You're on a stale feature branch — run branch cleanup now? (yes / skip)" |
| Branch + tracking files | "You're on a stale feature branch with leftover tracking files — run full cleanup now? (yes / skip)" |
| Tracking-files-only | "Stale tracking files found from a merged branch — run tracking file cleanup now? (yes / skip)" |

Each prompt is prefaced with `**Agent instruction**: Before responding to the user's request, use ask_questions to confirm:` to make the expected agent behavior unambiguous.

Closes #40 (post-ship polish)

## Summary by Sourcery

Update the session cleanup detector hook to recognize stale branches as well as stale tracking files and to require explicit user confirmation before running cleanup, and add a dedicated test harness plus documentation updates for this behavior.

New Features:
- Add stale branch detection to the SessionStart cleanup hook so it can prompt cleanup even when no tracking files exist.
- Introduce an explicit agent instruction in injected context that forces an ask_questions confirmation before running any cleanup commands.

Enhancements:
- Refine cleanup messaging to distinguish between branch-only, tracking-only, and combined stale states, including tailored cleanup commands for each path.
- Improve default-branch resolution and guard against false positives in git remote checks within the cleanup detector script.

Documentation:
- Document the dual-path (branch and tracking-file) detection behavior and the post-ship enhancement for issue #40 in the janitor-to-hook design doc.

Tests:
- Add a PowerShell verification harness that mocks git to cover multiple stale/active branch and tracking-file scenarios for the session cleanup detector.