### PR TITLE
feat(#38): add Script & Automation Files review perspective to Code-Critic

### DIFF
--- a/.github/agents/Code-Critic.agent.md
+++ b/.github/agents/Code-Critic.agent.md
@@ -286,11 +286,11 @@ For any **new data field, constant, or map** added:
 - [ ] Unnecessary complexity removed
 - [ ] Comments explain "why", not "what"
 
-### 6. Script & Automation Files (.ps1, .sh, .py)
+### 6. Script & Automation Files
 
-**When to apply**: PR includes `.ps1`, `.sh`, `.py`, or `.yml` (for `run:` shell blocks) files.
+**When to apply**: PR includes `.ps1`, `.sh`, `.py`, `.yml`, or `.yaml` (for `run:` shell blocks) files.
 
-- [ ] Native executable calls (`git`, `gh`, `curl`, `pwsh`, etc.) have explicit exit-code checks immediately after the call — do NOT rely on shell error modes (`set -e`, `$ErrorActionPreference = 'Stop'`, `try/catch`, `trap`) to catch them — none of these capture native-executable exit codes; only `$LASTEXITCODE`/`$?` checks or `|| exit` are reliable
+- [ ] Native executable calls (`git`, `gh`, `curl`, `pwsh`, etc.) have explicit exit-code checks immediately after the call — do NOT rely on `$ErrorActionPreference = 'Stop'`, `try/catch`, or `trap` in PowerShell (these do not catch non-zero native exit codes); in POSIX shells, `set -e` / `trap ERR` can intercept exit codes but carry well-known caveats (subshells, pipelines, `&&` chains) — always prefer explicit `$LASTEXITCODE` (PowerShell) or `$?` / `|| exit` (POSIX) checks for each call
 - [ ] Dynamic values are NOT passed to `Invoke-Expression`, `& $dynamicVar`, `Start-Process` with runtime-constructed argument strings, or equivalent constructs (`eval`, `subprocess.Popen(shell=True)`); if unavoidable, input is allowlist-validated — not merely escaped
 - [ ] Any string constructed from dynamic values and emitted to an output sink (Markdown, JSON, terminal display) is sanitized for that medium's metacharacters (e.g., backtick and triple-backtick sequences break Markdown code-block rendering; unescaped `"` breaks JSON structure)
 - [ ] Regex patterns involving domain-specific character sets (repo names, branch names, file paths) are validated against known edge cases (dotted names, slashes, special chars)


### PR DESCRIPTION
## Summary

Adds a new **`### 6. Script & Automation Files`** review perspective to Code-Critic's checklist, generalizing three missed findings from PR #37's post-PR review (H-1 command injection, H-2 silent native executable failure, M-1 regex edge cases) into a cross-platform checklist covering `.ps1`, `.sh`, `.py`, and `.yml` (run: shell blocks).

**Design decision**: Generalized from PowerShell-only to all script types — the same failure modes appear identically in bash/sh/Python subprocess calls and GitHub Actions workflow `run:` blocks.

## Changed Files

| File | Change |
|---|---|
| `.github/agents/Code-Critic.agent.md` | +14 lines, -1 line — new perspective #6 + output format entry |

## What Changed

**New `### 6. Script & Automation Files` perspective** (appended after #5 Simplicity):

- **Condition gate** (bold `**When to apply**` — matching Browser-Based Review style): `.ps1`, `.sh`, `.py`, `.yml` run blocks
- **Item 1 (H-2)**: Explicit exit-code checks after native executable calls — explicitly excludes `set -e`, `$ErrorActionPreference = 'Stop'`, `try/catch`, `trap` (none catch native non-zero exits; only `$LASTEXITCODE`/`$?` or `|| exit` are reliable)
- **Item 2a (H-1)**: Dynamic values NOT passed to `Invoke-Expression`, `& $dynamicVar`, `Start-Process`, `eval`, `subprocess.Popen(shell=True)` — commands using runtime-constructed argument strings flagged as high-risk injection sites requiring allowlist validation
- **Item 2b (H-1 output-sink)**: Output-sink sanitization for Markdown/JSON/terminal display metacharacters (with concrete examples)
- **Item 3 (M-1)**: Regex character-class validation against domain-specific edge cases (dotted names, slashes, special chars)

**Output format template**: new `### ✅ Script & Automation: PASS/FAIL/N-A` entry with "mark N/A when PR has no script files" (omit option removed for auditability).

**Count update**: `all 5 perspectives` → `all 6 perspectives`.

## Validation Evidence

**TDD RED → GREEN**:
```
Check A (### 6. Script & Automation Files): False → True ✅
Check B (all 6 perspectives):               False → True ✅
Check C (Script & Automation: PASS/FAIL):   False → True ✅
```

**Quick-validate**:
```
Plan-Architect refs (pre-existing in architecture-rules.md, not introduced): 2 (baseline unchanged)
Janitor refs (pre-existing in architecture-rules.md, not introduced):        1 (baseline unchanged)
Agent count: 13 ✅
Scope (git diff --name-only): .github/agents/Code-Critic.agent.md only ✅
```

Pre-existing stale refs in `architecture-rules.md` (`Plan-Architect` × 2, `Janitor` × 1) are not introduced by this PR — confirmed by stash/check against main baseline.

**Code-Critic review**: 7 findings (3 Issues, 3 Concerns, 1 Nit). All accepted findings implemented via Code-Review-Response adjudication cycle. Finding 6 rejected as duplicate of Finding 1.

## CE Gate

⏭️ **CE Gate not applicable** — change is to an agent instruction file (`.agent.md`). No Web UI, REST API, CLI, SDK, or batch pipeline surface is exposed.

## Process Retrospective

The review cycle surfaced that the initially proposed checklist (directly from the issue body) had a gap: Item 2's examples were calibrated for output-sink injection (Markdown escaping) but H-1 was execution-context injection (`Invoke-Expression`). The adversarial Code-Critic pass caught this before merge — which is exactly the process this PR is designed to reinforce for future reviews.

No systemic process gap identified; the existing review loop worked as intended.

Closes #38

## Summary by Sourcery

Add a new mandatory Script & Automation Files review perspective to the Code-Critic agent and update its output template accordingly.

New Features:
- Introduce a dedicated checklist perspective for reviewing script and automation files across PowerShell, shell, Python, and YAML run blocks.

Enhancements:
- Require reviewers to explicitly cover six perspectives instead of five in Code-Critic reviews.
- Extend the review output template with a Script & Automation PASS/FAIL/N-A section for better auditability.