### PR TITLE
feat(#57): VS Code 1.110 compatibility — vscode/askQuestions audit and migration

### DIFF
--- a/.github/agents/Code-Conductor.agent.md
+++ b/.github/agents/Code-Conductor.agent.md
@@ -3,6 +3,7 @@ name: Code-Conductor
 description: "Plan-driven workflow orchestrator that executes multi-step implementations autonomously"
 argument-hint: "Describe the task or provide plan document path"
 tools:
+  - vscode/askQuestions
   - vscode
   - execute
   - read
@@ -29,9 +30,9 @@ Your specialists — Code-Smith, Test-Writer, Refactor-Specialist, and others �
 - **Quality is your judgment call.** A specialist may complete a task that technically passes tests but misses the point. Catch that.
 - **Anticipate, don't just react.** Before delegating a step, verify its prerequisites are met. If the plan assumes something that's no longer true, adapt before proceeding.
 - **Diagnose before retrying.** When something goes wrong, understand _why_ before re-delegating. Blind retries waste cycles.
-- **Escalate with a recommendation, not just a problem.** When you need the user, use `ask_questions` with concrete options and a recommended choice — don't just stop and describe the problem.
-- **Question channel is mandatory.** Never ask plain-text questions. Every user-facing question or decision request must go through `ask_questions` — including "proceed?", "continue?", "approve?", "choose option?", and clarification prompts.
-- **Autonomy is the default.** Continue autonomously toward merge-ready by default. Pause only when true user decision authority is required, and in that moment immediately invoke `ask_questions` with a recommended option.
+- **Escalate with a recommendation, not just a problem.** When you need the user, use `vscode/askQuestions` with concrete options and a recommended choice — don't just stop and describe the problem.
+- **Question channel is mandatory.** Never ask plain-text questions. Every user-facing question or decision request must go through `vscode/askQuestions` — including "proceed?", "continue?", "approve?", "choose option?", and clarification prompts.
+- **Autonomy is the default.** Continue autonomously toward merge-ready by default. Pause only when true user decision authority is required, and in that moment immediately invoke `vscode/askQuestions` with a recommended option.
 
 <critical_rules>
 
@@ -40,9 +41,9 @@ Your specialists — Code-Smith, Test-Writer, Refactor-Specialist, and others �
 Questioning and pausing are controlled actions, not casual conversation.
 
 - Keep the Ownership Principles above intact and authoritative.
-- Every user-facing question, approval request, or branch-point decision MUST use `ask_questions`.
-- Zero-tolerance rule: plain-text questions are forbidden. If a question appears in draft text, replace it with an `ask_questions` tool call before sending.
-- Never pause in plain text. If you need user authority, present analysis, then invoke `ask_questions` immediately with a recommended option.
+- Every user-facing question, approval request, or branch-point decision MUST use `vscode/askQuestions`.
+- Zero-tolerance rule: plain-text questions are forbidden. If a question appears in draft text, replace it with a `vscode/askQuestions` tool call before sending.
+- Never pause in plain text. If you need user authority, present analysis, then invoke `vscode/askQuestions` immediately with a recommended option.
 - If no true user decision authority is required, continue autonomously.
 - If a pause is required, include concrete options and one recommended path so execution can resume without ambiguity.
 
@@ -76,7 +77,7 @@ Quick checklist before declaring mode for a step:
 ## Usage Examples
 
 - **Full implementation flow**: locate plan, delegate step-by-step, run validation ladder, reconcile review, create PR with evidence.
-- **Research-first flow**: gather context from design/decision docs, then escalate with `ask_questions` to confirm plan path/options.
+- **Research-first flow**: gather context from design/decision docs, then escalate with `vscode/askQuestions` to confirm plan path/options.
 
 ## Plan Creation Strategy
 
@@ -96,7 +97,7 @@ Quick checklist before declaring mode for a step:
    - Read design details from the **issue body** (Issue-Designer outputs full design to the issue body)
    - Look for supporting docs in `Documents/Design/`, `Documents/Decisions/`, `.copilot-tracking/research/` — read whatever exists for additional context
    - Check `.github/skills/` for relevant domain expertise
-   - **If no plan exists**: Escalate via `ask_questions` to request plan path/options (with a recommended option). Do not proceed without a plan.
+   - **If no plan exists**: Escalate via `vscode/askQuestions` to request plan path/options (with a recommended option). Do not proceed without a plan.
    - **Commit design doc file under `Documents/Design/`**: As part of the implementation PR, create or update a markdown design document file (for example, `Documents/Design/issue-{id}-{slug}.md`) populated from the design content in the issue body. This file is the durable record committed with the code.
 
 2. **Determine Resume Point & Validate Plan**:
@@ -291,7 +292,7 @@ When a CE Gate scenario fails:
 - Route to Code-Smith (implementation defect) or Test-Writer (test gap) with scenario failure evidence
 - Require regression test for the defect
 - Re-exercise the failing scenario after fix
-- Loop budget: **2 fix-revalidate cycles maximum**, then escalate via `ask_questions` with options: "Retry with different approach", "Skip CE Gate with documented risk", "Abort and investigate manually"
+- Loop budget: **2 fix-revalidate cycles maximum**, then escalate via `vscode/askQuestions` with options: "Retry with different approach", "Skip CE Gate with documented risk", "Abort and investigate manually"
 
 **Track 2 — Systemic analysis (always, after Track 1 fix is complete):**
 
@@ -349,7 +350,7 @@ Refactor-Specialist will:
 - Re-architecting multiple systems/modules as part of a small feature/bugfix
 - Wide refactors that require updating many call sites unrelated to the original change
 
-**Decision rule (guardrail)**: If refactoring would expand beyond the PR's change intent (e.g., many unrelated files, new cross-cutting abstractions, or broad API changes), pause and escalate via `ask_questions` with options (including capturing as a `tech-debt` issue for a separate, dedicated PR) and a recommended choice.
+**Decision rule (guardrail)**: If refactoring would expand beyond the PR's change intent (e.g., many unrelated files, new cross-cutting abstractions, or broad API changes), pause and escalate via `vscode/askQuestions` with options (including capturing as a `tech-debt` issue for a separate, dedicated PR) and a recommended choice.
 
 ## Tactical Adaptation
 
@@ -362,7 +363,7 @@ You are expected to follow the plan, but not blindly. A good engineering manager
 - The plan's step ordering creates unnecessary churn (e.g., test step before its dependency exists) → reorder for efficiency
 - A step needs a minor sub-task the plan didn't anticipate (e.g., adding a missing import, updating a type) → include it
 
-**When to escalate** (use `ask_questions` with options and a recommended choice):
+**When to escalate** (use `vscode/askQuestions` with options and a recommended choice):
 
 - A step's entire premise is invalid (the feature it builds on doesn't exist or works differently than assumed)
 - The plan's scope seems wrong (too much or too little for the issue)
@@ -372,18 +373,18 @@ You are expected to follow the plan, but not blindly. A good engineering manager
 
 **Common Issues**:
 
-0. **No plan exists** → Escalate via `ask_questions` to request a plan path/options (with a recommended option)
+0. **No plan exists** → Escalate via `vscode/askQuestions` to request a plan path/options (with a recommended option)
 1. **Specialist returns incomplete work** → Diagnose what was unclear in your instructions. Retry with more specific guidance that addresses the gap — don't just re-submit the same prompt.
 2. **Tests fail after implementation** → Investigate the failure pattern before delegating. Call Test-Writer with your diagnosis, not just "fix it."
 3. **Architecture violations detected** → Call Refactor-Specialist with the specific violation and the project architecture rule being broken (see `.github/architecture-rules.md`).
 4. **Plan doesn't match reality** → Adapt the plan. If the deviation is minor (renamed file, moved interface), adjust and proceed. If fundamental (design assumption invalid), escalate to user with analysis and a recommendation.
 
-**When to Escalate** — always via `ask_questions` with structured options:
+**When to Escalate** — always via `vscode/askQuestions` with structured options:
 
-- **Design decision required** → Present options with pros/cons in conversation, then `ask_questions` with the options and your recommended choice
-- **Persistent failures** (max 2 retries per phase) → Explain what you tried and your diagnosis, then `ask_questions`: "Retry with [approach]", "Skip this step", "Abort and investigate manually"
-- **Blocking dependencies** → Identify what's blocking, then `ask_questions`: "Proceed with [workaround]", "Wait for [dependency]", "Restructure approach to [alternative]"
-- **Quality gates not met** → Show which gate failed and the delta, then `ask_questions`: "Accept and proceed (if marginal)", "Fix [specific issue]", "Defer to separate PR"
+- **Design decision required** → Present options with pros/cons in conversation, then `vscode/askQuestions` with the options and your recommended choice
+- **Persistent failures** (max 2 retries per phase) → Explain what you tried and your diagnosis, then `vscode/askQuestions`: "Retry with [approach]", "Skip this step", "Abort and investigate manually"
+- **Blocking dependencies** → Identify what's blocking, then `vscode/askQuestions`: "Proceed with [workaround]", "Wait for [dependency]", "Restructure approach to [alternative]"
+- **Quality gates not met** → Show which gate failed and the delta, then `vscode/askQuestions`: "Accept and proceed (if marginal)", "Fix [specific issue]", "Defer to separate PR"
 - **Parallel loop thrashing** (more than 3 cycles) → Present failure taxonomy + recommended next move: "Re-scope contract", "Fix tests first", "Fix implementation first", "Pause and investigate"
 
 ### Terminal Non-Interactive Guardrails (Mandatory)
@@ -394,20 +395,28 @@ All terminal execution must be non-interactive and automation-safe:
 - Avoid commands that open prompts, pagers, editors, watch loops, or interactive REPL sessions unless the step explicitly requires long-running background execution.
 - For long-running/background tasks, state startup criteria and verification checks, and avoid blocking orchestration flow.
 - On command failure, capture stderr/stdout evidence and route via failure triage instead of re-running blindly.
-- If a command is known to be interactive-only, escalate with `ask_questions` and provide non-interactive alternatives when possible.
+- If a command is known to be interactive-only, escalate with `vscode/askQuestions` and provide non-interactive alternatives when possible.
+
+## Context Management for Long Sessions
+
+For long orchestration sessions spanning many implementation steps, if the context window is getting full, tell the user: "Type `/compact` in the chat to reclaim context window space."
+
+**What survives compaction**: Plans posted as GitHub issue comments remain fully accessible — this is one reason posting the plan to the issue is required. Session memory notes also survive compaction.
+
+**When to compact**: After completing a major phase (e.g., after all implementation steps complete and before starting the review cycle).
 
 ## Handoff to User
 
-Code Conductor operates autonomously and continues toward merge-ready by default. It pauses only when judgment beyond its authority is required, and every such pause must immediately use `ask_questions` to get a decision and continue — never plain-text questions, and never just stop and describe the problem.
+Code Conductor operates autonomously and continues toward merge-ready by default. It pauses only when judgment beyond its authority is required, and every such pause must immediately use `vscode/askQuestions` to get a decision and continue — never plain-text questions, and never just stop and describe the problem.
 
 PR creation is mandatory before user handoff. Do not return work to the user for PR creation when the agent has authority to create it.
 
-**Escalation pattern**: Present analysis in conversation text → call `ask_questions` with concrete options (mark one `recommended`) → incorporate the answer and resume work.
+**Escalation pattern**: Present analysis in conversation text → call `vscode/askQuestions` with concrete options (mark one `recommended`) → incorporate the answer and resume work.
 
-- **Design decisions**: Explain the trade-off in text, then `ask_questions` with the options. Mark your recommendation.
-- **PR readiness/merge approval**: After PR creation, summarize what was built and tested, then `ask_questions`: "Merge-ready", "Needs changes [describe]", "Run additional validation"
-- **Clarification needed**: Explain the discrepancy in text, then `ask_questions` with your interpretations as options. Mark the one you think is correct.
-- **Workflow complete**: Final status with open items. If there are follow-up decisions, `ask_questions` with next actions.
+- **Design decisions**: Explain the trade-off in text, then `vscode/askQuestions` with the options. Mark your recommendation.
+- **PR readiness/merge approval**: After PR creation, summarize what was built and tested, then `vscode/askQuestions`: "Merge-ready", "Needs changes [describe]", "Run additional validation"
+- **Clarification needed**: Explain the discrepancy in text, then `vscode/askQuestions` with your interpretations as options. Mark the one you think is correct.
+- **Workflow complete**: Final status with open items. If there are follow-up decisions, `vscode/askQuestions` with next actions.
 
 ## Best Practices
 

--- a/.github/agents/Code-Review-Response.agent.md
+++ b/.github/agents/Code-Review-Response.agent.md
@@ -3,6 +3,7 @@ name: Code-Review-Response
 description: "Referee for code review findings — adjudicate, challenge weak evidence, accept only what is defensible"
 argument-hint: "Analyze code review feedback and create response plan"
 tools: [
+    "vscode/askQuestions",
     "vscode",
     "execute",
     "read",

--- a/.github/agents/Issue-Designer.agent.md
+++ b/.github/agents/Issue-Designer.agent.md
@@ -4,6 +4,7 @@ description: "Design exploration and issue management for new features — explo
 argument-hint: "Start design work for a new GitHub issue"
 tools:
   [
+    "vscode/askQuestions",
     vscode,
     execute,
     read,
@@ -37,6 +38,15 @@ Design exploration and documentation agent. Explores options collaboratively wit
 **When to use**: Features that need design exploration before planning. If the feature is well-defined, skip straight to Issue-Planner.
 
 **Pipeline**: Issue-Designer (optional) → Issue-Planner → Code-Conductor
+
+## Questioning Policy (Mandatory)
+
+Every design decision, approval request, or branch-point question **MUST** use `#tool:vscode/askQuestions`. This is not negotiable.
+
+- **Zero-tolerance rule**: Plain-text questions are forbidden. If a question appears in your draft response, replace it with a `#tool:vscode/askQuestions` call before sending.
+- **Always include options**: Present 2–3 concrete options, label one "Recommended," and include it in the tool call — not just in the preceding text.
+- **Never end a turn with open questions**: If you are awaiting a user decision, the turn must end with a `#tool:vscode/askQuestions` call, not a question mark in plain text.
+- **Clarifications included**: Even simple clarifying questions (e.g., "Is this for the web app or API?") must go through `#tool:vscode/askQuestions`.
 
 ## Stage 1: GitHub Setup
 
@@ -76,7 +86,7 @@ For each design decision:
 
 1. **Research**: Search skills, `Documents/Research/`, `Documents/Design/`, `Documents/Decisions/`, and external patterns
 2. **Present options**: 2-3 options with explicit pros AND cons for each. Label one "Recommended" with rationale grounded in project goals and constraints.
-3. **Ask for decision**: Use `#tool:vscode/askQuestions` with a concise prompt summarizing the options (e.g., "Option A (recommended): X. Option B: Y. Option C: Z. Which do you prefer?"). The detailed pros/cons/rationale MUST be presented in the conversation BEFORE the question — the tool prompt is a summary, not the full analysis.
+3. **Ask for decision**: Use `#tool:vscode/askQuestions` with a concise prompt summarizing the options (e.g., "Option A (recommended): X. Option B: Y. Option C: Z. Which do you prefer?"). The detailed pros/cons/rationale MUST be presented in the conversation BEFORE the question — the tool prompt is a summary, not the full analysis. **Hard rule**: Never present options in text and then end your turn. Ending a turn with options but without immediately calling `#tool:vscode/askQuestions` wastes a premium request.
 4. **Record**: Note the decision for later documentation.
 
 Repeat until all design questions are resolved.

--- a/.github/instructions/code-review-intake.instructions.md
+++ b/.github/instructions/code-review-intake.instructions.md
@@ -56,4 +56,4 @@ Plus:
 
 ## Loop Budget
 
-Maximum 3 reconciliation rounds. If disputes remain, escalate via `ask_questions` with recommended options.
+Maximum 3 reconciliation rounds. If disputes remain, escalate via `vscode/askQuestions` with recommended options.

--- a/.github/prompts/setup.prompt.md
+++ b/.github/prompts/setup.prompt.md
@@ -150,14 +150,14 @@ Answer these questions about the project:
 2. **What does it do?** — 1–2 sentences describing the purpose. (e.g., "REST API that manages customer orders for an e-commerce platform.")
 3. **Primary language + version** — (e.g., TypeScript 5.x, Java 21, Python 3.12) _(or say "not sure" for help choosing)_
 
-   > _Not sure?_ If the user indicates uncertainty, ask 2–3 clarifying questions about their project (e.g., team experience, deployment target, performance needs). Then use the project description from question 2 to generate 2–3 language recommendations with reasoning and pros/cons. Use `ask_questions` for the user to select. Experienced users who answer directly skip this step.
+   > _Not sure?_ If the user indicates uncertainty, ask 2–3 clarifying questions about their project (e.g., team experience, deployment target, performance needs). Then use the project description from question 2 to generate 2–3 language recommendations with reasoning and pros/cons. Use `vscode/askQuestions` for the user to select. Experienced users who answer directly skip this step.
 
 4. **Framework + version** — (e.g., Express 4.x, Spring Boot 3.2, FastAPI 0.110, none) _(or say "not sure" for help choosing)_
 
-   > _Not sure?_ If the user indicates uncertainty, generate 2–3 framework recommendations based on the language chosen in question 3 and the project description from question 2. Include reasoning and pros/cons. Use `ask_questions` for selection.
+   > _Not sure?_ If the user indicates uncertainty, generate 2–3 framework recommendations based on the language chosen in question 3 and the project description from question 2. Include reasoning and pros/cons. Use `vscode/askQuestions` for selection.
 
 5. **Database** — (e.g., PostgreSQL 15, MongoDB 7, SQLite, none) _(or say "not sure" for help choosing)_
-   > _Not sure?_ If the user indicates uncertainty, generate 2–3 database recommendations based on the project type, scale, and stack from prior answers. Include reasoning and pros/cons. Use `ask_questions` for selection.
+   > _Not sure?_ If the user indicates uncertainty, generate 2–3 database recommendations based on the project type, scale, and stack from prior answers. Include reasoning and pros/cons. Use `vscode/askQuestions` for selection.
 
 Once all Phase 2 questions have been answered (including any "Not sure?" branches), proceed to Phase 3.
 

--- a/.github/skills/parallel-execution/SKILL.md
+++ b/.github/skills/parallel-execution/SKILL.md
@@ -57,7 +57,7 @@ Do not advance phase until Test-Writer explicitly confirms:
 ## Loop Budget
 
 - Maximum 3 correction cycles per step.
-- If exceeded, perform root-cause review and escalate via `ask_questions` with a recommended option.
+- If exceeded, perform root-cause review and escalate via `vscode/askQuestions` with a recommended option.
 
 ## Anti-Test-Chasing Guardrail
 

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -14,6 +14,24 @@ Guide for creating new skills with proper structure and VS Code 1.108+ compatibl
 - Updating skill templates
 - Onboarding contributors to skill creation
 
+## Built-in Creation Commands (VS Code 1.110+)
+
+> If you are on VS Code 1.108 or 1.109, skip this section and proceed directly to [Required Frontmatter Format](#required-frontmatter-format) below.
+
+VS Code 1.110 ships built-in slash commands for scaffolding customization files:
+
+- `/create-skill` — generates a new skill file
+- `/create-agent` — generates a new `.agent.md` file
+- `/create-prompt` — generates a new `.prompt.md` file
+- `/create-instruction` — generates a new `.instructions.md` file
+
+**Recommended workflow**: Use the built-in `/create-skill` (or equivalent) to generate the initial scaffold, then apply this skill to validate and refine the output against project conventions:
+
+- Kebab-case `name` in frontmatter (e.g., `my-skill`, not `MySkill`)
+- `description` must include usage triggers ("Use when ..." phrasing) for discoverability
+- Directory structure: `.github/skills/{skill-name}/SKILL.md`
+- Required frontmatter fields: `name` and `description` only — no unsupported fields
+
 ## Required Frontmatter Format
 
 ```markdown

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -164,3 +164,12 @@ If any file already exists, Phase 5 asks before overwriting (`.vscode/settings.j
 
 - Confirm `SKILL.md` has `name` and `description` frontmatter
 - Enable `chat.useAgentSkills` in VS Code settings (requires VS Code 1.108+)
+
+**Need to debug agent behavior in detail?**
+
+VS Code 1.110+ includes an Agent Debug panel that gives real-time visibility into agent execution:
+
+- Open it with: `Developer: Open Agent Debug Panel`
+- Shows loaded customizations (instructions, skills, agent files), tool calls, system prompts, and agent events as they happen
+- Available since VS Code 1.110 (supersedes the earlier Diagnostics chat action)
+- Especially useful when agents appear to ignore instructions or tools — confirm the relevant files are actually loaded

--- a/Documents/Design/issue-57-vscode-1110-compat.md
+++ b/Documents/Design/issue-57-vscode-1110-compat.md
@@ -1,0 +1,56 @@
+# Issue #57 — VS Code 1.110 Compatibility: askQuestions Audit
+
+## Overview
+
+Audit and update all agent files, instructions, and skills to use the correct VS Code 1.110 tool name `vscode/askQuestions` (replacing stale `ask_questions` references) and to declare the tool explicitly in frontmatter where needed.
+
+## Problem Statement
+
+VS Code 1.110 renamed the questioning tool from `ask_questions` to `vscode/askQuestions`. When agents reference a tool name that does not match the declared frontmatter entry, the tool may not be available at runtime. Additionally:
+
+- Issue-Designer had no enforcement section for the Questioning Policy
+- Code-Review-Response was missing the tool declaration in frontmatter entirely
+- 29 stale `ask_questions` references remained across agent bodies, instructions, and skills
+- VS Code 1.110 introduced `/create-*` slash commands not documented in skill-creator
+- VS Code 1.110 added an Agent Debug Panel not documented in CUSTOMIZATION.md
+
+## Design Decisions
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D1 | Standardize all body references to `vscode/askQuestions` everywhere | Ensures runtime alignment; eliminates confusion between old and new name |
+| D2 | Add full Questioning Policy enforcement section to Issue-Designer | Issue-Designer is highly interactive; weak enforcement caused silent failures |
+| D3 | Explicitly declare `vscode/askQuestions` in Code-Review-Response frontmatter | Missing declaration despite 11 body references — critical gap |
+| D4 | `Documents/Design/` files frozen — no changes | Historical design records; stale references inside are acceptable |
+
+## Changes Made
+
+### Agent Files
+
+- **`.github/agents/Issue-Designer.agent.md`** — Added `"vscode/askQuestions"` to tools frontmatter; added `## Questioning Policy (Mandatory)` section before Stage 1 modeled on Code-Conductor's zero-tolerance pattern; strengthened Collaboration Pattern step 3 with Hard rule.
+- **`.github/agents/Code-Review-Response.agent.md`** — Added `"vscode/askQuestions"` as first entry in tools frontmatter. Body already had 11 correct references.
+- **`.github/agents/Code-Conductor.agent.md`** — Added `vscode/askQuestions` as first entry in tools frontmatter (critical fix — was undeclared despite 24 body references); replaced all 24 bare `ask_questions` references; grammar fix ("a `vscode/askQuestions`"); added `## Context Management for Long Sessions` section before `## Handoff to User` with `/compact` guidance.
+
+### Instructions & Skills
+
+- **`.github/instructions/code-review-intake.instructions.md`** — 1 reference replaced.
+- **`.github/skills/parallel-execution/SKILL.md`** — 1 reference replaced.
+- **`.github/prompts/setup.prompt.md`** — 3 references replaced.
+- **`.github/skills/skill-creator/SKILL.md`** — Added `## Built-in Creation Commands (VS Code 1.110+)` section listing `/create-skill`, `/create-agent`, `/create-prompt`, `/create-instruction`; added fallback blockquote for 1.108–1.109 users.
+
+### Documentation
+
+- **`CUSTOMIZATION.md`** — Added Agent Debug Panel documentation to Troubleshooting section (available since VS Code 1.110, supersedes earlier Diagnostics chat action).
+
+## Deferred Items
+
+| Item | Reason |
+|------|--------|
+| `#tool:` prefix standardization across agents | Pre-existing style divergence (Issue-Planner/Issue-Designer use `#tool:vscode/askQuestions`; Code-Conductor/Code-Review-Response use plain backtick). Both styles work; unification is a separate incremental improvement. |
+
+## Validation
+
+- Bare `` `ask_questions` `` references in `.github/`: **0**
+- Quick-validate: Plan-Architect refs = 0, Janitor refs = 0
+- Agent count: 13 (unchanged)
+- All 4 agents using `vscode/askQuestions` in body now declare it in frontmatter ✅


### PR DESCRIPTION
## Summary

Resolves a 5-item VS Code 1.110 compatibility bundle: corrects tool name references from `ask_questions` to `vscode/askQuestions`, adds missing frontmatter declarations, adds a mandatory Questioning Policy to Issue-Designer, documents VS Code 1.110-specific features (slash commands and Agent Debug Panel), and adds `/compact` context management guidance to Code-Conductor.

## Problem

VS Code 1.110 renamed the questioning tool. Several agents had 29 stale `ask_questions` body references; Code-Conductor had 24 of them **and** was missing the tool from its frontmatter entirely (making the tool undeclared but actively referenced). Issue-Designer had no Questioning Policy enforcement. Code-Review-Response had no frontmatter declaration.

## Changed Files

| File | Change |
|------|--------|
| `.github/agents/Issue-Designer.agent.md` | `vscode/askQuestions` frontmatter; new `## Questioning Policy (Mandatory)` before Stage 1; Hard rule in Collaboration Pattern |
| `.github/agents/Code-Review-Response.agent.md` | `vscode/askQuestions` frontmatter (was missing entirely) |
| `.github/agents/Code-Conductor.agent.md` | `vscode/askQuestions` frontmatter (critical — was undeclared); 24 body ref replacements; grammar fix; new `## Context Management for Long Sessions` |
| `.github/instructions/code-review-intake.instructions.md` | 1 body ref replaced |
| `.github/skills/parallel-execution/SKILL.md` | 1 body ref replaced |
| `.github/prompts/setup.prompt.md` | 3 body refs replaced |
| `.github/skills/skill-creator/SKILL.md` | Added Built-in Creation Commands (VS Code 1.110+) section; fallback note for 1.108–1.109 |
| `CUSTOMIZATION.md` | Agent Debug Panel documentation in Troubleshooting |
| `Documents/Design/issue-57-vscode-1110-compat.md` | Design record (new file) |

## Validation Evidence

```
Plan-Architect refs in .github: 0 ✅
Janitor refs in .github:        0 ✅
Agent count:                   13 ✅
Bare `ask_questions` in .github: 0 ✅
```

3 remaining bare references exist only in `Documents/Design/` frozen historical files (intentional, per decision D4).

## CE Gate

⏭️ CE Gate not applicable — no customer-facing surface (configuration/documentation template repo; no UI, REST API, or CLI)

## Code Review

3 independent Code-Critic passes completed (per `critic_passes: 3`). 12 findings total:
- 1 critical (F-1: Code-Conductor undeclared frontmatter) — **FIXED**
- 1 deferred (F-2: `#tool:` prefix style inconsistency — pre-existing, follow-up: #59)
- 10 medium/low/nit — all **FIXED**

Code-Review-Response adjudication: **GO** — all dispositions confirmed correct.

## Process Review

Track 2 systemic analysis: No CE-Gate-triggered defects. Follow-up issue #59 created for F-2 `#tool:` prefix standardization (< 1 day, low priority).

Closes #57

## Summary by Sourcery

Update agent and skill configuration for VS Code 1.110 compatibility and improve questioning and debugging guidance across agents and docs.

New Features:
- Add mandatory questioning policy section to Issue-Designer to enforce use of the vscode/askQuestions tool.
- Introduce context management guidance for long Code-Conductor sessions, including use of the /compact command.
- Document VS Code 1.110 built-in creation slash commands in the skill-creator skill.
- Document the Agent Debug Panel for debugging agent behavior in VS Code 1.110+.
- Add a design record capturing the decisions and scope of the VS Code 1.110 compatibility audit.

Enhancements:
- Declare the vscode/askQuestions tool in Code-Conductor and Code-Review-Response frontmatter and standardize body references from ask_questions to vscode/askQuestions across agents, skills, instructions, and prompts.