### PR TITLE
fix: reduce Code-Critic latency on documentation-only PRs

### DIFF
--- a/.github/agents/Code-Conductor.agent.md
+++ b/.github/agents/Code-Conductor.agent.md
@@ -183,11 +183,13 @@ Classify the PR change type using `git diff --name-only main..HEAD` and include 
 
 | Change type | Condition | Active perspectives |
 |---|---|---|
-| `documentation-only` | All changed files are `.md`, `.instructions.md`, `.prompt.md`, or `.agent.md` | Simplicity (§5), Documentation Script Audit (§7), Patterns doc-clarity angle (§4 partial) |
+| `documentation-only` | All changed files are `.md`, `.instructions.md`, `.prompt.md`, or `.agent.md` | Architecture (§1, docs-misrepresentation check only), Simplicity (§5), Documentation Script Audit (§7, if `.md` files contain shell blocks), Patterns doc-clarity angle (§4 partial) |
 | `mixed` | Changed files include both source/scripts AND docs | All 7 perspectives |
 | `code` (default) | Changed files include source code, scripts, or runtime config | All 7 perspectives |
 
-Include in each pass prompt: `"Change type: {classification}. Per Code-Critic's 'When to apply' gates, mark out-of-scope perspectives as ⏭️ N/A — do not expand them."` For `documentation-only` reviews, include only the changed files in the file reading list — do not include supporting context files.
+> **Precedence**: Evaluate rows in order; the first matching condition applies. `mixed` takes priority over `code` for source+docs PRs.
+
+Include in each pass prompt: `"Change type: {classification}. Per Code-Critic's 'When to apply' gates, mark out-of-scope perspectives as ⏭️ N/A — do not expand them."` For `documentation-only` reviews, include only the changed files in the file reading list — do not include supporting context files (exception: always include `.github/architecture-rules.md` for the §1 docs-misrepresentation check).
 
 - Launch all 3 passes **in parallel** as independent subagent invocations.
 - Label each call: `"This is adversarial review pass N of M. Conduct your review independently. Prior passes have already been run. Look for anything they may have missed."`

--- a/.github/agents/Code-Critic.agent.md
+++ b/.github/agents/Code-Critic.agent.md
@@ -231,11 +231,12 @@ Performs a final review for architecture, security, and overall quality.
 
 Every review MUST address all 7 perspectives in sequence, using the **"When to apply" gate** for each:
 - **In scope** (gate triggered): apply the full checklist for that perspective.
-- **Out of scope** (gate not triggered): return a single-line `⏭️ N/A` marker. Do not expand the section with checklist items.
+- **Out of scope** (gate not triggered): replace the entire section with the Compact N/A heading (see **Compact N/A rule** below). Do not expand the section with checklist items.
+- **Partially in scope** (gate specifies sub-sections to skip, e.g., §1 for docs-only PRs): apply the in-scope portions of the perspective; sub-sections explicitly marked "Skip" produce no output — do not emit a sub-section N/A marker.
 
 ### 1. Architecture Perspective
 
-**When to apply**: PR includes source code files (`.ts`, `.tsx`, `.cs`, `.py`, etc.), scripts, or runtime configuration. For documentation-only PRs (`.md`/`.instructions.md`/`.agent.md` files only): skip §1b and §1c entirely; apply the §1 checklist only to verify documentation does not misrepresent architectural constraints.
+**When to apply**: PR includes source code files (`.ts`, `.tsx`, `.cs`, `.py`, etc.), scripts, or runtime configuration. For documentation-only PRs (`.md`/`.instructions.md`/`.prompt.md`/`.agent.md` files only): skip §1b and §1c entirely; apply the §1 checklist only to verify documentation does not misrepresent architectural constraints.
 
 - [ ] Project architecture compliance (see `.github/architecture-rules.md`)
 - [ ] Dependencies follow documented layer direction (e.g., interface/adapters into domain/core logic)
@@ -277,7 +278,7 @@ For any **new data field, constant, or map** added:
 
 ### 2. Security Perspective
 
-**When to apply**: PR includes source code files, scripts, or configuration with authentication/authorization/data-handling concerns. For documentation-only PRs: return `⏭️ N/A — no runtime code in this PR` and skip checklist items.
+**When to apply**: PR includes source code files, scripts, or configuration with authentication/authorization/data-handling concerns. Not triggered for documentation-only PRs — apply the Compact N/A rule.
 
 - [ ] No hardcoded secrets or credentials
 - [ ] Input validation present
@@ -286,7 +287,7 @@ For any **new data field, constant, or map** added:
 
 ### 3. Performance Perspective
 
-**When to apply**: PR includes source code files or configuration affecting runtime execution paths. For documentation-only PRs: return `⏭️ N/A — no runtime code in this PR` and skip checklist items.
+**When to apply**: PR includes source code files or configuration affecting runtime execution paths. Not triggered for documentation-only PRs — apply the Compact N/A rule.
 
 - [ ] Algorithm complexity appropriate (no O(n²) where O(n) possible)
 - [ ] No unnecessary re-renders or computations
@@ -297,11 +298,11 @@ For any **new data field, constant, or map** added:
 
 **When to apply**: PR includes source code files. For documentation-only PRs: skip code-specific checklist items; DRY across documentation sections (content repetition, contradictory guidance) remains in scope as a documentation pattern concern.
 
-- [ ] Design patterns used correctly
-- [ ] Anti-patterns avoided (God classes, spaghetti)
-- [ ] DRY principle followed
-- [ ] SOLID principles applied
-- [ ] UI tests query by `aria-label`/behavior, NOT DOM structure (see `.github/skills/ui-testing/SKILL.md`)
+- [ ] Design patterns used correctly *(code-only — skip for docs)*
+- [ ] Anti-patterns avoided (God classes, spaghetti) *(code-only — skip for docs)*
+- [ ] DRY principle followed *(docs-applicable — check for content repetition and contradictory guidance)*
+- [ ] SOLID principles applied *(code-only — skip for docs)*
+- [ ] UI tests query by `aria-label`/behavior, NOT DOM structure (see `.github/skills/ui-testing/SKILL.md`) *(code-only — skip for docs)*
 
 ### 5. Simplicity Perspective
 
@@ -394,13 +395,13 @@ Do not include checklist items. This eliminates output bloat without reducing co
 
 [Specific findings]
 
-### ✅ Script & Automation: PASS/FAIL/N-A
+### ✅ Script & Automation: PASS/FAIL
 
-[Specific findings — mark N/A when PR has no script files]
+[Specific findings — use `### ⏭️ Script & Automation: N/A — no script files in this PR` when gate not triggered]
 
-### ✅ Documentation Script Audit: PASS/FAIL/N-A
+### ✅ Documentation Script Audit: PASS/FAIL
 
-[Specific findings — mark N/A when PR has no `.md` files with shell code blocks]
+[Specific findings — use `### ⏭️ Documentation Script Audit: N/A — no .md files with shell code blocks` when gate not triggered]
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Reduces Code-Critic review latency on documentation-only PRs by introducing conditional "When to apply" gates on perspectives that don't apply to non-executable changes, and adding a Compact N/A output rule.

**Root cause** (identified via process review after issue #65): Each of 3 parallel Code-Critic passes was evaluating all 7 perspectives unconditionally — for a documentation-only PR where Security (§2), Performance (§3), and source-code Architecture sub-checks (§1b/§1c) are structurally N/A. Each N/A section still required reasoning and formatted output, producing 10KB+ responses and forcing temp-file writes rather than inline returns.

## Changes

### `Code-Critic.agent.md`
- Added `**When to apply**` gates to perspectives §1 (Architecture), §1b, §1c, §2 (Security), §3 (Performance), §4 (Patterns), §5 (Simplicity)
- §2 and §3: `⏭️ N/A — no runtime code in this PR` for documentation-only PRs  
- §4: code-specific checks skip for docs-only; DRY/repetition across doc sections stays in scope
- §5: active for all change types
- §1: narrowed to "does documentation misrepresent architectural constraints" for docs-only
- Added **Compact N/A rule**: out-of-scope perspectives → single line instead of expanded section

### `Code-Conductor.agent.md`
- Added **change-type classification** pre-step to Critic Pass Protocol
- Classify PR as `documentation-only` / `mixed` / `code` using `git diff --name-only main..HEAD`
- Each pass prompt now includes: `"Change type: {classification}. Per Code-Critic's 'When to apply' gates, mark out-of-scope perspectives as ⏭️ N/A — do not expand them."`
- For `documentation-only` reviews: reading list includes only changed files, not supporting context files

## Quality Preservation

No detection capability is removed for code PRs — all 7 perspectives remain mandatory. For documentation-only PRs, the perspectives that actually find documentation defects remain fully active:
- **§5 Simplicity** — active (catches over-complicated docs)
- **§7 Documentation Script Audit** — active (catches wrong shell commands in code blocks)
- **§4 Patterns** — DRY/repetition angle active (catches contradictory guidance)
- **§1 Architecture** — narrowed check active (catches docs misrepresenting constraints)

The two perspectives that produced 5 of 7 accepted findings in issue #65 remain fully active.

## Validation Evidence

```
Plan-Architect references: 0 ✅
Janitor references:        0 ✅
Agent count: 13 ✅
```

## CE Gate

⏭️ CE Gate not applicable — agent configuration change, no customer-facing surface.

## Related

- Triggered by process review after issue #65 Code-Critic pass latency
- Follow-up issue filed for pass-count evaluation: see process review findings

## Summary by Sourcery

Gate Code-Critic review perspectives based on PR change type and classify documentation-only changes to reduce unnecessary analysis and output size while preserving coverage for code changes.

Enhancements:
- Add "When to apply" gates and a compact N/A rule to Code-Critic perspectives so out-of-scope checks return a single-line marker instead of full sections.
- Refine architecture, security, performance, pattern, and simplicity perspectives to treat documentation-only PRs differently while keeping relevant documentation checks active.
- Extend Code-Conductor to classify PRs as documentation-only, mixed, or code based on changed files and pass this classification into Code-Critic invocations, limiting file context for docs-only reviews.