### PR TITLE
fix(agents): remove phantom domain-reference skill, sync skill tables, add symmetric-fix step

### DIFF
--- a/.github/agents/Code-Conductor.agent.md
+++ b/.github/agents/Code-Conductor.agent.md
@@ -252,6 +252,8 @@ When delegating to subagents, instruct them to use the relevant skill(s):
 | `parallel-execution`             | Applying build-test orchestration protocol in parallel/serial lanes       |
 | `property-based-testing`         | Applying incremental PBT rollout policy and constraints                   |
 
+<!-- Keep in sync: when adding or removing a delegation skill in .github/skills/, update this table (delegation-scoped: only skills Code-Conductor instructs subagents to use). Always also update Process-Review's Skill Mapping Reference table (all-skills scope). -->
+
 Include in prompt: _"Use the `{skill-name}` skill (`.github/skills/{skill-name}/SKILL.md`) to guide your work."_
 
 **Skill-specific instructions**:

--- a/.github/agents/Process-Review.agent.md
+++ b/.github/agents/Process-Review.agent.md
@@ -610,22 +610,29 @@ When reviewing a completed workflow, audit skill usage:
 
 1. **List agents called**: Which agents were invoked during the workflow?
 2. **List skills instructed**: Which skills were explicitly mentioned in delegation prompts?
-3. **Cross-reference with mapping**: Per Code-Conductor's skill mapping table, which skills SHOULD have been used?
+3. **Cross-reference with mapping**: Per the Skill Mapping Reference table below, which skills SHOULD have been used?
 4. **Identify gaps**: Any applicable skills that weren't instructed?
 
-### Skill Mapping Reference (from Code-Conductor)
+### Skill Mapping Reference
 
-| Skill                            | When Applicable                          |
-| -------------------------------- | ---------------------------------------- |
-| `domain-reference`               | Domain rules, terminology research       |
-| `brainstorming`                  | Design exploration, unclear requirements |
-| `frontend-design`                | UI components, styling                   |
-| `software-architecture`          | Layer placement, design patterns         |
-| `test-driven-development`        | Writing tests, TDD workflow              |
-| `ui-testing`                     | Component tests, Testing Library         |
-| `systematic-debugging`           | Bug investigation, test failures         |
-| `verification-before-completion` | Pre-commit checks, quality gates         |
-| `webapp-testing`                 | E2E tests, Playwright                    |
+| Skill                            | When Applicable                                  |
+| -------------------------------- | ------------------------------------------------ |
+| `brainstorming`                  | Design exploration, unclear requirements         |
+| `browser-canvas-testing`         | Canvas game browser interaction                  |
+| `code-review-intake`             | GitHub review intake, ledger-based judgment      |
+| `frontend-design`                | UI components, styling                           |
+| `parallel-execution`             | Parallel/serial build-test orchestration         |
+| `post-pr-review`                 | Post-merge cleanup, archiving, releases          |
+| `property-based-testing`         | Incremental PBT rollout                          |
+| `skill-creator`                  | Creating or updating skills                      |
+| `software-architecture`          | Layer placement, design patterns                 |
+| `systematic-debugging`           | Bug investigation, test failures                 |
+| `test-driven-development`        | Writing tests, TDD workflow                      |
+| `ui-testing`                     | Component tests, Testing Library                 |
+| `verification-before-completion` | Pre-commit checks, quality gates                 |
+| `webapp-testing`                 | E2E tests, Playwright                            |
+
+<!-- Keep in sync: when adding or removing any skill in .github/skills/, update this table (all-skills scope). Update Code-Conductor's Skill Mapping table only if the skill is a delegation target (a skill Code-Conductor instructs a subagent to use). -->
 
 ### Output Format
 
@@ -634,6 +641,6 @@ When reviewing a completed workflow, audit skill usage:
 
 | Phase | Agent          | Skills Instructed         | Should Have Used          | Gap? |
 | ----- | -------------- | ------------------------- | ------------------------- | ---- |
-| 1     | Research-Agent | None                      | `domain-reference`        | ⚠️   |
+| 1     | Research-Agent | None                      | `brainstorming`           | ⚠️   |
 | 2     | Test-Writer    | `test-driven-development` | `test-driven-development` | ✅   |
 ```

--- a/.github/agents/Refactor-Specialist.agent.md
+++ b/.github/agents/Refactor-Specialist.agent.md
@@ -100,6 +100,8 @@ Examples of integration gaps to FIX NOW (not defer):
 
 4. **Report findings** even if not acting on all of them
 
+5. **Symmetric fix check (post-fix, before closing)**: When applying a fix to a recurring pattern (validation commands, grep exclusions, path references, agent instruction fragments), grep the full repo for the same pattern. Fix all symmetric occurrences in the same PR if the transformation is mechanical (same change, no new design decisions needed). Create a follow-up issue only if the fix in other files requires different logic or design judgment.
+
 ## Refactoring Checklist
 
 For each file modified in the PR, evaluate:

--- a/.github/agents/Research-Agent.agent.md
+++ b/.github/agents/Research-Agent.agent.md
@@ -428,7 +428,7 @@ You MUST maintain focused research scope:
 
 **When researching domain-specific business rules:**
 
-- Load the project's domain-reference skill (if available) for canonical rules and terminology
+- Load relevant skills from `.github/skills/` for project-specific domain context (if available)
 
 **When exploring design options or unclear requirements:**
 


### PR DESCRIPTION
## Summary

Combines two process-improvement issues in a single bounded PR:

- **#32**: Eliminates all 3 phantom `domain-reference` skill references, syncs Process-Review's skill table to all 14 real skills, and fixes a stale checklist cross-reference introduced by the header rename.
- **#45**: Adds Step 5 "Symmetric fix check (post-fix, before closing)" to Refactor-Specialist's Mandatory Analysis Steps, with an intent-based (not line-count-based) threshold.

---

## Changed Files

| File | What changed |
|------|-------------|
| `.github/agents/Process-Review.agent.md` | Deleted phantom `domain-reference` row; added 6 missing skills (`browser-canvas-testing`, `code-review-intake`, `frontend-design` wasn't missing — see actual list below); renamed table header; added scope-aware sync note; updated example audit row from `domain-reference` → `brainstorming`; fixed stale checklist step 3 cross-reference |
| `.github/agents/Research-Agent.agent.md` | Replaced phantom "Load domain-reference skill" bullet with "Load relevant skills from `.github/skills/` for project-specific domain context" |
| `.github/agents/Refactor-Specialist.agent.md` | Added Step 5: "Symmetric fix check (post-fix, before closing)" after Step 4 |
| `.github/agents/Code-Conductor.agent.md` | Added scope-aware sync note after Skill Mapping table |

**Skills added to Process-Review table** (now comprehensive at 14 rows, alphabetically sorted):
`browser-canvas-testing`, `code-review-intake`, `parallel-execution`, `post-pr-review`, `property-based-testing`, `skill-creator`

---

## Validation Evidence

```
Quick-validate Plan-Architect refs: 0  ✅
Quick-validate Janitor refs:        0  ✅
domain-reference refs (full repo):  0  ✅
```

**Migration completeness scan** (domain-reference, all .md files in repo):
- Pre-fix: 3 hits (Process-Review.agent.md ×2, Research-Agent.agent.md ×1)
- Post-fix: 0 hits
- Files scanned: all `.md` files in repo (Get-ChildItem -Path . -Recurse -Filter "*.md")

---

## CE Gate

⏭️ **CE Gate not applicable** — no customer-facing surface. All changes are agent instruction files (`.agent.md`) with no runtime behavior.

---

## Code-Critic Review (3 independent passes)

3 passes run. Merged ledger findings and dispositions:

| Finding | Severity | Disposition |
|---------|----------|-------------|
| Sync notes self-violating — 3 skills present in Process-Review but absent from Code-Conductor | Medium | ACCEPT-MODIFIED — notes rewritten to declare different scopes (delegation-scoped vs. all-skills); gap is intentional by design |
| Refactor-Specialist Step 5 is a scope-expansion directive inside analysis section | Low | ACCEPT-MODIFIED — label updated to "(post-fix, before closing)" to disambiguate timing |
| Sync note language doesn't flag intentional scope divergence | Low | ACCEPT — resolved by amended sync note language |
| Sync notes say "adding" but omit "removing" | Low | ACCEPT — notes now say "adding or removing" |
| Research-Agent "Check" verb weaker than adjacent "Load" | Low | ACCEPT — changed to "Load relevant skills from" |
| Process-Review step 3 stale cross-reference (introduced by header rename) | Medium | ACCEPT — caught by Refactor-Specialist pass; fixed to "Per the Skill Mapping Reference table below" |

**Process-Review: no systemic gap found** — all findings were localized to the changed sections and addressed within this PR.

---

## Process Retrospective

- **Observation**: Code-Review-Response applied all 5 fixes directly rather than recommending them. For low-risk doc changes this was net-positive; for higher-risk changes, separation between judgment and implementation is worth enforcing.
- **Late-catch by Refactor-Specialist**: Stale checklist cross-reference (step 3 in Process-Review) was not flagged by any Code-Critic pass — it was caught during the refactoring pass. Pattern: header renames should trigger a same-file scan for references to the old name.

Closes #32
Closes #45

## Summary by Sourcery

Align agent instruction docs with the current skill set and strengthen refactoring process guidance.

New Features:
- Expand Process-Review's skill mapping reference to cover all current skills and use it as the canonical audit reference instead of Code-Conductor's table.
- Add a symmetric-fix checklist step to Refactor-Specialist to ensure recurring patterns are consistently updated across the repo.

Bug Fixes:
- Remove obsolete references to the deprecated domain-reference skill from agent instructions.
- Correct a stale cross-reference in the Process-Review checklist that pointed to Code-Conductor's mapping table instead of the local reference table.

Enhancements:
- Clarify skill-loading guidance for Research-Agent to use relevant project skills from the skills directory.
- Add explicit scope-aware sync notes between Process-Review and Code-Conductor skill mapping tables to document intentional differences and required updates when skills change.