### PR TITLE
feat(code-smith): add serialized output correctness to post-implementation verification

### DIFF
--- a/.github/agents/Code-Smith.agent.md
+++ b/.github/agents/Code-Smith.agent.md
@@ -133,7 +133,7 @@ Your job is NOT just "make tests pass" — you must ensure the solution meets re
 1. **New components are wired in**: Search for imports in production code (not just tests). If you create `NewProcessor.ts`, verify it's imported and used somewhere.
 2. **Integration points connected**: If component A should call component B, verify the call exists in production code.
 3. **Design requirements met**: Review the design doc/issue — does your implementation satisfy all acceptance criteria?
-4. **Serialized output correctness**: When the change edits, creates, or produces a JSON file (including JSON embedded via string interpolation in scripts), verify the output is parseable before handing off. Prefer structured serializers over manual quoting — e.g., `ConvertTo-Json` in PowerShell, `json.dumps()` in Python. Validate with `ConvertFrom-Json` (PowerShell) or the language's native JSON parser.
+4. **Serialized output correctness**: When the change edits, creates, or produces a JSON file (including JSON embedded via string interpolation in scripts), verify the output is parseable before handing off. Prefer structured serializers over manual quoting — e.g., `JSON.stringify()` in TypeScript/JavaScript, `ConvertTo-Json` in PowerShell, or `json.dumps()` in Python. Validate with `JSON.parse()` (TypeScript/JavaScript), `ConvertFrom-Json` (PowerShell), or the language's native JSON parser.
 
 **If you find gaps not covered by tests**:
 


### PR DESCRIPTION
## Summary

Adds a 4th checklist item to Code-Smith's "After implementation, verify" section covering JSON serialization correctness. Motivated by Issue #39 (PR feat/#39) where a `session-cleanup.json` Windows hook had invalid JSON from PowerShell single-quoted string escaping — a defect caught by Code-Critic Pass 1 but that should have been caught during implementation.

## Changed Files

| File | Change |
|------|--------|
| `.github/agents/Code-Smith.agent.md` | Added item 4 to "After implementation, verify" checklist |

## New Checklist Item

> **4. Serialized output correctness**: When the change edits, creates, or produces a JSON file (including JSON embedded via string interpolation in scripts), verify the output is parseable before handing off. Prefer structured serializers over manual quoting — e.g., `ConvertTo-Json` in PowerShell, `json.dumps()` in Python. Validate with `ConvertFrom-Json` (PowerShell) or the language's native JSON parser.

**Design decisions from 3-pass Code-Critic review + reconciliation**:
- Scope narrowed to JSON-only (original "JSON, YAML, or TOML" had no actionable validators for YAML/TOML)
- Trigger "edits, creates, or produces" (not "emits or templates") — covers direct JSON file edits like the Issue #39 scenario
- Language-generic framing with PowerShell + Python examples (repo is a multi-language template)
- `jq .` dropped (not available by default on Windows); `ConvertFrom-Json` kept as primary

## Validation Evidence

```
Quick-validate (Plan-Architect refs): 0  ✅
Quick-validate (Janitor refs): 0         ✅

AC: "Serialized output correctness" in Code-Smith.agent.md: 1 match  ✅
AC: "ConvertTo-Json" in Code-Smith.agent.md: 1 match                  ✅
AC: "ConvertFrom-Json" in Code-Smith.agent.md: 1 match                ✅
```

Diff scope: single file (`.github/agents/Code-Smith.agent.md`) ✅

## CE Gate

⏭️ CE Gate not applicable — internal agent instruction change with no customer-facing surface.

## Process Gaps Found

None.

Closes #44