### PR TITLE
feat: add domain peer check to TDD RED phase and Code-Critic §1d (#107)

### DIFF
--- a/.github/agents/Code-Critic.agent.md
+++ b/.github/agents/Code-Critic.agent.md
@@ -412,18 +412,17 @@ For any **new data field, constant, or map** added:
 
 _To identify peers: grep for the field name in function signatures (criterion a), consult the plan for shared-concept fields under different names (criterion b), and trace call chains for output→input relationships (criterion c)._
 
-- [ ] **Range check**: For each field with multiple consumers (new or existing), are accepted input ranges identical?
-- [ ] **Documentation check**: If ranges differ, is the difference documented as intentional (plan step or inline code comment)?
+- [ ] **Range and documentation check**: For each field with multiple consumers (new or existing), do all functions accept identical input ranges — or, if ranges differ, is the difference documented as intentional (plan step or inline code comment)?
 - [ ] **Boundary alignment**: Do all functions agree on inclusive/exclusive bounds, signed/unsigned treatment, and type coercion behavior?
 
 **Red flags**:
 
-| Pattern | Example | Risk |
-| ------- | ------- | ---- |
-| Validator accepts values parser rejects | `validate: [-∞, ∞]` vs `parse: [0, 2³²-1]` | Valid input silently fails at parse step |
-| Parser accepts values validator rejects | `parse: [0, MAX]` vs `validate: [1, 3600]` | Parsed value fails downstream validation |
-| Signed/unsigned range mismatch | `validate: int` vs `parse: uint32` | Negative values accepted then truncated/wrapped |
-| String-to-number boundary mismatch | `validate: "finite number"` vs `parse: [0, 4294967295]` | Edge values like `-1` or `NaN` treated inconsistently |
+| Pattern                                 | Example                                                 | Risk                                                  |
+| --------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------- |
+| Validator accepts values parser rejects | `validate: [-∞, ∞]` vs `parse: [0, 2³²-1]`              | Valid input silently fails at parse step              |
+| Parser accepts values validator rejects | `parse: [0, MAX]` vs `validate: [1, 3600]`              | Parsed value fails downstream validation              |
+| Signed/unsigned range mismatch          | `validate: int` vs `parse: uint32`                      | Negative values accepted then truncated/wrapped       |
+| String-to-number boundary mismatch      | `validate: "finite number"` vs `parse: [0, 4294967295]` | Edge values like `-1` or `NaN` treated inconsistently |
 
 ### 2. Security Perspective
 

--- a/.github/skills/test-driven-development/workflows/write-tests-first.md
+++ b/.github/skills/test-driven-development/workflows/write-tests-first.md
@@ -24,7 +24,7 @@ Ask yourself: **What should this code do?** (not how it does it)
 
 ### 2. Domain Peer Check
 
-**When to complete**: If the function under test validates, parses, deserializes, or constrains an input field for which another function (new in the PR or existing in the codebase) also operates on the same field, complete this step before writing tests. Otherwise, skip to Step 3.
+**When to complete**: If the function under test validates, parses, converts, deserializes, or constrains an input field for which another function (new in the PR or existing in the codebase) also operates on the same field, complete this step before writing tests. Otherwise, skip to Step 3.
 
 **Identifying the same field**: A field is "the same" when any of the following hold:
 
@@ -110,7 +110,7 @@ git commit -m "test: add failing test for user lookup by ID"
 - [ ] Test follows AAA pattern (Arrange-Act-Assert)
 - [ ] Test fails for the right reason (missing implementation, not wrong setup)
 - [ ] No `@Disabled` or skipped tests
-- [ ] Domain Peer Check: if function shares a field with another validator, parser, deserializer, or constraining function (new or existing), input ranges confirmed identical or difference documented
+- [ ] Domain Peer Check: if function shares a field with another validator, parser, converter, deserializer, or constraining function (new or existing), input ranges confirmed identical or difference documented
 
 ## Anti-Patterns to Avoid
 

--- a/Documents/Design/domain-alignment-checking.md
+++ b/Documents/Design/domain-alignment-checking.md
@@ -11,7 +11,7 @@ Two complementary guardrails that catch cross-function input domain mismatches: 
 | # | Decision | Choice | Rationale |
 |---|----------|--------|-----------|
 | D1 | Placement in TDD workflow | Step 2 (new), before "Write the Test" | Proactive — resolve range mismatches before RED tests are written; inserting earlier ensures tests don't encode the wrong domain assumptions |
-| D2 | Placement in Code-Critic | §1d sub-perspective under §1 Architecture | Reactive complement to D1; sub-perspective keeps the "7 code perspectives" count accurate across all reference locations; §1b/§1c precedent for unnamed sub-perspectives |
+| D2 | Placement in Code-Critic | §1d sub-perspective under §1 Architecture | Reactive complement to D1; sub-perspective keeps the "7 code perspectives" count accurate across all reference locations; §1b/§1c precedent for lettered sub-perspectives |
 | D3 | "Same field" heuristic | Three criteria: (a) same parameter/field name, (b) same documented concept (different names allowed), (c) one function's output feeds the other's input | Criteria must be concrete enough for authors to apply without judgment ambiguity; "when uncertain, err toward checking" catchall covers edge cases |
 | D4 | Scope | PR diff + existing codebase (not PR-only) | A new validator can conflict with an existing parser not in the diff; PR-only scope would reproduce the original defect |
 | D5 | Gate condition | Function "validates, parses, deserializes, or constrains" a field also handled by another function | Covers the class broadly: range-clampers / normalizers included via "constrains"; vocabulary symmetry between TDD gate and §1d gate maintained |


### PR DESCRIPTION
## Summary

Fixes a workflow gap where validator/parser input range mismatches survive both implementation and code review phases. Adds two complementary guardrails triggered when multiple functions operate on the same input field:

1. **TDD RED phase Step 2 — Domain Peer Check** (`write-tests-first.md`): Authors grep for peer functions before writing tests, compare accepted input ranges, and resolve or document divergence. Steps renumbered 2→3, 3→4, 4→5.

2. **Code-Critic §1d — Domain Alignment Verification** (`Code-Critic.agent.md`): Sub-perspective under §1 Architecture. Reviewers check that all functions operating on the same field agree on input range, boundary semantics (inclusive/exclusive, signed/unsigned, type coercion), and documented intentional differences. §1 gate updated to skip §1b, §1c, and §1d for documentation-only PRs.

Also adds `Documents/Design/domain-alignment-checking.md` with 8 design decisions, the root-cause bug class, and rejected alternatives.

**Root cause fixed**: Countdown-Clash #91 — `validateGameSetup` accepted `seed: -1` while `parseSeedParam` only accepted `[0, 4294967295]`. Defect survived 3 Code-Critic passes and was caught only at CE Gate (Error States lens).

---

## Changed Files

| File | Change |
|------|--------|
| `.github/skills/test-driven-development/workflows/write-tests-first.md` | New Step 2 "Domain Peer Check"; steps renumbered 2→3, 3→4, 4→5; checklist bullet updated with all 4 function types |
| `.github/agents/Code-Critic.agent.md` | New §1d "Domain Alignment Verification"; §1 gate adds §1d to docs-only skip list; §1d gate vocabulary aligned with TDD gate ("constrains"); §1d peer-discovery note added |
| `Documents/Design/domain-alignment-checking.md` | New design doc (D1–D8, root-cause class, rejected alternatives) |

---

## Validation Evidence

```
Plan-Architect refs: 0 ✅
Janitor refs:        0 ✅
Agent count:        13 ✅
Step headings:       5 (### 1–5) ✅
§1d heading:         1 match ✅
Old gate text "skip §1b and §1c entirely": 0 matches ✅
Domain Peer Check:   2 matches (heading + checklist) ✅
"constrains" in §1d gate: 1 match ✅
Peer-discovery note in §1d: 1 match ✅
Coercion/signed sub-checks in sub-step 2: 1 match ✅
Checklist bullet covers deserializers/constrainers: 1 match ✅
```

---

## CE Gate

⏭️ CE Gate not applicable — documentation-only PR; no customer-facing surface.

---

## Adversarial Review Scores

| Stage | Prosecutor | Defense | Judge rulings |
|-------|-----------|---------|---------------|
| Code Review | 21 pts (5 sustained) | −9 pts (2 disproved, 1 false-disproof penalty) | 6 rulings |
| CE Review | ⏭️ N/A | ⏭️ N/A | ⏭️ N/A |
| Post-fix Review | ⏭️ N/A (not triggered) | ⏭️ N/A | ⏭️ N/A |

**Accepted findings routed to Doc-Keeper (5/6):**
- A: Added peer-discovery note to §1d gate (grep + plan doc + call-chain)
- B: Extended sub-step 1 with criteria (b) and (c) discovery methods
- C: Added "or constrains" to §1d gate vocabulary
- D: Expanded sub-step 2 with inclusive/exclusive bounds, signed/unsigned, and type coercion prompts
- E: Expanded checklist bullet to all 4 function types (validator/parser/deserializer/constrainer)

**Rejected (1/6):**
- F: Checklist ordering — defense disproved (checklists are retrospective verification tools; execution order is determined by step numbering)

---

## Pipeline Metrics

<!-- pipeline-metrics
prosecution_findings: 6
pass_1_findings: 3
pass_2_findings: 3
pass_3_findings: 0
defense_disproved: 2
judge_accepted: 5
judge_rejected: 1
judge_deferred: 0
ce_gate_result: not-applicable
ce_gate_intent: n/a
ce_gate_defects_found: n/a
rework_cycles: 1
postfix_triggered: false
postfix_prosecution_findings: n/a
postfix_judge_accepted: n/a
postfix_judge_rejected: n/a
postfix_judge_deferred: n/a
postfix_defense_disproved: n/a
postfix_rework_cycles: n/a
-->

---

## Process Notes

**Step 7 retrospective**: Context compaction interrupted mid-Step 5 after all 3 prosecution passes completed. Conversation summary recovery was seamless — the merged ledger, defense pass, and judge pass all executed correctly in the resumed session with no state loss. No systemic gap identified.

Closes #107

## Summary by Sourcery

Introduce domain alignment checks into both the TDD workflow and Code-Critic review process, supported by a dedicated design document describing the approach and rationale.

Documentation:
- Add a Domain Peer Check step to the TDD write-tests-first workflow to ensure functions sharing an input field have aligned accepted ranges or documented differences.
- Extend the Code-Critic Architecture perspective with a Domain Alignment Verification sub-section that guides reviewers to verify consistent input ranges, boundary semantics, and documentation across related functions.
- Document the domain alignment checking design, including decision points, the root-cause bug class, and rejected alternatives.