### PR TITLE
fix: inline session startup check into copilot-instructions.md (#118)

### DIFF
--- a/.github/agents/Code-Conductor.agent.md
+++ b/.github/agents/Code-Conductor.agent.md
@@ -98,7 +98,7 @@ Quick checklist before declaring mode for a step:
 ## Core Workflow
 
 0. **Issue Transition (Step 0, before implementation)**:
-   - Cleanup note: The `session-startup` instruction detects stale tracking files from merged branches and prompts you at the start of your next conversation — cleanup requires one confirmation. If stale artifacts persist, run `pwsh "$env:WORKFLOW_TEMPLATE_ROOT/.github/scripts/post-merge-cleanup.ps1" -IssueNumber {N} -FeatureBranch feature/issue-{N}-description` directly.
+   - Cleanup note: The `copilot-instructions.md` "Session Startup Check" detects stale tracking files from merged branches and prompts you at the start of your next conversation — cleanup requires one confirmation. If stale artifacts persist, run `pwsh "$env:WORKFLOW_TEMPLATE_ROOT/.github/scripts/post-merge-cleanup.ps1" -IssueNumber {N} -FeatureBranch feature/issue-{N}-description` directly.
    - Optional planning lane: If scope/acceptance criteria changed or are ambiguous, call Issue-Planner to confirm whether plan updates are needed before execution.
    - If planning is unnecessary, explicitly note "Step 0 skipped: no planning transition required" and continue.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,6 +72,37 @@ This repo uses a **scored prosecution → defense → judge pipeline** across al
 - `"Use CE review perspectives"` — CE prosecution
 - `"Score and represent GitHub review"` — proxy prosecution
 
+## Session Startup Check
+
+At the start of every new conversation, **before responding to the user's first message**, run the session-cleanup detector:
+
+### Step 1 — Check prerequisites
+
+If `$env:WORKFLOW_TEMPLATE_ROOT` is not set, skip the entire check silently and continue with the user's request.
+
+### Step 2 — Run the detector
+
+```powershell
+pwsh -NoProfile -NonInteractive -File "$env:WORKFLOW_TEMPLATE_ROOT/.github/scripts/session-cleanup-detector.ps1"
+```
+
+### Step 3 — Parse output
+
+- Output is `{}` → continue silently, no prompt
+- Output contains `hookSpecificOutput` → stale state found; proceed to Step 4
+
+### Step 4 — Prompt the user
+
+Present the `additionalContext` field from the output to the user using `#tool:vscode/askQuestions` with two options: "Yes — run cleanup" and "No — skip for now".
+
+### Step 5 — Run cleanup (only if confirmed)
+
+Execute the PowerShell code block from `additionalContext` in the terminal. Report what was cleaned up when complete.
+
+Continue with the user's original request regardless of whether cleanup was run, skipped, or declined.
+
+> **Silent skip conditions**: Skip the entire check when `$env:WORKFLOW_TEMPLATE_ROOT` is not set, `pwsh` is not available, or the script produces non-JSON output. See `.github/instructions/session-startup.instructions.md` for full edge case details.
+
 ## Build & Run
 
 No build step. This is a configuration/documentation template.

--- a/.github/instructions/post-pr-review.instructions.md
+++ b/.github/instructions/post-pr-review.instructions.md
@@ -38,7 +38,7 @@ Get-ChildItem .copilot-tracking -Recurse -File |
 - Files moved to `.copilot-tracking-archive/{year}/{month}/issue-{ID}/`
 - No tracking files remain in `.copilot-tracking/research/` for this issue
 
-> **Automation**: The `session-startup` instruction detects stale tracking files and prompts you at the start of your next conversation — cleanup requires one confirmation. You can also run the script directly: `pwsh "$env:WORKFLOW_TEMPLATE_ROOT/.github/scripts/post-merge-cleanup.ps1" -IssueNumber {ID} -FeatureBranch feature/issue-{ID}-description`
+> **Automation**: The `copilot-instructions.md` "Session Startup Check" detects stale tracking files and prompts you at the start of your next conversation — cleanup requires one confirmation. You can also run the script directly: `pwsh "$env:WORKFLOW_TEMPLATE_ROOT/.github/scripts/post-merge-cleanup.ps1" -IssueNumber {ID} -FeatureBranch feature/issue-{ID}-description`
 
 ### 2. Update Documentation
 
@@ -129,7 +129,7 @@ git push origin --delete feature/issue-{ID}-description
 
 **Note**: Some projects auto-delete branches on PR merge. Verify your project settings.
 
-> **Automation**: Branch deletion is also handled by `.github/scripts/post-merge-cleanup.ps1` when invoked via the session-startup instruction cleanup flow (see Section 1 above).
+> **Automation**: Branch deletion is also handled by `.github/scripts/post-merge-cleanup.ps1` when invoked via the "Session Startup Check" cleanup flow (see Section 1 above).
 
 ### 6. Update Project Tracking
 

--- a/.github/instructions/session-startup.instructions.md
+++ b/.github/instructions/session-startup.instructions.md
@@ -1,5 +1,7 @@
 # Session Startup Instructions
 
+> **Reference only**: The operational session startup check is inline in `.github/copilot-instructions.md` (Section: "Session Startup Check"). This file documents detailed edge cases and rationale. Agents should follow the inline check; use this file for deeper context.
+
 ## Purpose
 
 Instruct agents to run the session-cleanup detector at the start of every conversation. This replaces the VS Code `SessionStart` hook, which was retired in issue #109 due to unreliable firing across different repos. The detector is implemented in `.github/scripts/session-cleanup-detector.ps1` and identifies stale tracking files left over from merged pull requests.

--- a/.github/prompts/setup.prompt.md
+++ b/.github/prompts/setup.prompt.md
@@ -101,7 +101,7 @@ For **macOS/Linux**:
 export WORKFLOW_TEMPLATE_ROOT="/path/to/workflow-template"
 ```
 
-> **Important**: VS Code launched from the Start Menu or a desktop shortcut may not run your PowerShell profile. Use the permanent approach to ensure `WORKFLOW_TEMPLATE_ROOT` is always available — the session-startup instruction silently skips if the variable is not set.
+> **Important**: VS Code launched from the Start Menu or a desktop shortcut may not run your PowerShell profile. Use the permanent approach to ensure `WORKFLOW_TEMPLATE_ROOT` is always available — the Session Startup Check (in `copilot-instructions.md`) silently skips if the variable is not set.
 
 **Step 1.2** — Show the VS Code settings to add to your user `settings.json` (`Ctrl+,` → open `settings.json`):
 

--- a/.github/skills/post-pr-review/SKILL.md
+++ b/.github/skills/post-pr-review/SKILL.md
@@ -47,7 +47,7 @@ Get-ChildItem .copilot-tracking -Recurse -File |
 - Files moved to `.copilot-tracking-archive/{year}/{month}/issue-{ID}/`
 - No tracking files remain in `.copilot-tracking/research/` for this issue
 
-> **Automation**: The `session-startup` instruction detects stale tracking files and prompts you at the start of your next conversation — cleanup requires one confirmation. You can also run the script directly: `pwsh "$env:WORKFLOW_TEMPLATE_ROOT/.github/scripts/post-merge-cleanup.ps1" -IssueNumber {ID} -FeatureBranch feature/issue-{ID}-description`
+> **Automation**: The `copilot-instructions.md` "Session Startup Check" detects stale tracking files and prompts you at the start of your next conversation — cleanup requires one confirmation. You can also run the script directly: `pwsh "$env:WORKFLOW_TEMPLATE_ROOT/.github/scripts/post-merge-cleanup.ps1" -IssueNumber {ID} -FeatureBranch feature/issue-{ID}-description`
 
 ### 2. Update Documentation
 
@@ -138,7 +138,7 @@ git push origin --delete feature/issue-{ID}-description
 
 **Note**: Some projects auto-delete branches on PR merge. Verify your project settings.
 
-> **Automation**: Branch deletion is also handled by `.github/scripts/post-merge-cleanup.ps1` when invoked via the session-startup instruction cleanup flow (see Section 1 above).
+> **Automation**: Branch deletion is also handled by `.github/scripts/post-merge-cleanup.ps1` when invoked via the "Session Startup Check" cleanup flow (see Section 1 above).
 
 ### 6. Strategic Assessment (Pre-Merge)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Read these instruction files for cross-cutting rules:
 - `.github/instructions/tracking-format.instructions.md` — YAML frontmatter format for tracking files
 - `.github/instructions/code-review-intake.instructions.md` — GitHub review intake protocol (deterministic ledger-based judgment) _(also available as skill: `.github/skills/code-review-intake/SKILL.md`)_
 - `.github/instructions/post-pr-review.instructions.md` — Post-merge checklist (archive tracking, update docs, tag releases) _(also available as skill: `.github/skills/post-pr-review/SKILL.md`)_
-- `.github/instructions/session-startup.instructions.md` — VS Code Copilot–specific: session startup check for stale tracking files (no action needed in Claude Code — no startup trigger exists)
+- `.github/instructions/session-startup.instructions.md` — detailed reference for edge cases and silent skip conditions; the startup check itself is inline in `copilot-instructions.md` "Session Startup Check" section (no action needed in Claude Code — no startup trigger exists)
 
 ## Validation Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,9 @@ To enable automatic skill discovery from `.github/skills/` (VS Code 1.108+):
 
 This enables agents to interact directly with GitHub issues and PRs without external MCP server configuration.
 
-### Session Startup Instruction
+### Session Startup Check
 
-This template includes a `session-startup` instruction (`.github/instructions/session-startup.instructions.md`) that tells agents to check for post-merge cleanup work at the start of each conversation. When merged feature branches have stale tracking files in `.copilot-tracking/`, the active agent prompts you to confirm cleanup. Requires PowerShell 7+ (`pwsh`) and `WORKFLOW_TEMPLATE_ROOT` set.
+This template includes a session startup check (inline in `copilot-instructions.md`) that tells agents to check for post-merge cleanup work at the start of each conversation. When merged feature branches have stale tracking files in `.copilot-tracking/`, the active agent prompts you to confirm cleanup. Requires PowerShell 7+ (`pwsh`) and `WORKFLOW_TEMPLATE_ROOT` set. See `.github/instructions/session-startup.instructions.md` for edge case details.
 
 ## Ways to Contribute
 

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -24,7 +24,7 @@ This template supports two distribution models:
 
 2. Open Extensions view (`Ctrl+Shift+X`), search `@agentPlugins workflow-template`, install.
 
-> **Note**: If you use the plugin, you will not receive automatic loading of `.github/instructions/` files (including the session-startup instruction). For those features, use the clone/fork model instead.
+> **Note**: If you use the plugin, you will not receive automatic loading of `.github/instructions/` files. The session-startup check (which requires `WORKFLOW_TEMPLATE_ROOT`) is a clone/fork-only feature. For full instruction support, use the clone/fork model and enable `chat.instructionsFilesLocations`.
 
 ---
 
@@ -102,7 +102,7 @@ To share agents across all repositories in your org:
 >
 > The steps below are the manual equivalent — follow them if you prefer to configure without the wizard, or if you need to adjust an existing configuration.
 
-The workflow-template includes a `session-startup` instruction (`.github/instructions/session-startup.instructions.md`) that tells agents to check for stale feature branches and leftover tracking files at the start of each conversation. When cleanup is needed, the agent prompts you to confirm before running cleanup.
+The workflow-template includes a session startup check (inline in `copilot-instructions.md`) that tells agents to check for stale feature branches and leftover tracking files at the start of each conversation. When cleanup is needed, the agent prompts you to confirm before running cleanup. The full edge-case details are in `.github/instructions/session-startup.instructions.md` (detailed reference only — the check itself runs from `copilot-instructions.md`).
 
 **Setup — two steps:**
 
@@ -130,9 +130,9 @@ The workflow-template includes a `session-startup` instruction (`.github/instruc
 
 > **Windows path**: Use forward slashes or escaped backslashes in the JSON value, e.g. `"C:/Users/you/workflow-template/.github/instructions"`. Apply the same format to all four settings above.
 >
-> **Migration note**: If you previously configured `chat.hookFilesLocations`, you can safely remove it — hooks have been replaced by the `session-startup` instruction file.
+> **Migration note**: If you previously configured `chat.hookFilesLocations`, you can safely remove it — hooks have been replaced by the session startup check (inline in `copilot-instructions.md`).
 
-**Step 2**: Set the `WORKFLOW_TEMPLATE_ROOT` environment variable to the absolute path of your local workflow-template clone. Without this, the session-startup instruction will not be able to run cleanup scripts.
+**Step 2**: Set the `WORKFLOW_TEMPLATE_ROOT` environment variable to the absolute path of your local workflow-template clone. Without this, the session startup check will not be able to run cleanup scripts.
 
 **Windows (permanent — recommended)**:
 

--- a/Documents/Design/agent-plugin.md
+++ b/Documents/Design/agent-plugin.md
@@ -85,7 +85,7 @@ If VS Code resolves `chat.plugins.marketplaces: ["Grimblaz/workflow-template"]` 
 | 13 agents | ✅ | ✅ |
 | 14 skills | ✅ | ✅ |
 | `/setup`, `/start-issue` slash commands | ✅ | ✅ |
-| `.github/instructions/` (shared rules, incl. `session-startup`) | ❌ not distributed | ✅ auto-discovered |
+| `.github/instructions/` (shared rules; `session-startup` operational content inlined into `copilot-instructions.md`) | ❌ not distributed | ✅ auto-discovered |
 | `.github/scripts/` (cleanup script) | ❌ not distributed | ✅ |
 
 Plugin users relying on `post-pr-review` skill Step 1 (preferred cleanup script) must use the manual archive method — the `$env:WORKFLOW_TEMPLATE_ROOT` path is unavailable in plugin-only setups. The skill's Step 1 includes a disclaimer for this case.

--- a/Documents/Design/session-hooks.md
+++ b/Documents/Design/session-hooks.md
@@ -87,7 +87,7 @@ Added alongside the portability fix to close a gap found in the post-PR review o
 | File | Purpose | Status |
 |------|---------|--------|
 | `.github/hooks/session-cleanup.json` | `SessionStart` hook configuration; resolves scripts via `$WORKFLOW_TEMPLATE_ROOT`; structured JSON error when unset | **Deleted** — retired in issue #109 |
-| `.github/instructions/session-startup.instructions.md` | Agent self-check instruction; runs detector at conversation start; uses `$env:WORKFLOW_TEMPLATE_ROOT` for script paths | **Active** — added in issue #109 |
+| `.github/instructions/session-startup.instructions.md` | Agent self-check instruction; runs detector at conversation start; uses `$env:WORKFLOW_TEMPLATE_ROOT` for script paths | **Reference** — operational content inlined into `copilot-instructions.md` (issue #118) |
 | `.github/scripts/session-cleanup-detector.ps1` | Dual-path detection: branch check + tracking file check; emits cleanup command paths using `$env:WORKFLOW_TEMPLATE_ROOT` | Active — unchanged |
 | `.github/scripts/post-merge-cleanup.ps1` | Archives tracking files, deletes local/remote branch, syncs default branch | Active — unchanged |
 


### PR DESCRIPTION
## Summary

The session-startup check was broken: `.github/instructions/session-startup.instructions.md` had no `applyTo` frontmatter, so VS Code only listed it as a reference path. Agents never read it proactively — the entire branch cleanup pipeline was silently dead.

**Fix**: Inline the condensed 5-step startup check directly into `.github/copilot-instructions.md` (which has `applyTo: "**"` and is auto-injected into every agent context as full content).

`.github/instructions/session-startup.instructions.md` is retained as a detailed reference and now has a "Reference only" header to prevent dual-injection confusion for clone/fork users with `chat.instructionsFilesLocations` configured.

---

## Changed Files

| File | Change |
|------|--------|
| `.github/copilot-instructions.md` | Added `## Session Startup Check` section (5-step inline protocol) |
| `.github/instructions/session-startup.instructions.md` | Added "Reference only" header to prevent dual-injection |
| `CLAUDE.md` | Updated session-startup bullet to describe it as "detailed reference" |
| `CONTRIBUTING.md` | Renamed "Session Startup Instruction" → "Session Startup Check"; updated body |
| `CUSTOMIZATION.md` | Updated plugin note and Section 6 to reference inline check; fixed 2 stale phrases |
| `.github/agents/Code-Conductor.agent.md` | Updated cleanup note to reference inline check |
| `.github/instructions/post-pr-review.instructions.md` | Updated 2 references |
| `.github/skills/post-pr-review/SKILL.md` | Updated 2 references |
| `.github/prompts/setup.prompt.md` | Updated 1 reference |
| `Documents/Design/session-hooks.md` | Updated status from "Active" → "Reference — operational content inlined..." |
| `Documents/Design/agent-plugin.md` | Updated coverage table row |

---

## Validation Evidence

**Quick-validate:**
```
Plan-Architect references: 0 ✅
Janitor references: 0 ✅
Agent count: 13 ✅
```

**Stale session-startup reference grep** (no file should present `session-startup.instructions.md` as primary delivery mechanism):
```powershell
Get-ChildItem -Path . -Recurse -Include "*.md" |
  Where-Object { $_.Name -ne "session-startup.instructions.md" } |
  Select-String -Pattern "session-startup\.instructions\.md.*(tells|that tells|check for|detects stale)"
# Result: 0 matches ✅
```

---

## CE Gate

⏭️ CE Gate not applicable — internal developer tooling only; no customer-facing surface.

---

## Adversarial Review Scores

| Stage | Prosecutor | Defense | Judge rulings |
|-------|-----------|---------|---------------|
| Code Review | 6 pts (2 sustained) | 3 pts (3 disproved, 0 rejected) | 5 rulings |
| CE Review | ⏭️ N/A | ⏭️ N/A | ⏭️ N/A |
| Post-fix Review | ⏭️ N/A | ⏭️ N/A | ⏭️ N/A |

**Judge rulings:**
- S1: ✅ Sustained — Added "Reference only" header to `session-startup.instructions.md`
- S2: ❌ Defense sustained — CUSTOMIZATION.md heading rename was explicitly out-of-scope per plan Non-goals
- S3: ✅ Sustained — Updated 2 stale phrases in CUSTOMIZATION.md body
- S4: ❌ Defense sustained — "continue silently" is a complete terminal directive; trailing note covers all paths
- S5: ❌ Defense sustained — 4th silent-skip condition covered transitively; inline pointer makes omission intentional

---

## Pipeline Metrics

<!-- pipeline-metrics
prosecution_findings: 5
pass_1_findings: 2
pass_2_findings: 4
pass_3_findings: 3
defense_disproved: 3
judge_accepted: 2
judge_rejected: 3
judge_deferred: 0
ce_gate_result: not-applicable
ce_gate_intent: n/a
ce_gate_defects_found: n/a
rework_cycles: 1
postfix_triggered: false
postfix_prosecution_findings: n/a
postfix_judge_accepted: n/a
postfix_judge_rejected: n/a
postfix_judge_deferred: n/a
postfix_defense_disproved: n/a
postfix_rework_cycles: n/a
-->

Closes #118

## Summary by Sourcery

Inline the session startup cleanup check into the primary Copilot instructions so it runs in every VS Code agent session, and update references to treat the original session-startup instructions file as a detailed reference only.

Documentation:
- Document the session startup check as inline content in `copilot-instructions.md` and clarify its prerequisites and silent skip conditions.
- Update CONTRIBUTING, CUSTOMIZATION, CLAUDE, setup prompt, agent, skill, and design docs to reference the new inline session startup check and mark `session-startup.instructions.md` as reference-only.