### PR TITLE
Add unknown-category boundary test for systemic patterns

### DIFF
--- a/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
+++ b/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
@@ -1339,7 +1339,7 @@ Describe 'aggregate-review-scores.ps1 -CalibrationFile' {
         It 'excludes unknown categories from systemic patterns' -Tag 'requires-gh' {
             # Both valid (security) and unknown findings are present; section must
             # appear for the valid finding but must not contain an unknown category key.
-            if (-not $script:GhAvailable) { Set-ItResult -Skipped -Because 'gh CLI not found' }
+            if (-not $script:GhAvailable) { Set-ItResult -Skipped -Because 'gh CLI not found'; return }
 
             $workDir = & $script:NewWorkDir
             $findings = @(
@@ -1366,7 +1366,7 @@ Describe 'aggregate-review-scores.ps1 -CalibrationFile' {
                 -Because 'systemic_patterns section must appear when valid known-category findings exist'
             $result.Output | Should -Match '(?ms)^  systemic_patterns:\r?\n(?:(?!^  \S).*\r?\n)*?      security:' `
                 -Because 'known categories must still appear inside the systemic_patterns block for the same fixture'
-            $result.Output | Should -Not -Match '(?s)systemic_patterns:.*?unknown-cat:' `
+            $result.Output | Should -Not -Match '(?ms)^  systemic_patterns:\r?\n(?:(?!^  \S).*\r?\n)*?      unknown-cat:' `
                 -Because 'unknown categories must be excluded from systemic_patterns'
         }
 


### PR DESCRIPTION
## Summary

Adds a regression test in `.github/scripts/Tests/aggregate-review-scores.Tests.ps1` to verify that an `instruction` finding with category `unknown-cat` is excluded from `systemic_patterns` while a valid known-category finding still renders inside the same block.

## Changed Files

- `.github/scripts/Tests/aggregate-review-scores.Tests.ps1` — added the unknown-category boundary test and tightened the positive assertion so it proves `security:` appears inside the `systemic_patterns` block.

## Validation Evidence

- `pwsh -NoProfile -NonInteractive -Command "Invoke-Pester .github/scripts/Tests/aggregate-review-scores.Tests.ps1 -Output Minimal"` → 58 passed, 0 failed, 0 skipped
- `pwsh -NoProfile -NonInteractive -Command "Invoke-Pester .github/scripts/Tests/ -Output Minimal"` → 196 passed, 0 failed, 0 skipped
- `if (Get-Module -ListAvailable PSScriptAnalyzer) { (Invoke-ScriptAnalyzer -Path .github/scripts/ -Recurse -Settings .github/config/PSScriptAnalyzerSettings.psd1).Count } else { Write-Warning ''PSScriptAnalyzer not installed — skipping'' }` → 0

## Adversarial Review Scores

| Stage | Prosecutor | Defense | Judge rulings |
| --- | --- | --- | --- |
| Code Review | 5 pts (1 sustained) | 0 pts (0 disproved, 0 rejected) | 1 ruling |
| CE Review | ⏭️ N/A | ⏭️ N/A | ⏭️ N/A |
| Post-fix Review | ⏭️ N/A | ⏭️ N/A | ⏭️ N/A |

## Prosecution Depth Summary

Prosecution depth: 7 full, 0 light, 0 skip

| Category | Depth | Rationale |
| --- | --- | --- |
| architecture | full | aggregate script recommendation |
| security | full | aggregate script recommendation |
| performance | full | aggregate script recommendation |
| pattern | full | aggregate script recommendation |
| simplicity | full | aggregate script recommendation |
| script-automation | full | aggregate script recommendation |
| documentation-audit | full | aggregate script recommendation |

Re-activated categories (if any): none

## CE Gate

⏭️ CE Gate not applicable — internal Pester-only change with no customer-facing surface.

## Process Gaps Found

- Process-Review: no systemic gap found

## Retrospective Checkpoint

- What slowed this down: the adversarial review caught that the first positive assertion was not scoped tightly enough to the `systemic_patterns` block.
- What would have failed later without this boundary test: a regression removing the known-category allowlist term could allow `unknown-cat` to accumulate into `systemic_patterns` without a dedicated failing test.
- One guardrail to add next: when adding a negative boundary test for a report subsection, pair it with a positive assertion scoped to the same block.

Closes #208

## Pipeline Metrics

<!-- pipeline-metrics
metrics_version: 2
prosecution_findings: 1
pass_1_findings: 0
pass_2_findings: 1
pass_3_findings: 0
defense_disproved: 0
judge_accepted: 1
judge_rejected: 0
judge_deferred: 0
ce_gate_result: not-applicable
ce_gate_intent: n/a
ce_gate_defects_found: n/a
rework_cycles: 1
postfix_triggered: false
postfix_prosecution_findings: n/a
postfix_judge_accepted: n/a
postfix_judge_rejected: n/a
postfix_judge_deferred: n/a
postfix_defense_disproved: n/a
postfix_rework_cycles: n/a
express_lane_count: 0
postfix_passes: n/a
batch_dispatch_calls: 1
batch_dispatch_findings: 1
rate_limit_retries: 0
rate_limit_deferred: false
prosecution_depth_light: []
prosecution_depth_skip: []
prosecution_depth_override: false
prosecution_depth_reactivations: 0
findings:
  - id: F1
    category: script-automation
    severity: medium
    points: 5
    pass: 2
    defense_verdict: conceded
    judge_ruling: sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: main
-->

## Summary by Sourcery

Tests:
- Add a Pester test that verifies unknown-category instruction findings are excluded from systemic_patterns while known-category findings still cause the section and their category to appear.