### PR TITLE
feat(review): add prototype-chain review rule to JS/TS template + hub/consumer classification gate

### DIFF
--- a/.github/agents/Experience-Owner.agent.md
+++ b/.github/agents/Experience-Owner.agent.md
@@ -110,6 +110,16 @@ At each major step, decide whether to proceed autonomously or pause for user inp
 - **Checkpoint examples**: issue number needed, ambiguous scope or persona, conflicting signals in research, architectural constraints unclear
 - **Hub-mode guidance**: When called by Code-Conductor as part of the full pipeline, target 2–3 `#tool:vscode/askQuestions` calls — one for scope or persona ambiguity, one for key framing decisions, and one to confirm CE Gate scenario drafts with the user.
 
+### Hub/Consumer Classification Gate
+
+Before framing, classify whether the issue proposes adding content that primarily manifests in one language's type system, runtime, or framework to a hub agent (any `.agent.md` in `.github/agents/`). Hub agents are language-agnostic — language-specific review rules, prosecution perspectives, and behavioral patterns belong in consumer-repo artifacts:
+
+- **Review rules / pitfalls** → `examples/{stack}/architecture-rules.md`
+- **Stack-specific conventions** → `examples/{stack}/copilot-instructions.md`
+- **Reusable cross-stack skills** → `.github/skills/{skill-name}/`
+
+If the gate fires, redirect the proposal to the appropriate consumer artifact and frame the issue accordingly. The user may override with explicit rationale if the proposed content is genuinely language-agnostic.
+
 ### Customer Problem Statement
 
 Write the customer-facing problem statement in non-technical language:

--- a/.github/agents/Experience-Owner.agent.md
+++ b/.github/agents/Experience-Owner.agent.md
@@ -112,7 +112,7 @@ At each major step, decide whether to proceed autonomously or pause for user inp
 
 ### Hub/Consumer Classification Gate
 
-Before framing, classify whether the issue proposes adding content that primarily manifests in one language's type system, runtime, or framework to a hub agent (any `.agent.md` in `.github/agents/`). Hub agents are language-agnostic — language-specific review rules, prosecution perspectives, and behavioral patterns belong in consumer-repo artifacts:
+Before proceeding, classify whether the issue proposes adding content that primarily manifests in one language's type system, runtime, or framework to a hub agent (any `.agent.md` in `.github/agents/`). Hub agents are language-agnostic — language-specific review rules, prosecution perspectives, and behavioral patterns belong in consumer-repo artifacts:
 
 - **Review rules / pitfalls** → `examples/{stack}/architecture-rules.md`
 - **Stack-specific conventions** → `examples/{stack}/copilot-instructions.md`

--- a/.github/agents/Solution-Designer.agent.md
+++ b/.github/agents/Solution-Designer.agent.md
@@ -101,6 +101,16 @@ When the design involves UI changes, new screens, or modifications to existing v
 
 This is optional context-gathering — skip if the design is purely backend/domain logic or the change is well-understood.
 
+### Hub/Consumer Classification Gate
+
+Before framing, classify whether the issue proposes adding content that primarily manifests in one language's type system, runtime, or framework to a hub agent (any `.agent.md` in `.github/agents/`). Hub agents are language-agnostic — language-specific review rules, prosecution perspectives, and behavioral patterns belong in consumer-repo artifacts:
+
+- **Review rules / pitfalls** → `examples/{stack}/architecture-rules.md`
+- **Stack-specific conventions** → `examples/{stack}/copilot-instructions.md`
+- **Reusable cross-stack skills** → `.github/skills/{skill-name}/`
+
+If the gate fires, redirect the proposal to the appropriate consumer artifact and frame the issue accordingly. The user may override with explicit rationale if the proposed content is genuinely language-agnostic.
+
 ### Collaboration Pattern
 
 For each design decision:

--- a/.github/agents/Solution-Designer.agent.md
+++ b/.github/agents/Solution-Designer.agent.md
@@ -103,7 +103,7 @@ This is optional context-gathering — skip if the design is purely backend/doma
 
 ### Hub/Consumer Classification Gate
 
-Before framing, classify whether the issue proposes adding content that primarily manifests in one language's type system, runtime, or framework to a hub agent (any `.agent.md` in `.github/agents/`). Hub agents are language-agnostic — language-specific review rules, prosecution perspectives, and behavioral patterns belong in consumer-repo artifacts:
+Before proceeding, classify whether the issue proposes adding content that primarily manifests in one language's type system, runtime, or framework to a hub agent (any `.agent.md` in `.github/agents/`). Hub agents are language-agnostic — language-specific review rules, prosecution perspectives, and behavioral patterns belong in consumer-repo artifacts:
 
 - **Review rules / pitfalls** → `examples/{stack}/architecture-rules.md`
 - **Stack-specific conventions** → `examples/{stack}/copilot-instructions.md`

--- a/examples/nodejs-typescript/architecture-rules.md
+++ b/examples/nodejs-typescript/architecture-rules.md
@@ -323,6 +323,40 @@ app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
 });
 ```
 
+## Code Review Pitfalls
+
+Rules for Code-Critic prosecution passes. These pitfalls are specific to JS/TS and are commonly masked by TypeScript's structural type system or mock-based test patterns.
+
+### Prototype-Chain Preservation
+
+Object spread (`{...obj}`) and `Object.assign({}, obj)` copy only own enumerable properties. When `obj` is a class instance, every method defined on the prototype chain becomes `undefined` on the copy. TypeScript's structural type system does not flag this because the interface is satisfied structurally. Mock-based tests also mask it because mocks define methods directly on the object.
+
+#### ❌ PROHIBITED
+
+```typescript
+// Wrapper/proxy/decorator that strips the prototype chain
+function wrapWithTracking(repo: TaskRepository): TaskRepository {
+  const tracked = { ...repo };           // ❌ Methods from prototype are lost
+  // or: const tracked = Object.assign({}, repo);  // ❌ Same problem
+  return tracked;
+}
+```
+
+#### ✅ SAFE
+
+```typescript
+// Preserve the prototype chain when copying a class instance
+function wrapWithTracking(repo: TaskRepository): TaskRepository {
+  const tracked = Object.assign(
+    Object.create(Object.getPrototypeOf(repo)),
+    repo,
+  );
+  return tracked;
+}
+```
+
+**Scope**: Applies when the source object is a class instance in a wrapper, proxy, decorator, or factory function. Plain-object spread (`{...plainObj}`) is not affected.
+
 <!--
 ## Migration Safety
 


### PR DESCRIPTION
## Summary

Adds a prototype-chain preservation review rule to the JS/TS consumer template and introduces a Hub/Consumer Classification Gate to prevent language-specific rules from bloating hub agents.

Closes #290

## Changes

### 1. `examples/nodejs-typescript/architecture-rules.md`
- New `## Code Review Pitfalls` section after `## Observability Rules`
- `### Prototype-Chain Preservation` with ❌ PROHIBITED / ✅ SAFE patterns
- Scope: wrapper/proxy/decorator/factory functions using `{...classInstance}` or `Object.assign({}, classInstance)`

### 2. `.github/agents/Experience-Owner.agent.md`
- New `### Hub/Consumer Classification Gate` inside `## Upstream Phase: Customer Framing`
- Redirects language/framework/domain-specific rule proposals to consumer-repo templates

### 3. `.github/agents/Solution-Designer.agent.md`
- Identical `### Hub/Consumer Classification Gate` inside `## Stage 2: Design Exploration`
- Character-identical to EO gate text (D6 — prevents wording drift)

## Design Decisions

| ID | Decision |
|---|---|
| D1 | Language-specific rules → consumer template, not hub agent |
| D2 | Classification gate in EO + SD agents |
| D3 | Active JS/TS consumer repos get sync issues |
| D4 | New `## Code Review Pitfalls` section after Observability Rules |
| D5 | Focused rule with ❌/✅ examples |
| D6 | Character-identical gate text in both EO and SD |

## Validation

- markdownlint: 0 new errors
- quick-validate: 9/9 checks passed
- Agent count: 14 (unchanged)
- Gate text identity: verified character-identical

## Follow-up

Consumer sync issues to be created in Windgust-Questbook, Countdown-Clash, and Organizations-of-Elos after merge.

## Summary by Sourcery

Add JS/TS-specific code review guidance for prototype-chain preservation and introduce a hub vs. consumer classification gate in key agent workflows.

Enhancements:
- Add a Hub/Consumer Classification Gate step to Experience Owner and Solution Designer agent workflows to keep language-specific rules in consumer templates rather than hub agents.

Documentation:
- Document a JS/TS code review pitfall around prototype-chain loss when copying class instances in the Node.js/TypeScript architecture rules.