### PR TITLE
feat(bdd-scenarios): add declarative-over-imperative authoring guidance

### DIFF
--- a/.github/skills/bdd-scenarios/SKILL.md
+++ b/.github/skills/bdd-scenarios/SKILL.md
@@ -19,7 +19,7 @@ Structured Given/When/Then scenario authoring with ID traceability and CE Gate c
 
 - Scenarios use numbered IDs: S1, S2, S3…
 - Heading convention: `### SN — {title} (Type)` where Type is Functional or Intent
-- G/W/T clauses in customer language (no technical jargon, no implementation details)
+- G/W/T clauses in customer language — see **Declarative-over-Imperative** below for details
 - Example template:
 
   ```markdown
@@ -32,6 +32,27 @@ Structured Given/When/Then scenario authoring with ID traceability and CE Gate c
 
 - Multiple Given or Then clauses allowed; And/But connectors supported for readability
 - Each scenario must be independently understandable
+
+### Declarative-over-Imperative
+
+Step text should describe *what the user intends* (outcome or state change), not *how they interact with UI* (action sequence). Declarative scenarios are more maintainable (survive UI redesigns), more reusable (same step across features), and decoupled from implementation (step definitions don't break when selectors change).
+
+| Imperative (avoid) | Declarative (preferred) |
+| --- | --- |
+| `When I click the 'Sign in with Google' button` | `When I choose to connect my Google account` |
+| `When the mock auth adapter returns a successful sign-in` | `Given a successful sign-in will occur for 'user@example.com'` |
+| `When I navigate to '/quests'` | `When I visit the quests area` |
+| `Then I should see a 'Sign in with Google' button` | `Then I see an option to connect my Google account` |
+| `Then I should see a green checkmark icon` | `Then the action is confirmed` |
+
+This rule narrows the broader "no implementation details" principle (see **Gotchas** below) to two actionable categories: imperative UI-interaction verbs and test-infrastructure leakage (adapter names, mock behavior, internal paths).
+
+**Validation scan** — when reviewing scenarios, flag any of these as signals to review (not automatic rejections — common English words like "type" or "press" may appear in legitimate customer-language scenarios; evaluate in context):
+
+- **Imperative verbs**: `click`, `navigate`, `tap`, `type`, `scroll`, `press`, `wait`
+- **Implementation nouns**: `mock`, `adapter`, `stub`, `spy`, `fixture`, path strings (e.g., `/quests`, `#submit-btn`, `.settings.json` — any string that reveals URL structure, CSS selectors, or file system paths)
+
+This scan is especially important before Phase 2 Gherkin conversion — imperative step text produces unmaintainable step definitions.
 
 ## Scenario Type Tags
 
@@ -76,7 +97,7 @@ BDD structured scenarios are only active when the consumer repo's `copilot-instr
 ## Gotchas
 
 - **S-IDs vs Specification's AC-NNN format**: This skill uses S-IDs (S1, S2, S3) for CE Gate scenarios. Specification agent uses `AC-NNN` for acceptance criteria. These are different namespaces — do not mix them or treat AC-NNN as a scenario ID.
-- **Customer language principle**: G/W/T keywords are structural framing only. The clause content must be in customer terms — no method names, no file paths, no agent names, no implementation details. "When the system calls ExperienceOwner.FrameScenarios()" is wrong; "When the team begins feature planning" is correct.
+- **Customer language principle**: G/W/T keywords are structural framing only. The clause content must be in customer terms — no method names, no file paths, no agent names, no implementation details. "When the system calls ExperienceOwner.FrameScenarios()" is wrong; "When the team begins feature planning" is correct. See also: **Declarative-over-Imperative** above for specific anti-patterns, preferred alternatives, and a validation scan. This gotcha states the broad principle (no implementation details); the subsection above provides actionable examples covering imperative UI verbs and test-infrastructure leakage.
 - **BDD detection gating**: All BDD-specific behavior (G/W/T authoring, classification, pre-flight, per-scenario prosecution) is conditional on `## BDD Framework` presence. Repos without this section keep the existing natural-language workflow unchanged — do not apply rubric, IDs, or pre-flight to natural-language scenarios.
 - **Issue-body source of truth**: The `## Scenarios` section in the GitHub issue body is the authoritative store for scenario IDs. Any abbreviated or derived authoring path (e.g., generating scenarios only in the plan's `[CE GATE]` step) **must** also write the full scenarios back into the issue body using the GitHub issue update tool — Code-Conductor's CE Gate pre-flight reads from the issue body and will treat missing issue-body scenarios as coverage gaps.
 - **Phase 2 scope boundary**: Phase 2 (Gherkin conversion + framework runner integration) is documented in the `## Phase 2: Gherkin Conversion & Framework Runner` section below. Phase 1 content (authoring, traceability, coverage detection) is unchanged.
@@ -92,9 +113,9 @@ Phase 2 is active when **both** conditions are met in the consumer repo's `copil
 1. `## BDD Framework` section heading is present (Phase 1 condition)
 2. A `bdd: {framework}` config line is present with a recognized framework name
 
-**Known migration case — `bdd: true`**: If a consumer repo was set up under Phase 1 only and still has `bdd: true` in a comment, emit a warning: _"bdd: true detected — Phase 2 requires a recognized framework name. Set `bdd: {framework}` with one of: cucumber.js, behave, jest-cucumber, cucumber. Falling back to Phase 1 behavior."_ Then fall back to Phase 1.
+**Known migration case — `bdd: true`**: If a consumer repo was set up under Phase 1 only and still has `bdd: true` in a comment, emit a warning: *"bdd: true detected — Phase 2 requires a recognized framework name. Set `bdd: {framework}` with one of: cucumber.js, behave, jest-cucumber, cucumber. Falling back to Phase 1 behavior."* Then fall back to Phase 1.
 
-**Unrecognized framework name**: If a `bdd: {framework}` line is present but the value is not in the mapping table, emit a warning: _"Unrecognized framework '{value}'. Recognized values: cucumber.js, behave, jest-cucumber, cucumber. Falling back to Phase 1 behavior."_ Then fall back to Phase 1.
+**Unrecognized framework name**: If a `bdd: {framework}` line is present but the value is not in the mapping table, emit a warning: *"Unrecognized framework '{value}'. Recognized values: cucumber.js, behave, jest-cucumber, cucumber. Falling back to Phase 1 behavior."* Then fall back to Phase 1.
 
 **Phase-1-only repos** (heading present, no `bdd:` line): Phase 2 detection requires BOTH conditions. A repo with only the `## BDD Framework` heading is Phase 1 only — behavior is unchanged.
 

--- a/Documents/Design/bdd-framework.md
+++ b/Documents/Design/bdd-framework.md
@@ -43,6 +43,17 @@ When BDD is enabled, Experience-Owner writes scenarios **before** handing off to
 - IDs are sequential from S1; no gaps, no reuse after plan approval
 - Scenario content stays in customer language — no implementation details
 
+### Declarative-over-Imperative Guidance (Issue #319)
+
+The `bdd-scenarios` skill includes a `### Declarative-over-Imperative` subsection within its G/W/T Authoring Patterns section. It provides:
+
+- A "why" principle paragraph (maintainability, reusability, implementation decoupling)
+- A 5-row paired anti-pattern table (3 Given/When + 2 Then examples) showing imperative vs. declarative rewrites
+- An implementation-detail rule and advisory validation scan with word lists (`click`, `enter`, `navigate`, `xpath`, `css`, `selector`, `scroll`, `hover`, `timeout`)
+- Cross-reference from the existing "Customer language principle" gotcha, with explicit authority boundary (skill owns the guidance; design doc references it)
+
+Design decisions: D1 placed the subsection within existing G/W/T Authoring Patterns rather than a new top-level section; D2 chose a 5-row paired table covering Given, When, and Then; D3 made the scan word lists advisory (not blocking); D4 scoped Phase 2 cross-referencing to the validation scan only.
+
 ---
 
 ## Scenario ID Lifecycle


### PR DESCRIPTION
## Summary

Adds a `### Declarative-over-Imperative` H3 subsection to the G/W/T Authoring Patterns section of `.github/skills/bdd-scenarios/SKILL.md`, addressing the imperative-step-text gap discovered during Windgust-Questbook#164 (BDD runner setup). The existing feature file required substantial rewriting because it contained imperative UI language and leaked implementation details — this skill guidance gap is now closed.

### Changes

| File | Change |
| --- | --- |
| `.github/skills/bdd-scenarios/SKILL.md` | New `### Declarative-over-Imperative` subsection with 4-part structure; gotcha cross-reference; refactored one-liner to forward-reference |
| `Documents/Design/bdd-framework.md` | Design doc update with declarative guidance summary |

### New Subsection Content

1. **"Why" paragraph** — maintainability (survive UI redesigns), reusability (same step across features), implementation decoupling (step definitions don't break when selectors change)
2. **5-row paired table** — rows 1–3: Given/When examples, rows 4–5: Then examples
3. **Implementation-detail rule** — narrowing of broader "no implementation details" principle to test-infrastructure specifics
4. **Validation scan** — advisory word lists (7 imperative verbs, 6+ implementation nouns with path-string exemplars); Phase 2 motivation sentence

### Design Decisions

- D1: Subsection within `## G/W/T Authoring Patterns` (not new H2, not expanded gotcha)
- D2: Paired table with 5 rows — rows 1–3 Given/When, rows 4–5 Then
- D3: Advisory scan word lists ("signal to review, not auto-rejection")
- D4: Phase 2 cross-reference in validation scan only

## Validation Evidence

- `markdownlint-cli2 --fix` → 0 errors on changed files
- `quick-validate.ps1` → 9/9 checks passed
- Completeness: `### Declarative-over-Imperative` heading exists (1 match), `Declarative-over-Imperative` referenced in gotcha (confirmed)

## Adversarial Review Scores

| Stage | Prosecutor | Defense | Judge rulings |
| --- | --- | --- | --- |
| Code Review | 17 pts (5 findings) | 6 pts (2 disproved, 0 rejected) | 5 rulings |
| CE Review | ⏭️ N/A | ⏭️ N/A | ⏭️ N/A |
| Post-fix Review | ⏭️ N/A | ⏭️ N/A | ⏭️ N/A |

### Review Detail

| Finding | Severity | Pass | Ruling | Disposition |
| --- | --- | --- | --- | --- |
| F1: "stated above" broken reference | medium | 1 | ✅ Sustained | Fixed — changed to "(see **Gotchas** below)" |
| F2: "no technical jargon" dropped | medium | 1 | ❌ Defense sustained | "Customer language" is better abstraction |
| F3: Table row 2 keyword conflation | low | 1 | ❌ Defense sustained | Keyword correction inherent to declarative rewriting |
| F4: Bridging text mischaracterizes scope | medium | 3 | ✅ Sustained | Fixed — reworded to cover both UI verbs and test-infrastructure |
| F5: "feature files" trigger ambiguity | low | 3 | finding-sustained (express) | Fixed — changed to "when reviewing scenarios" |

## Prosecution Depth Summary

| Category | Depth | Rationale |
| --- | --- | --- |
| architecture | full | — |
| security | full | — |
| performance | full | — |
| pattern | full | — |
| implementation-clarity | full | — |
| script-automation | full | — |
| documentation-audit | full | — |

Re-activated categories: none

## CE Gate

⏭️ CE Gate not applicable — docs-only change, no customer-facing surface (`ce_gate: false`)

Process-Review: not invoked (no CE defects found)

## Pipeline Metrics

<!-- pipeline-metrics
metrics_version: 2
prosecution_findings: 5
pass_1_findings: 3
pass_2_findings: 2
pass_3_findings: 3
defense_disproved: 2
judge_accepted: 3
judge_rejected: 2
judge_deferred: 0
ce_gate_result: not-applicable
ce_gate_intent: n/a
ce_gate_defects_found: n/a
rework_cycles: 1
postfix_triggered: false
postfix_prosecution_findings: n/a
postfix_judge_accepted: n/a
postfix_judge_rejected: n/a
postfix_judge_deferred: n/a
postfix_defense_disproved: n/a
postfix_rework_cycles: n/a
express_lane_count: 1
postfix_passes: n/a
batch_dispatch_calls: 1
batch_dispatch_findings: 3
rate_limit_retries: 0
rate_limit_deferred: false
prosecution_depth_light: []
prosecution_depth_skip: []
prosecution_depth_override: false
prosecution_depth_reactivations: 0
findings:
  - id: F1
    category: implementation-clarity
    severity: medium
    points: 5
    pass: 1
    defense_verdict: conceded
    judge_ruling: sustained
    judge_confidence: high
    review_stage: main
    systemic_fix_type: none
  - id: F2
    category: implementation-clarity
    severity: medium
    points: 5
    pass: 1
    defense_verdict: disproved
    judge_ruling: defense-sustained
    judge_confidence: high
    review_stage: main
    systemic_fix_type: none
  - id: F3
    category: implementation-clarity
    severity: low
    points: 1
    pass: 1
    defense_verdict: disproved
    judge_ruling: defense-sustained
    judge_confidence: medium
    review_stage: main
    systemic_fix_type: none
  - id: F4
    category: documentation-audit
    severity: medium
    points: 5
    pass: 3
    defense_verdict: insufficient-to-disprove
    judge_ruling: sustained
    judge_confidence: high
    review_stage: main
    systemic_fix_type: skill
  - id: F5
    category: documentation-audit
    severity: low
    points: 1
    pass: 3
    review_stage: main
    systemic_fix_type: none
    express_lane: true
    judge_ruling: finding-sustained
-->

Closes #319

## Summary by Sourcery

Add declarative-over-imperative guidance to BDD scenario authoring documentation and reference it from the BDD framework design doc.

Documentation:
- Document a Declarative-over-Imperative pattern for Given/When/Then step authoring, including examples, validation guidance, and links from existing gotchas.
- Update the BDD framework design document to summarize and reference the new declarative authoring guidance within the bdd-scenarios skill.