### PR TITLE
feat: scriptify deterministic routing

### DIFF
--- a/.github/agents/Code-Conductor.agent.md
+++ b/.github/agents/Code-Conductor.agent.md
@@ -146,25 +146,7 @@ Skip hub mode entirely when the user invokes a specific slash command (e.g., `/i
 
 Before calling any upstream agent, classify the issue scope to determine the appropriate pipeline tier. Use `#tool:vscode/askQuestions` with your analysis and recommendation.
 
-**5-criterion rubric for abbreviated tier** (ALL five must hold):
-
-1. Acceptance criteria are clearly defined or the change is self-evident from the issue title
-2. Implementation touches ≤3 files in a single domain (no cross-cutting changes)
-3. No new user-facing behavior is introduced (configuration, internal protocol, documentation-only)
-4. No cross-cutting architectural changes (no shared interfaces, new abstractions, or multi-agent contracts)
-5. No CE Gate scenarios are needed (no customer-facing surface affected)
-
-**Default to full pipeline when**: any criterion is absent, the issue is ambiguous, or the scope is sparse. When in doubt, choose full.
-
-**Two-tier table**:
-
-| Phase                               | Full pipeline | Abbreviated pipeline |
-| ----------------------------------- | ------------- | -------------------- |
-| Experience-Owner                    | ✅            | ❌ (skip)            |
-| Solution-Designer                   | ✅            | ❌ (skip)            |
-| Issue-Planner (incl. design review) | ✅            | ✅ (required)        |
-| D9 Checkpoint                       | ✅            | ✅ (required)        |
-| Implementation                      | ✅            | ✅                   |
+Load `.github/skills/routing-tables/SKILL.md` and evaluate the canonical abbreviated-tier rubric with `Test-GateCriteria -Gate scope_classification -Criteria @{ ... }`. The five abbreviated-tier criteria, the default-to-`full` rule when any criterion is absent, and the authoritative full-vs-abbreviated phase matrix all live in `.github/skills/routing-tables/assets/gate-criteria.json`.
 
 **User override**: Always present both tiers as options and recommend one — the user may choose either regardless of your analysis. This is how scope override (D5) is implemented.
 
@@ -316,18 +298,7 @@ For PBT rollout guidance, use `.github/skills/property-based-testing/SKILL.md`.
 
 ## Agent Selection
 
-| File Type / Task                                                                                                     | Keywords                                          | Agent                |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | -------------------- |
-| `*.test.*`, test suites, fixtures                                                                                    | test, assertion, flaky, coverage                  | Test-Writer          |
-| `src/**/*.ts`, `src/**/*.tsx` (new behavior)                                                                         | implement, feature, bugfix, logic                 | Code-Smith           |
-| `src/**/*.ts`, `src/**/*.tsx` (restructure existing)                                                                 | refactor, simplify, extract, dedupe               | Refactor-Specialist  |
-| UI source files (visual polish)                                                                                      | ui polish, spacing, alignment, styling            | UI-Iterator          |
-| `*.md`, `README.*`, `CHANGELOG.*`                                                                                    | docs, guide, changelog                            | Doc-Keeper           |
-| Session memory `/memories/session/plan-issue-{ID}.md` or GitHub issue comment with `<!-- plan-issue-{ID} -->` marker | plan, acceptance criteria, sequencing             | Issue-Planner        |
-| CE Gate evidence capture (downstream); upstream customer framing, scenarios, design intent                           | ce gate, customer, experience, journey, scenarios | Experience-Owner     |
-| Code review (read-only)                                                                                              | review, risks, quality, critique                  | Code-Critic          |
-| Categorize review feedback (read-only)                                                                               | judge, score, prosecution, defense, categorize    | Code-Review-Response |
-| Process/systemic gap analysis                                                                                        | ce-gate-defect, process-gap, systemic             | Process-Review       |
+Load `.github/skills/routing-tables/SKILL.md` for the canonical specialist-dispatch mapping. When a step or finding maps cleanly to a listed file or task pattern, use `Invoke-RoutingLookup -Table specialist_dispatch -Key FilePattern -Value "{pattern}"`. When dispatch depends on task intent or keyword matching rather than a literal file-pattern lookup, consult the `specialist_dispatch` entries in `.github/skills/routing-tables/assets/routing-config.json` and apply the surrounding routing rules in this agent.
 
 > **native Explore vs Research-Agent**: Use the native Explore subagent for lightweight read-only fact-finding (runs on a fast model in a short-lived context — the returned summary is typically smaller than running equivalent tool calls inline). Use Research-Agent when analysis is deep/multi-file and the result needs to be persisted to a research document for future reference. When in doubt: Explore for discovery, Research-Agent for output that must survive compaction.
 >
@@ -343,14 +314,7 @@ Code-Conductor retains the orchestration around that method: review-mode entry, 
 
 After merging and deduplicating the prosecution ledger, partition findings before the defense pass:
 
-A finding qualifies for the **express lane** (bypasses defense+judge, routes directly to specialist) only when ALL six criteria are met:
-
-1. **Severity is `low`** — as rated by prosecution output (the only severity level below medium in the `critical | high | medium | low` schema)
-2. **Fix type is strictly mechanical**: string literal changes, import path fixes, comment corrections, or formatting fixes — exhaustive list; no other fix types qualify
-3. **No logic changes**: the fix does not add, remove, or modify any `if`/`else`/`switch`/loop/return/guard clause or conditional short-circuit (`&&`/`||` guard reordering)
-4. **No test file cascade**: the fix does not require changes to any test file or assertion
-5. **Changed value not in stored IDs or DB schema**: backward compatibility is not at risk
-6. **Scope ≤ 1 file**: the fix touches exactly one file
+Load `.github/skills/routing-tables/SKILL.md` and evaluate the canonical six-condition express-lane gate with `Test-GateCriteria -Gate express_lane -Criteria @{ ... }`. The authoritative criteria and default non-qualifying outcome live in `.github/skills/routing-tables/assets/gate-criteria.json`.
 
 Route express-eligible findings directly to the specialist dispatch queue with an `express_lane: true` marker. All remaining findings continue to the defense → judge pipeline as normal.
 
@@ -435,8 +399,7 @@ When the review originated from GitHub (proxy prosecution pipeline), Code-Conduc
 
 **When to run** — Mandatory when any of the following apply after all specialists apply all accepted main-review findings:
 
-- ≥1 accepted finding was Critical or High severity
-- Any accepted fix modifies control flow — defined as: adding/changing/removing `if`/`else`/`switch` branches, loop structure changes (`for`/`while`/`forEach` — bounds, iteration variable, or `break`/`continue`), guard clause additions/removals, try/catch restructuring, early returns, or conditional short-circuit reordering (`&&`/`||` guard reordering) — inspect the fix diff computed in Diff scoping below to evaluate this condition.
+Load `.github/skills/routing-tables/SKILL.md` and use `Test-GateCriteria -Gate post_fix_trigger -Criteria @{ ... }` against the canonical trigger conditions in `.github/skills/routing-tables/assets/gate-criteria.json`. Preserve the same OR semantics: accepted `critical` or `high` findings can trigger immediately from the main-review judge output, while control-flow-trigger evaluation still happens only after Tier 1 re-validation and diff scoping.
 
 Skip if no findings were accepted and applied (post-judgment: all REJECT or DEFERRED-SIGNIFICANT, no fixes applied).
 
@@ -474,27 +437,7 @@ Skip if no findings were accepted and applied (post-judgment: all REJECT or DEFE
 
 When delegating to subagents, instruct them to use the relevant skill(s):
 
-| Skill                        | When to Instruct Subagent to Use                                                   |
-| ---------------------------- | ---------------------------------------------------------------------------------- |
-| `adversarial-review`         | Running prosecution passes or defense perspectives with Code-Critic                |
-| `customer-experience`        | Framing customer journeys or capturing CE evidence with Experience-Owner           |
-| `design-exploration`         | Researching and converging technical design options with Solution-Designer         |
-| `documentation-finalization` | Updating design docs, READMEs, or implementation-facing docs with Doc-Keeper       |
-| `frontend-design`            | Designing new UI components, screens, or evaluating for uniqueness                 |
-| `implementation-discipline`  | Implementing bounded plan steps or verifying production wiring with Code-Smith     |
-| `parallel-execution`         | Coordinating concurrent implementation paths, convergence gates, or triage routing |
-| `plan-authoring`             | Drafting or refining execution plans with Issue-Planner                            |
-| `property-based-testing`     | Adding randomized testing, validating input ranges, or verifying invariants        |
-| `refactoring-methodology`    | Running a proportionate structural cleanup pass with Refactor-Specialist           |
-| `research-methodology`       | Gathering verified multi-file findings for a research document with Research-Agent |
-| `review-judgment`            | Ruling on prosecution plus defense ledgers with Code-Review-Response               |
-| `skill-creator`              | Adding new skills, updating skill templates, or reviewing skill structure          |
-| `software-architecture`      | Evaluating layer boundaries, dependency flow, or ADR-level decisions               |
-| `systematic-debugging`       | Debugging failures, investigating flaky tests, or tracking root causes             |
-| `test-driven-development`    | Writing tests first, red-green-refactor, or validating quality gates               |
-| `ui-iteration`               | Running screenshot-driven UI polish passes with UI-Iterator                        |
-| `ui-testing`                 | Writing component-level React tests, fixing flaky tests, or establishing patterns  |
-| `webapp-testing`             | Creating or improving browser-based E2E coverage, test stability, or CI            |
+Load `.github/skills/routing-tables/SKILL.md` and consult the `skill_mapping` reference entries in `.github/skills/routing-tables/assets/routing-config.json` when deciding which reusable skills to name in a delegation prompt. Treat that mapping as a canonical reference list for when each skill is relevant; decision authority for the actual delegation remains here.
 
 <!-- Keep in sync: when adding or removing a delegation skill in .github/skills/, update this table (delegation-scoped: only skills Code-Conductor instructs subagents to use). Always also update Process-Review's Skill Mapping Reference table (all-skills scope). -->
 
@@ -528,14 +471,7 @@ Run this gate as the final step before PR creation (Tier 4, after the post-fix t
 
 Read the plan's `[CE GATE]` step to identify the customer surface. Pass this surface type information to Experience-Owner when delegating evidence capture (step 3 of the Scenario Exercise Protocol). If no `[CE GATE]` step exists, infer from the change type and include the inferred surface type in the Experience-Owner delegation:
 
-| Surface Type        | Tool / Method                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------- |
-| Web UI              | Native browser tools (`openBrowserPage` + `screenshotPage`); Playwright MCP as fallback |
-| REST / GraphQL      | `curl` or `httpie` in terminal                                                          |
-| CLI                 | Invoke command in terminal with test args                                               |
-| SDK                 | Example invocation in terminal                                                          |
-| Batch / pipeline    | Invoke with representative test data                                                    |
-| No customer surface | Skip with documented reason (`⏭️ CE Gate not applicable — {reason}`)                    |
+Load `.github/skills/routing-tables/SKILL.md` and use `Invoke-RoutingLookup -Table surface_identification -Key Surface -Value "{surface}"` for the canonical surface-to-tool mapping in `.github/skills/routing-tables/assets/routing-config.json`. Preserve the same behavior: native browser tools remain the primary Web UI path with Playwright MCP fallback, terminal invocations remain the default for REST/GraphQL, CLI, SDK, and batch surfaces, and `No customer surface` still emits `⏭️ CE Gate not applicable — {reason}`.
 
 ### Scenario Exercise Protocol
 

--- a/.github/agents/Code-Critic.agent.md
+++ b/.github/agents/Code-Critic.agent.md
@@ -97,14 +97,7 @@ If after genuine adversarial effort you find no issues, state what you checked a
 
 When the prompt contains one of the following markers, switch modes before reviewing:
 
-| Marker in prompt                       | Mode                          | Passes       |
-| -------------------------------------- | ----------------------------- | ------------ |
-| _(none / default)_                     | Code prosecution              | 3 (parallel) |
-| `"Use design review perspectives"`     | Design/plan prosecution       | 2 (parallel) |
-| `"Use product-alignment perspectives"` | Product-alignment prosecution | 1            |
-| `"Use defense review perspectives"`    | Defense                       | 1            |
-| `"Use CE review perspectives"`         | CE prosecution                | 1            |
-| `"Score and represent GitHub review"`  | Proxy prosecution             | 1            |
+Load `.github/skills/routing-tables/SKILL.md` and use `Invoke-RoutingLookup -Table review_mode_routing -Key Marker -Value "{marker}"` for the canonical marker-to-mode mapping in `.github/skills/routing-tables/assets/routing-config.json`. When no marker is present, default to `code_prosecution` with the standard 3-pass parallel structure.
 
 **Conflict rule**: Priority order (most specific wins): defense > CE > proxy > product-alignment > design > code. Exception: `"Use code review perspectives"` always overrides `"Use design review perspectives"` and forces Code Review Mode.
 
@@ -173,15 +166,17 @@ Every finding must be categorized with the appropriate evidence:
 
 Every finding must also include these automation-routing fields:
 
-- `severity`: critical | high | medium | low
-- `points`: 10 (critical/high) | 5 (medium) | 1 (low) — assigned by prosecutor; judge may override
+- Load `.github/skills/routing-tables/SKILL.md` when assigning canonical automation-routing values. The authoritative enum values and points mapping live in `.github/skills/routing-tables/assets/routing-config.json` under `enums`.
+- `severity`: use the canonical `enums.severity` values
+- `points`: use the canonical `enums.points_mapping` values — assigned by prosecutor; judge may override
 - `confidence`: high | medium | low
 - `id`: F1 | F2 | F3 | … — sequential label within this review cycle; used by defense and judge to cross-reference findings by ID. Assign in order of appearance.
 - `pass`: 1 | 2 | 3 — prosecution pass number that originated this finding. Code prosecution and design/plan prosecution; omit in CE review, proxy prosecution, and defense mode.
-- `category`: architecture | security | performance | pattern | implementation-clarity | script-automation | documentation-audit — the active prosecution perspective for this finding. Code prosecution only; use `n/a` in CE review, design review, product-alignment prosecution, and proxy prosecution modes. For findings that span multiple perspectives, use the primary perspective.
-- `blast_radius`: localized | module | cross-module | system-wide
-- `authority_needed`: yes | no
-- `systemic_fix_type`: instruction | skill | agent-prompt | plan-template | none — root cause classification: what kind of guardrail would prevent this defect class? Filled in by prosecutor during each prosecution pass (code, design/plan, product-alignment, CE, and proxy prosecution). Always emit this field; use `none` when no specific guardrail type applies.
+- `confidence`: use the canonical `enums.confidence` values
+- `category`: use the canonical `enums.category` values — the active prosecution perspective for this finding. Code prosecution only; use `n/a` in CE review, design review, product-alignment prosecution, and proxy prosecution modes. For findings that span multiple perspectives, use the primary perspective.
+- `blast_radius`: use the canonical `enums.blast_radius` values
+- `authority_needed`: use the canonical `enums.authority_needed` values
+- `systemic_fix_type`: use the canonical `enums.systemic_fix_type` values — root cause classification: what kind of guardrail would prevent this defect class? Filled in by prosecutor during each prosecution pass (code, design/plan, product-alignment, CE, and proxy prosecution). Always emit this field; use `none` when no specific guardrail type applies.
 
 **Root cause tagging**: After identifying each finding, tag the `systemic_fix_type` — ask: _What kind of guardrail would prevent this defect class?_ This is a lightweight classification, not a full root cause analysis — Process-Review will perform deeper analysis on sustained findings retrospectively (Sub C).
 

--- a/.github/agents/Code-Critic.agent.md
+++ b/.github/agents/Code-Critic.agent.md
@@ -169,7 +169,6 @@ Every finding must also include these automation-routing fields:
 - Load `.github/skills/routing-tables/SKILL.md` when assigning canonical automation-routing values. The authoritative enum values and points mapping live in `.github/skills/routing-tables/assets/routing-config.json` under `enums`.
 - `severity`: use the canonical `enums.severity` values
 - `points`: use the canonical `enums.points_mapping` values — assigned by prosecutor; judge may override
-- `confidence`: high | medium | low
 - `id`: F1 | F2 | F3 | … — sequential label within this review cycle; used by defense and judge to cross-reference findings by ID. Assign in order of appearance.
 - `pass`: 1 | 2 | 3 — prosecution pass number that originated this finding. Code prosecution and design/plan prosecution; omit in CE review, proxy prosecution, and defense mode.
 - `confidence`: use the canonical `enums.confidence` values

--- a/.github/architecture-rules.md
+++ b/.github/architecture-rules.md
@@ -7,7 +7,7 @@ These rules define the structural constraints for Copilot Orchestra. All agents 
 | Directory                | Purpose                                              | Allowed Contents                                               |
 | ------------------------ | ---------------------------------------------------- | -------------------------------------------------------------- |
 | `.github/agents/`        | Agent definitions                                    | `*.agent.md` files with YAML frontmatter                      |
-| `.github/skills/{name}/` | Domain-specific knowledge                            | `SKILL.md` with frontmatter, supporting files                 |
+| `.github/skills/{name}/` | Domain-specific knowledge                            | `SKILL.md` with frontmatter, plus optional `assets/` and `scripts/` subdirectories for supporting files |
 | `.github/instructions/`  | Shared rules loaded by agents                        | `*.instructions.md` files                                     |
 | `.github/prompts/`       | Prompt files and workflow templates                  | `*.prompt.md` with frontmatter; supporting `*.md` templates   |
 | `.github/scripts/`       | Automation scripts invoked by agents or instructions | `*.ps1` PowerShell scripts                                    |
@@ -17,6 +17,13 @@ These rules define the structural constraints for Copilot Orchestra. All agents 
 | `Documents/Design/`      | Design documents (committed with implementation PRs) | `{domain-slug}.md`                                            |
 | `Documents/Decisions/`   | Standalone decision records                          | Markdown files                                                 |
 | `examples/`              | Example configurations for different tech stacks     | Subdirectories per stack                                       |
+
+## Layer Model
+
+- Skills: Fat, on-demand methodology, judgment, documentation, and supporting data
+- Harness: Agent files keep routing, context, safety, and decision authority
+- Deterministic/Application bottom layer: Same-input, same-output evaluation and concrete tools/code
+- Resolvers: Structured context and routing data that helps load the right skill or content
 
 ## Dependency Rules
 
@@ -33,6 +40,7 @@ These rules define the structural constraints for Copilot Orchestra. All agents 
 - Internal agents (`user-invocable: false`) must NOT be directly user-invocable; they MAY appear in agent `handoffs` lists as subagents
 - Agents must NOT reference deleted agents (e.g., Plan-Architect, Issue-Designer) — validate with `grep`
 - Skills must NOT own orchestration boundaries such as user-turn routing, agent handoffs, commit authority, issue-state transitions, or Code-Conductor's step execution loop
+- Skills MAY contain static data files (JSON, YAML) in `assets/` and deterministic evaluation scripts in `scripts/` that agents invoke for routing decisions
 - Skills MAY contain reusable methodology and protocol content, including ordered workflows, checklists, decision heuristics, and evidence requirements that agents load on demand
 - Concrete boundary examples: Code-Conductor's validation ladder may live in a skill, but CE Gate orchestration and subagent routing stay in the agent; test-driven-development may hold Test-Writer methodology, but conditional delegation and execution flow stay in Test-Writer; session-startup, provenance-gate, and terminal-hygiene remain portable skills while the trigger points that invoke them stay in agents
 - `guidance-complexity` remains agent-only in issue #344; do not move that rule set into a skill as part of this architecture split
@@ -53,6 +61,7 @@ Optional frontmatter: `handoffs`, `user-invocable` (defaults to `true` if omitte
 
 Required frontmatter: `name`, `description`
 Must live in `.github/skills/{skill-name}/SKILL.md`
+Supporting files MAY live under optional `.github/skills/{skill-name}/assets/` and `.github/skills/{skill-name}/scripts/` subdirectories
 
 ### Instruction Files (`.instructions.md`)
 

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "copilot-orchestra",
       "source": ".",
-      "description": "Multi-agent workflow system for GitHub Copilot with 14 specialized agents, 32 skills, and pipeline orchestration.",
+      "description": "Multi-agent workflow system for GitHub Copilot with 14 specialized agents, 33 skills, and pipeline orchestration.",
       "version": "1.11.0"
     }
   ]

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -39,6 +39,7 @@
     "./.github/skills/refactoring-methodology/",
     "./.github/skills/research-methodology/",
     "./.github/skills/review-judgment/",
+    "./.github/skills/routing-tables/",
     "./.github/skills/session-startup/",
     "./.github/skills/skill-creator/",
     "./.github/skills/software-architecture/",

--- a/.github/scripts/Tests/routing-tables.Tests.ps1
+++ b/.github/scripts/Tests/routing-tables.Tests.ps1
@@ -1,0 +1,172 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Contract tests for deterministic routing table lookups and gate evaluation.
+
+.DESCRIPTION
+    Locks issue #346 Step 4 before production implementation exists:
+      - specialist dispatch lookup contract
+      - review mode routing lookup contract
+      - CE surface identification lookup contract
+      - scope classification gate contract
+      - express lane gate contract
+      - safe fallback for unknown lookups and omitted AND-gate criteria
+      - config re-read behavior for single-source-of-truth edits
+      - taxonomy category parity with script-safety-contract.Tests.ps1
+
+    This file is intentionally red before Step 5 because
+    .github/skills/routing-tables/scripts/routing-tables-core.ps1 does not exist yet.
+#>
+
+Describe 'routing tables deterministic contract' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:RoutingTablesCore = Join-Path $script:RepoRoot '.github\skills\routing-tables\scripts\routing-tables-core.ps1'
+        $script:RoutingConfigPath = Join-Path $script:RepoRoot '.github\skills\routing-tables\assets\routing-config.json'
+
+        . $script:RoutingTablesCore
+    }
+
+    It 'routes src/app/foo.tsx to Code-Smith for specialist dispatch' {
+        $result = Invoke-RoutingLookup -Table specialist_dispatch -Key FilePattern -Value 'src/app/foo.tsx'
+
+        $result | Should -Be 'Code-Smith'
+    }
+
+    It 'routes src/foo.ts to Code-Smith for specialist dispatch' {
+        $result = Invoke-RoutingLookup -Table specialist_dispatch -Key FilePattern -Value 'src/foo.ts'
+
+        $result | Should -Be 'Code-Smith'
+    }
+
+    It 'routes FilePattern *.ps1 to Code-Smith for specialist dispatch' {
+        $result = Invoke-RoutingLookup -Table specialist_dispatch -Key FilePattern -Value '*.ps1'
+
+        $result | Should -Be 'Code-Smith' -Because 'the specialist dispatch asset now owns explicit file-pattern routing for PowerShell files'
+    }
+
+    It 'maps the CE review marker to ce_prosecution mode' {
+        $result = Invoke-RoutingLookup -Table review_mode_routing -Key Marker -Value 'Use CE review perspectives'
+
+        $result | Should -Be 'ce_prosecution'
+    }
+
+    It 'maps the Web UI surface to the browser-tools routing' {
+        $result = Invoke-RoutingLookup -Table surface_identification -Key Surface -Value 'Web UI'
+
+        $result | Should -Be 'Native browser tools (openBrowserPage + screenshotPage)'
+    }
+
+    It 'returns the documented CE Gate status marker for no customer surface exactly' {
+        $result = Invoke-RoutingLookup -Table surface_identification -Key Surface -Value 'No customer surface'
+
+        $result | Should -Be '⏭️ CE Gate not applicable — {reason}'
+    }
+
+    It 'returns abbreviated when all scope-classification criteria are true' {
+        $criteria = @{
+            acceptance_criteria_clear                     = $true
+            touches_three_or_fewer_files_in_single_domain = $true
+            no_new_user_facing_behavior                   = $true
+            no_cross_cutting_architectural_changes        = $true
+            no_ce_gate_scenarios_needed                   = $true
+        }
+
+        $result = Test-GateCriteria -Gate scope_classification -Criteria $criteria
+
+        $result | Should -Be 'abbreviated'
+    }
+
+    It 'returns qualifies when all express-lane criteria are true' {
+        $criteria = @{
+            severity_low                 = $true
+            strictly_mechanical_fix_type = $true
+            no_logic_changes             = $true
+            no_test_file_cascade         = $true
+            no_stored_id_or_schema_risk  = $true
+            scope_one_file_or_less       = $true
+        }
+
+        $result = Test-GateCriteria -Gate express_lane -Criteria $criteria
+
+        $result | Should -Be 'qualifies' -Because 'the Step 5 script contract should expose whether the AND gate qualifies, rather than leaking the asset''s internal outcome label'
+    }
+
+    It 'returns null for an unknown lookup value' {
+        $result = Invoke-RoutingLookup -Table surface_identification -Key Surface -Value 'Firmware console'
+
+        $result | Should -Be $null
+    }
+
+    It 're-reads routing-config.json on each invocation so asset edits take effect immediately' {
+        $originalJson = Get-Content -Path $script:RoutingConfigPath -Raw
+
+        try {
+            $initial = Invoke-RoutingLookup -Table specialist_dispatch -Key FilePattern -Value '*.ps1'
+            $initial | Should -Be 'Code-Smith'
+
+            $updatedConfig = $originalJson | ConvertFrom-Json -AsHashtable
+            $ps1Entry = $updatedConfig.specialist_dispatch.entries |
+                Where-Object { @($_.file_patterns) -contains '*.ps1' } |
+                Select-Object -First 1
+
+            $ps1Entry | Should -Not -BeNullOrEmpty -Because 'the routing asset must explicitly carry the *.ps1 mapping for this contract to stay data-driven'
+
+            $ps1Entry.agent = 'Doc-Keeper'
+            $updatedJson = $updatedConfig | ConvertTo-Json -Depth 20
+            [System.IO.File]::WriteAllText($script:RoutingConfigPath, $updatedJson, [System.Text.UTF8Encoding]::new($false))
+
+            $updated = Invoke-RoutingLookup -Table specialist_dispatch -Key FilePattern -Value '*.ps1'
+
+            $updated | Should -Be 'Doc-Keeper' -Because 'Invoke-RoutingLookup must re-read the routing asset instead of using a hardcoded PowerShell override'
+        }
+        finally {
+            [System.IO.File]::WriteAllText($script:RoutingConfigPath, $originalJson, [System.Text.UTF8Encoding]::new($false))
+        }
+    }
+
+    It 'throws when table name is missing' {
+        { Invoke-RoutingLookup -Table '' -Key FilePattern -Value '*.ps1' } | Should -Throw
+    }
+
+    It 'treats omitted express-lane criteria as false and does not qualify' {
+        $criteria = @{
+            severity_low                 = $true
+            strictly_mechanical_fix_type = $true
+            no_logic_changes             = $true
+            no_test_file_cascade         = $true
+            no_stored_id_or_schema_risk  = $true
+        }
+
+        $result = Test-GateCriteria -Gate express_lane -Criteria $criteria
+
+        $result | Should -Not -Be 'qualifies'
+    }
+}
+
+Describe 'routing tables asset parity contract' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:RoutingConfigPath = Join-Path $script:RepoRoot '.github\skills\routing-tables\assets\routing-config.json'
+        $script:ScriptSafetyContract = Join-Path $script:RepoRoot '.github\scripts\Tests\script-safety-contract.Tests.ps1'
+    }
+
+    It 'keeps routing-config category enums aligned with the script safety contract taxonomy' {
+        $routingConfig = Get-Content -Path $script:RoutingConfigPath -Raw | ConvertFrom-Json -AsHashtable
+        $contractContent = Get-Content -Path $script:ScriptSafetyContract -Raw
+
+        $mandatedCategoryMatch = [regex]::Match($contractContent, '(?s)\$script:MandatedCategories\s*=\s*@\((.*?)\)')
+        $mandatedCategoryMatch.Success | Should -BeTrue -Because 'the routing-tables enum parity test must compare against the same mandated taxonomy source used by the script safety contract'
+
+        $mandatedCategories = [regex]::Matches($mandatedCategoryMatch.Groups[1].Value, "'([a-z-]+)'") |
+            ForEach-Object { $_.Groups[1].Value } |
+            Sort-Object
+
+        $configuredCategories = @($routingConfig.enums.category) | Sort-Object
+
+        ($configuredCategories -join ',') | Should -Be ($mandatedCategories -join ',')
+    }
+}

--- a/.github/scripts/Tests/routing-tables.Tests.ps1
+++ b/.github/scripts/Tests/routing-tables.Tests.ps1
@@ -15,8 +15,6 @@
       - config re-read behavior for single-source-of-truth edits
       - taxonomy category parity with script-safety-contract.Tests.ps1
 
-    This file is intentionally red before Step 5 because
-    .github/skills/routing-tables/scripts/routing-tables-core.ps1 does not exist yet.
 #>
 
 Describe 'routing tables deterministic contract' {

--- a/.github/scripts/Tests/script-safety-contract.Tests.ps1
+++ b/.github/scripts/Tests/script-safety-contract.Tests.ps1
@@ -11,8 +11,8 @@
       - $knownCategories in aggregate-review-scores.ps1 must contain exactly the 7 mandated taxonomy values
 
     Production scripts are defined as all .ps1 files under .github/scripts/ (root and /lib/)
-    excluding the Tests/ subdirectory. Update these tests only when the underlying safety
-    contract intentionally changes.
+    plus skill scripts under .github/skills/**/scripts/, excluding test files. Update these
+    tests only when the underlying safety contract intentionally changes.
 #>
 
 Describe 'script safety contract' {
@@ -20,24 +20,32 @@ Describe 'script safety contract' {
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         $script:ScriptsRoot = Join-Path -Path $script:RepoRoot -ChildPath '.github' -AdditionalChildPath 'scripts'
+        $script:SkillsRoot = Join-Path -Path $script:RepoRoot -ChildPath '.github' -AdditionalChildPath 'skills'
         $script:AggregateReviewScores = Join-Path $script:ScriptsRoot 'aggregate-review-scores.ps1'
         $script:AggregateReviewScoresCore = Join-Path $script:ScriptsRoot 'lib\aggregate-review-scores-core.ps1'
 
-        $script:ProductionScripts = Get-ChildItem -Path $script:ScriptsRoot -Recurse -Filter '*.ps1' |
-            Where-Object { $_.DirectoryName -notmatch '[/\\]Tests([/\\]|$)' }
+        $script:ProductionScripts = @(
+            Get-ChildItem -Path $script:ScriptsRoot -Recurse -Filter '*.ps1' |
+                Where-Object { $_.DirectoryName -notmatch '[/\\]Tests([/\\]|$)' }
+                Get-ChildItem -Path $script:SkillsRoot -Recurse -Filter '*.ps1' |
+                    Where-Object {
+                        $_.DirectoryName -match '[/\\]scripts([/\\]|$)' -and
+                        $_.DirectoryName -notmatch '[/\\]Tests([/\\]|$)'
+                    }
+                ) | Sort-Object -Property FullName -Unique
 
-        # Canonical taxonomy — sorted alphabetically for deterministic comparison
-        $script:MandatedCategories = @(
-            'architecture', 'documentation-audit', 'implementation-clarity',
-            'pattern', 'performance', 'script-automation', 'security'
-        )
-    }
+                # Canonical taxonomy — sorted alphabetically for deterministic comparison
+                $script:MandatedCategories = @(
+                    'architecture', 'documentation-audit', 'implementation-clarity',
+                    'pattern', 'performance', 'script-automation', 'security'
+                )
+            }
 
-    It 'script safety: production scripts must not use Invoke-Expression or iex aliases' {
-        $violations = $script:ProductionScripts | Where-Object {
-            $content = Get-Content -Path $_.FullName -Raw
-            $content -match '(?i)Invoke-Expression|\biex\b'
-        } | Select-Object -ExpandProperty Name
+            It 'script safety: production scripts must not use Invoke-Expression or iex aliases' {
+                $violations = $script:ProductionScripts | Where-Object {
+                    $content = Get-Content -Path $_.FullName -Raw
+                    $content -match '(?i)Invoke-Expression|\biex\b'
+                } | Select-Object -ExpandProperty Name
 
         $violations | Should -HaveCount 0 -Because 'Invoke-Expression and its iex alias allow arbitrary code execution from strings, creating command-injection risk; use explicit cmdlet calls or operator pipelines instead'
     }

--- a/.github/scripts/lib/quick-validate-core.ps1
+++ b/.github/scripts/lib/quick-validate-core.ps1
@@ -103,8 +103,35 @@ function Test-QVGuidanceComplexity {
     }
 }
 
+function Get-QVExistingPSScriptAnalyzerPaths {
+    param(
+        [Parameter(Mandatory)]
+        [string]$RootPath,
+        [string]$ScriptsPath
+    )
+
+    $paths = [System.Collections.Generic.List[string]]::new()
+
+    if ($ScriptsPath -and (Test-Path $ScriptsPath)) {
+        $paths.Add((Resolve-Path $ScriptsPath).Path)
+    }
+
+    $skillScriptsPath = Join-Path -Path $RootPath -ChildPath '.github' -AdditionalChildPath 'skills'
+    if (Test-Path $skillScriptsPath) {
+        $skillScriptFiles = @(Get-ChildItem -Path $skillScriptsPath -Filter '*.ps1' -File -Recurse |
+                Where-Object { $_.DirectoryName -match '[\\/]scripts$' })
+        foreach ($file in $skillScriptFiles) {
+            $paths.Add($file.FullName)
+        }
+    }
+
+    return $paths.ToArray()
+}
+
 function Test-QVPSScriptAnalyzer {
     param(
+        [Parameter(Mandatory)]
+        [string]$RootPath,
         [Parameter(Mandatory)]
         [string]$ScriptsPath,
         [Parameter(Mandatory)]
@@ -116,13 +143,28 @@ function Test-QVPSScriptAnalyzer {
         return [PSCustomObject]@{ Name = 'PSScriptAnalyzer'; Passed = 'SKIP'; Detail = 'PSScriptAnalyzer not installed — skipping' }
     }
 
-    $resolvedScripts = (Resolve-Path $ScriptsPath).Path
-    $analyzerParams = @{ Path = $resolvedScripts; Recurse = $true }
-    if (Test-Path $SettingsPath) {
-        $analyzerParams['Settings'] = (Resolve-Path $SettingsPath).Path
+    $resolvedPaths = @(Get-QVExistingPSScriptAnalyzerPaths -RootPath $RootPath -ScriptsPath $ScriptsPath)
+    if ($resolvedPaths.Count -eq 0) {
+        return [PSCustomObject]@{ Name = 'PSScriptAnalyzer'; Passed = $true; Detail = '' }
     }
 
-    $issues = @(Invoke-ScriptAnalyzer @analyzerParams)
+    $resolvedSettingsPath = $null
+    if (Test-Path $SettingsPath) {
+        $resolvedSettingsPath = (Resolve-Path $SettingsPath).Path
+    }
+
+    $issues = foreach ($path in $resolvedPaths) {
+        $analyzerParams = @{ Path = $path }
+        if ((Get-Item $path).PSIsContainer) {
+            $null = $analyzerParams.Add('Recurse', $true)
+        }
+        if ($resolvedSettingsPath) {
+            $null = $analyzerParams.Add('Settings', $resolvedSettingsPath)
+        }
+
+        Invoke-ScriptAnalyzer @analyzerParams
+    }
+    $issues = @($issues)
     if ($issues.Count -eq 0) {
         return [PSCustomObject]@{ Name = 'PSScriptAnalyzer'; Passed = $true; Detail = '' }
     }
@@ -131,6 +173,48 @@ function Test-QVPSScriptAnalyzer {
         Name   = 'PSScriptAnalyzer'
         Passed = $false
         Detail = "$($issues.Count) issue(s) found"
+    }
+}
+
+function Test-QVSkillAssetJsonParse {
+    param(
+        [Parameter(Mandatory)]
+        [string]$RootPath
+    )
+
+    $skillsPath = Join-Path -Path $RootPath -ChildPath '.github' -AdditionalChildPath 'skills'
+    if (-not (Test-Path $skillsPath)) {
+        return [PSCustomObject]@{ Name = 'SkillAssetJsonParse'; Passed = $true; Detail = '' }
+    }
+
+    $jsonFiles = @(Get-ChildItem -Path $skillsPath -Filter '*.json' -File -Recurse |
+            Where-Object { $_.DirectoryName -match '[\\/]assets$' })
+    if ($jsonFiles.Count -eq 0) {
+        return [PSCustomObject]@{ Name = 'SkillAssetJsonParse'; Passed = $true; Detail = '' }
+    }
+
+    $invalidFiles = [System.Collections.Generic.List[string]]::new()
+    foreach ($file in $jsonFiles) {
+        try {
+            Get-Content -Path $file.FullName -Raw | ConvertFrom-Json | Out-Null
+        }
+        catch {
+            $invalidFiles.Add($file.FullName)
+        }
+    }
+
+    if ($invalidFiles.Count -eq 0) {
+        return [PSCustomObject]@{ Name = 'SkillAssetJsonParse'; Passed = $true; Detail = '' }
+    }
+
+    $relativePaths = $invalidFiles | ForEach-Object {
+        [System.IO.Path]::GetRelativePath($RootPath, $_)
+    }
+
+    return [PSCustomObject]@{
+        Name   = 'SkillAssetJsonParse'
+        Passed = $false
+        Detail = "$($invalidFiles.Count) JSON file(s) failed to parse: $($relativePaths -join ', ')"
     }
 }
 
@@ -187,8 +271,11 @@ function Invoke-QuickValidate {
         try { $results.Add((Test-QVGuidanceComplexity -ScriptPath $GuidanceComplexityScriptPath)) }
         catch { $results.Add([PSCustomObject]@{ Name = 'GuidanceComplexity'; Passed = $false; Detail = "Error: $_" }) }
         # 9. PSScriptAnalyzer
-        try { $results.Add((Test-QVPSScriptAnalyzer -ScriptsPath $ScriptsPath -SettingsPath $PSScriptAnalyzerSettingsPath)) }
+        try { $results.Add((Test-QVPSScriptAnalyzer -RootPath $RootPath -ScriptsPath $ScriptsPath -SettingsPath $PSScriptAnalyzerSettingsPath)) }
         catch { $results.Add([PSCustomObject]@{ Name = 'PSScriptAnalyzer'; Passed = $false; Detail = "Error: $_" }) }
+        # 10. SkillAssetJsonParse
+        try { $results.Add((Test-QVSkillAssetJsonParse -RootPath $RootPath)) }
+        catch { $results.Add([PSCustomObject]@{ Name = 'SkillAssetJsonParse'; Passed = $false; Detail = "Error: $_" }) }
 
         $passCount = @($results | Where-Object { $_.Passed -eq $true }).Count
         $failCount = @($results | Where-Object { $_.Passed -eq $false }).Count

--- a/.github/skills/routing-tables/SKILL.md
+++ b/.github/skills/routing-tables/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: routing-tables
+description: Concise reference for deterministic specialist dispatch, review mode routing, CE surface mapping, enum values, and gate criteria extracted from current orchestration agents. Use when an agent or script needs the canonical current routing data without re-deriving it from duplicated prompt prose. DO NOT USE FOR: taking orchestration decisions away from the calling agent, replacing judgment on uncovered cases, or storing mutable runtime state.
+---
+
+# Routing Tables
+
+This skill is the human-readable companion to the routing data in `assets/routing-config.json` and `assets/gate-criteria.json`. It centralizes current routing tables and enum values from Code-Conductor and Code-Critic so agents can load concise prompt context while future deterministic consumers read the same data from JSON.
+
+## When to Use
+
+- When an agent needs the canonical current specialist-dispatch, review-mode, CE-surface, enum, or gate data
+- When a deterministic consumer should read the shared routing assets instead of copying inline tables from an agent prompt
+- When reviewing or updating routing metadata and you need one human-readable summary aligned with the JSON assets
+
+## Schema Overview
+
+`assets/routing-config.json` contains five top-level sections:
+
+- `specialist_dispatch`: file and task routing entries from Code-Conductor's Agent Selection table; deterministic `FilePattern` consumers should use the optional `file_patterns` arrays rather than parsing `file_type_or_task`
+- `review_mode_routing`: prompt-marker to review-mode mapping from Code-Critic, including conflict resolution
+- `surface_identification`: CE Gate surface to tool mapping from Code-Conductor; `No customer surface` carries the exact status marker template in `status_result_template`
+- `skill_mapping`: delegation guidance from Code-Conductor's Skill Mapping table; this is a reference list, not a strict deterministic router
+- `enums`: canonical current enum values used by review and routing outputs
+
+`assets/gate-criteria.json` contains three top-level sections:
+
+- `scope_classification`: abbreviated-vs-full pipeline gate criteria and tier table
+- `express_lane`: low-risk fix gate criteria for routing findings directly to a specialist
+- `post_fix_trigger`: conditions that require post-fix targeted prosecution after accepted review fixes
+
+## Specialist Dispatch
+
+Specialist dispatch stays file- and task-oriented. Test files and fixtures route to Test-Writer. New behavior in `src/**/*.ts` and `src/**/*.tsx` routes to Code-Smith, while restructuring those same source files routes to Refactor-Specialist. PowerShell production scripts (`*.ps1`) also route to Code-Smith. Visual polish work on UI source files routes to UI-Iterator, and documentation files route to Doc-Keeper.
+
+For deterministic lookups keyed by `FilePattern`, use the structured `file_patterns` arrays in the asset. The prose-bearing `file_type_or_task` field remains the human-readable summary and should not be parsed by consumers.
+
+Planning artifacts and plan markers route to Issue-Planner. CE Gate evidence capture, customer framing, journeys, and scenarios route to Experience-Owner. Read-only quality review goes to Code-Critic, scored judgment goes to Code-Review-Response, and systemic gap analysis goes to Process-Review.
+
+## Review Mode Routing
+
+Review mode routing is driven by prompt markers. No marker means normal code prosecution with three parallel passes. Design review perspectives switch to design or plan prosecution with two parallel passes. Product-alignment, defense, CE prosecution, and GitHub proxy prosecution each run as single-pass modes.
+
+When multiple markers appear, the conflict rule applies in strict priority order: defense, then CE, then proxy, then product-alignment, then design, then code. One explicit override exists: `Use code review perspectives` beats `Use design review perspectives` and forces normal code prosecution.
+
+## Surface Identification
+
+CE Gate surface identification maps the customer surface to the expected validation tool. Web UI uses native browser tools first, with Playwright MCP as fallback. REST or GraphQL uses terminal HTTP calls. CLI and SDK surfaces use representative terminal invocations. Batch and pipeline surfaces use representative test data. No customer surface returns the documented status marker `⏭️ CE Gate not applicable — {reason}` from structured data so consumers do not need a separate hardcoded case.
+
+## Skill Mapping
+
+The skill mapping table is guidance for delegation prompts rather than a pure lookup table. It links each reusable skill to the kind of work where Code-Conductor should explicitly instruct a specialist to load it. The mappings cover review, customer experience, design exploration, documentation, frontend design, implementation discipline, parallel execution, planning, property-based testing, refactoring, research, review judgment, skill creation, software architecture, debugging, TDD, UI iteration, UI testing, and web app testing.
+
+Consumers should treat this section as a reference list that explains when a skill is relevant, not as a hard decision engine that replaces agent judgment.
+
+## Enums
+
+The enum section captures the canonical current values used by the review pipeline:
+
+- `severity`: `critical`, `high`, `medium`, `low`
+- `points`: `critical` and `high` map to `10`; `medium` maps to `5`; `low` maps to `1`
+- `confidence`: `high`, `medium`, `low`
+- `category`: `architecture`, `security`, `performance`, `pattern`, `implementation-clarity`, `script-automation`, `documentation-audit`
+- `blast_radius`: `localized`, `module`, `cross-module`, `system-wide`
+- `authority_needed`: `yes`, `no`
+- `systemic_fix_type`: `instruction`, `skill`, `agent-prompt`, `plan-template`, `none`
+
+The category list is canonical-only. Legacy `simplicity` is intentionally excluded.
+
+## Gate Criteria
+
+Scope classification is an AND gate: all five abbreviated-tier criteria must hold, otherwise the issue stays on the full pipeline. The stored tier table captures which phases run in full and abbreviated execution.
+
+Express lane is also an AND gate. A finding must be low severity, strictly mechanical, non-logic-changing, test-neutral, backward-compatible with respect to stored IDs and schema, and limited to one file. It only applies to main review and post-fix review routing, and Tier 1 re-validation is still required after the fix lands.
+
+Post-fix targeted prosecution uses OR semantics for its trigger conditions: one accepted critical or high finding is enough, and any accepted fix that modifies control flow is also enough. If no findings were accepted and applied, the post-fix review is skipped.
+
+## Interpretation Rules
+
+Use exact current values from the JSON assets when a mode, enum, or routing value needs to be preserved across prompts or scripts. Match review markers literally. For specialist dispatch file routing, use explicit `file_patterns` keys instead of parsing prose. Treat `skill_mapping` as explanatory metadata, not a replacement for human judgment. Treat `scope_classification` and `express_lane` as all-criteria gates, while `post_fix_trigger` activates when any trigger condition is met.
+
+When an entry includes prose qualifiers, preserve them rather than compressing them away. The goal of these files is stable extraction of current rules, not reinterpretation of the orchestration policy.
+
+## Fallback Guidance
+
+Future deterministic consumers should prefer the JSON assets first. If a later script is unavailable, agents can still read the JSON directly. If a case is not covered by the structured data or a prompt needs human-readable context, fall back to this skill summary.
+
+Routing authority remains with the calling agent. This skill provides shared data and summaries; it does not own orchestration decisions.
+
+## Gotchas
+
+| Trigger                                               | Gotcha                                                                                                                  | Fix                                                                                         |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Treating a routing table entry as binding policy      | The skill centralizes canonical data, but the calling agent still owns the final routing decision and fallback behavior | Use the skill for shared data, then keep decision authority and override logic in the agent |
+| Editing only the prose summary or only the JSON asset | Human-readable guidance and deterministic consumers drift apart                                                         | Update the JSON assets and the corresponding SKILL.md summary together in the same change   |

--- a/.github/skills/routing-tables/assets/gate-criteria.json
+++ b/.github/skills/routing-tables/assets/gate-criteria.json
@@ -1,0 +1,130 @@
+{
+  "scope_classification": {
+    "source": ".github/agents/Code-Conductor.agent.md",
+    "all_must_hold": true,
+    "outcome_if_all_true": "abbreviated",
+    "default_outcome": "full",
+    "criteria": [
+      {
+        "id": "acceptance_criteria_clear",
+        "text": "Acceptance criteria are clearly defined or the change is self-evident from the issue title"
+      },
+      {
+        "id": "touches_three_or_fewer_files_in_single_domain",
+        "text": "Implementation touches <=3 files in a single domain (no cross-cutting changes)"
+      },
+      {
+        "id": "no_new_user_facing_behavior",
+        "text": "No new user-facing behavior is introduced (configuration, internal protocol, documentation-only)"
+      },
+      {
+        "id": "no_cross_cutting_architectural_changes",
+        "text": "No cross-cutting architectural changes (no shared interfaces, new abstractions, or multi-agent contracts)"
+      },
+      {
+        "id": "no_ce_gate_scenarios_needed",
+        "text": "No CE Gate scenarios are needed (no customer-facing surface affected)"
+      }
+    ],
+    "default_rule": "Default to full pipeline when any criterion is absent, the issue is ambiguous, or the scope is sparse. When in doubt, choose full.",
+    "user_override": {
+      "allowed": true,
+      "text": "Always present both tiers as options and recommend one - the user may choose either regardless of your analysis."
+    },
+    "tier_table": [
+      {
+        "phase": "Experience-Owner",
+        "full_pipeline": true,
+        "abbreviated_pipeline": false,
+        "abbreviated_note": "skip"
+      },
+      {
+        "phase": "Solution-Designer",
+        "full_pipeline": true,
+        "abbreviated_pipeline": false,
+        "abbreviated_note": "skip"
+      },
+      {
+        "phase": "Issue-Planner (incl. design review)",
+        "full_pipeline": true,
+        "abbreviated_pipeline": true,
+        "abbreviated_note": "required"
+      },
+      {
+        "phase": "D9 Checkpoint",
+        "full_pipeline": true,
+        "abbreviated_pipeline": true,
+        "abbreviated_note": "required"
+      },
+      {
+        "phase": "Implementation",
+        "full_pipeline": true,
+        "abbreviated_pipeline": true
+      }
+    ]
+  },
+  "express_lane": {
+    "source": ".github/agents/Code-Conductor.agent.md",
+    "all_must_hold": true,
+    "outcome_if_all_true": "express_lane",
+    "default_outcome": "defense_and_judge_pipeline",
+    "applicable_review_stages": ["main", "postfix"],
+    "excluded_review_modes": ["proxy", "ce", "design_plan"],
+    "criteria": [
+      {
+        "id": "severity_low",
+        "text": "Severity is low - as rated by prosecution output (the only severity level below medium in the critical | high | medium | low schema)"
+      },
+      {
+        "id": "strictly_mechanical_fix_type",
+        "text": "Fix type is strictly mechanical: string literal changes, import path fixes, comment corrections, or formatting fixes - exhaustive list; no other fix types qualify"
+      },
+      {
+        "id": "no_logic_changes",
+        "text": "No logic changes: the fix does not add, remove, or modify any if/else/switch/loop/return/guard clause or conditional short-circuit (&&/|| guard reordering)"
+      },
+      {
+        "id": "no_test_file_cascade",
+        "text": "No test file cascade: the fix does not require changes to any test file or assertion"
+      },
+      {
+        "id": "no_stored_id_or_schema_risk",
+        "text": "Changed value not in stored IDs or DB schema: backward compatibility is not at risk"
+      },
+      {
+        "id": "scope_one_file_or_less",
+        "text": "Scope <= 1 file: the fix touches exactly one file"
+      }
+    ],
+    "revalidation_required": "Tier 1 re-validation required after the specialist applies an express-lane fix."
+  },
+  "post_fix_trigger": {
+    "source": ".github/agents/Code-Conductor.agent.md",
+    "recursion_guard": "This step is never triggered by another post-fix prosecution - only by a main review cycle (code review or GitHub intake proxy prosecution).",
+    "trigger_logic": "any",
+    "trigger_conditions": [
+      {
+        "id": "accepted_high_or_critical_finding",
+        "text": ">=1 accepted finding was Critical or High severity"
+      },
+      {
+        "id": "accepted_fix_modifies_control_flow",
+        "text": "Any accepted fix modifies control flow",
+        "control_flow_changes": [
+          "adding, changing, or removing if/else/switch branches",
+          "loop structure changes for for/while/forEach, including bounds, iteration variable, or break/continue",
+          "guard clause additions or removals",
+          "try/catch restructuring",
+          "early returns",
+          "conditional short-circuit reordering (&&/|| guard reordering)"
+        ]
+      }
+    ],
+    "skip_condition": "Skip if no findings were accepted and applied (post-judgment: all REJECT or DEFERRED-SIGNIFICANT, no fixes applied).",
+    "evaluation_ordering": [
+      "Condition 1 (severity) is evaluable immediately from the main-review judge output.",
+      "Condition 2 (control flow) requires the fix diff and is evaluated after Tier 1 re-validation and diff scoping.",
+      "If condition 1 does not trigger alone, proceed through Tier 1 re-validation and diff scoping before making the final skip decision."
+    ]
+  }
+}

--- a/.github/skills/routing-tables/assets/routing-config.json
+++ b/.github/skills/routing-tables/assets/routing-config.json
@@ -1,0 +1,260 @@
+{
+  "specialist_dispatch": {
+    "source": ".github/agents/Code-Conductor.agent.md",
+    "entries": [
+      {
+        "file_type_or_task": "*.test.*, test suites, fixtures",
+        "file_patterns": ["*.test.*"],
+        "keywords": ["test", "assertion", "flaky", "coverage"],
+        "agent": "Test-Writer"
+      },
+      {
+        "file_type_or_task": "src/**/*.ts, src/**/*.tsx (new behavior)",
+        "file_patterns": ["src/*.ts", "src/*.tsx"],
+        "keywords": ["implement", "feature", "bugfix", "logic"],
+        "agent": "Code-Smith"
+      },
+      {
+        "file_type_or_task": "*.ps1",
+        "file_patterns": ["*.ps1"],
+        "keywords": ["script", "automation", "powershell"],
+        "agent": "Code-Smith"
+      },
+      {
+        "file_type_or_task": "src/**/*.ts, src/**/*.tsx (restructure existing)",
+        "keywords": ["refactor", "simplify", "extract", "dedupe"],
+        "agent": "Refactor-Specialist"
+      },
+      {
+        "file_type_or_task": "UI source files (visual polish)",
+        "keywords": ["ui polish", "spacing", "alignment", "styling"],
+        "agent": "UI-Iterator"
+      },
+      {
+        "file_type_or_task": "*.md, README.*, CHANGELOG.*",
+        "file_patterns": ["*.md", "README.*", "CHANGELOG.*"],
+        "keywords": ["docs", "guide", "changelog"],
+        "agent": "Doc-Keeper"
+      },
+      {
+        "file_type_or_task": "Session memory /memories/session/plan-issue-{ID}.md or GitHub issue comment with <!-- plan-issue-{ID} --> marker",
+        "keywords": ["plan", "acceptance criteria", "sequencing"],
+        "agent": "Issue-Planner"
+      },
+      {
+        "file_type_or_task": "CE Gate evidence capture (downstream); upstream customer framing, scenarios, design intent",
+        "keywords": ["ce gate", "customer", "experience", "journey", "scenarios"],
+        "agent": "Experience-Owner"
+      },
+      {
+        "file_type_or_task": "Code review (read-only)",
+        "keywords": ["review", "risks", "quality", "critique"],
+        "agent": "Code-Critic"
+      },
+      {
+        "file_type_or_task": "Categorize review feedback (read-only)",
+        "keywords": ["judge", "score", "prosecution", "defense", "categorize"],
+        "agent": "Code-Review-Response"
+      },
+      {
+        "file_type_or_task": "Process/systemic gap analysis",
+        "keywords": ["ce-gate-defect", "process-gap", "systemic"],
+        "agent": "Process-Review"
+      }
+    ]
+  },
+  "review_mode_routing": {
+    "source": ".github/agents/Code-Critic.agent.md",
+    "default_mode": "code_prosecution",
+    "entries": [
+      {
+        "marker": null,
+        "mode": "code_prosecution",
+        "passes": 3,
+        "parallel": true
+      },
+      {
+        "marker": "Use design review perspectives",
+        "mode": "design_plan_prosecution",
+        "passes": 2,
+        "parallel": true
+      },
+      {
+        "marker": "Use product-alignment perspectives",
+        "mode": "product_alignment_prosecution",
+        "passes": 1,
+        "parallel": false
+      },
+      {
+        "marker": "Use defense review perspectives",
+        "mode": "defense",
+        "passes": 1,
+        "parallel": false
+      },
+      {
+        "marker": "Use CE review perspectives",
+        "mode": "ce_prosecution",
+        "passes": 1,
+        "parallel": false
+      },
+      {
+        "marker": "Score and represent GitHub review",
+        "mode": "proxy_prosecution",
+        "passes": 1,
+        "parallel": false
+      }
+    ],
+    "conflict_rule": {
+      "priority_order": [
+        "defense",
+        "ce_prosecution",
+        "proxy_prosecution",
+        "product_alignment_prosecution",
+        "design_plan_prosecution",
+        "code_prosecution"
+      ],
+      "override_rules": [
+        {
+          "marker": "Use code review perspectives",
+          "overrides_marker": "Use design review perspectives",
+          "forced_mode": "code_prosecution"
+        }
+      ]
+    }
+  },
+  "surface_identification": {
+    "source": ".github/agents/Code-Conductor.agent.md",
+    "entries": [
+      {
+        "surface_type": "Web UI",
+        "tool_or_method": "Native browser tools (openBrowserPage + screenshotPage)",
+        "fallback": "Playwright MCP as fallback"
+      },
+      {
+        "surface_type": "REST / GraphQL",
+        "tool_or_method": "curl or httpie in terminal"
+      },
+      {
+        "surface_type": "CLI",
+        "tool_or_method": "Invoke command in terminal with test args"
+      },
+      {
+        "surface_type": "SDK",
+        "tool_or_method": "Example invocation in terminal"
+      },
+      {
+        "surface_type": "Batch / pipeline",
+        "tool_or_method": "Invoke with representative test data"
+      },
+      {
+        "surface_type": "No customer surface",
+        "tool_or_method": "Skip with documented reason",
+        "status_result_template": "⏭️ CE Gate not applicable — {reason}"
+      }
+    ]
+  },
+  "skill_mapping": {
+    "source": ".github/agents/Code-Conductor.agent.md",
+    "reference_only": true,
+    "entries": [
+      {
+        "skill": "adversarial-review",
+        "when_to_use": "Running prosecution passes or defense perspectives with Code-Critic"
+      },
+      {
+        "skill": "customer-experience",
+        "when_to_use": "Framing customer journeys or capturing CE evidence with Experience-Owner"
+      },
+      {
+        "skill": "design-exploration",
+        "when_to_use": "Researching and converging technical design options with Solution-Designer"
+      },
+      {
+        "skill": "documentation-finalization",
+        "when_to_use": "Updating design docs, READMEs, or implementation-facing docs with Doc-Keeper"
+      },
+      {
+        "skill": "frontend-design",
+        "when_to_use": "Designing new UI components, screens, or evaluating for uniqueness"
+      },
+      {
+        "skill": "implementation-discipline",
+        "when_to_use": "Implementing bounded plan steps or verifying production wiring with Code-Smith"
+      },
+      {
+        "skill": "parallel-execution",
+        "when_to_use": "Coordinating concurrent implementation paths, convergence gates, or triage routing"
+      },
+      {
+        "skill": "plan-authoring",
+        "when_to_use": "Drafting or refining execution plans with Issue-Planner"
+      },
+      {
+        "skill": "property-based-testing",
+        "when_to_use": "Adding randomized testing, validating input ranges, or verifying invariants"
+      },
+      {
+        "skill": "refactoring-methodology",
+        "when_to_use": "Running a proportionate structural cleanup pass with Refactor-Specialist"
+      },
+      {
+        "skill": "research-methodology",
+        "when_to_use": "Gathering verified multi-file findings for a research document with Research-Agent"
+      },
+      {
+        "skill": "review-judgment",
+        "when_to_use": "Ruling on prosecution plus defense ledgers with Code-Review-Response"
+      },
+      {
+        "skill": "skill-creator",
+        "when_to_use": "Adding new skills, updating skill templates, or reviewing skill structure"
+      },
+      {
+        "skill": "software-architecture",
+        "when_to_use": "Evaluating layer boundaries, dependency flow, or ADR-level decisions"
+      },
+      {
+        "skill": "systematic-debugging",
+        "when_to_use": "Debugging failures, investigating flaky tests, or tracking root causes"
+      },
+      {
+        "skill": "test-driven-development",
+        "when_to_use": "Writing tests first, red-green-refactor, or validating quality gates"
+      },
+      {
+        "skill": "ui-iteration",
+        "when_to_use": "Running screenshot-driven UI polish passes with UI-Iterator"
+      },
+      {
+        "skill": "ui-testing",
+        "when_to_use": "Writing component-level React tests, fixing flaky tests, or establishing patterns"
+      },
+      {
+        "skill": "webapp-testing",
+        "when_to_use": "Creating or improving browser-based E2E coverage, test stability, or CI"
+      }
+    ]
+  },
+  "enums": {
+    "severity": ["critical", "high", "medium", "low"],
+    "points_mapping": {
+      "critical": 10,
+      "high": 10,
+      "medium": 5,
+      "low": 1
+    },
+    "confidence": ["high", "medium", "low"],
+    "category": [
+      "architecture",
+      "security",
+      "performance",
+      "pattern",
+      "implementation-clarity",
+      "script-automation",
+      "documentation-audit"
+    ],
+    "blast_radius": ["localized", "module", "cross-module", "system-wide"],
+    "authority_needed": ["yes", "no"],
+    "systemic_fix_type": ["instruction", "skill", "agent-prompt", "plan-template", "none"]
+  }
+}

--- a/.github/skills/routing-tables/scripts/routing-tables-core.ps1
+++ b/.github/skills/routing-tables/scripts/routing-tables-core.ps1
@@ -1,0 +1,328 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RTConfigPath {
+    return Join-Path $PSScriptRoot '..\assets\routing-config.json'
+}
+
+function Get-RTGateCriteriaPath {
+    return Join-Path $PSScriptRoot '..\assets\gate-criteria.json'
+}
+
+function Read-RTJsonFile {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    return Get-Content -Path $Path -Raw | ConvertFrom-Json -AsHashtable
+}
+
+function Resolve-RTRoutingLookupEntry {
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Entry,
+
+        [Parameter(Mandatory)]
+        [string]$Table,
+
+        [Parameter(Mandatory)]
+        [string]$Key
+    )
+
+    switch ($Table) {
+        'specialist_dispatch' {
+            if ($Key -eq 'FilePattern' -and $Entry.ContainsKey('file_patterns')) {
+                return $Entry.file_patterns
+            }
+
+            break
+        }
+        'review_mode_routing' {
+            if ($Key -eq 'Marker' -and $Entry.ContainsKey('marker')) {
+                return $Entry.marker
+            }
+
+            break
+        }
+        'surface_identification' {
+            if ($Key -eq 'Surface' -and $Entry.ContainsKey('surface_type')) {
+                return $Entry.surface_type
+            }
+
+            break
+        }
+    }
+
+    $candidateKey = $Key.Substring(0, 1).ToLowerInvariant() + $Key.Substring(1)
+    if ($Entry.ContainsKey($candidateKey)) {
+        return $Entry[$candidateKey]
+    }
+
+    return $null
+}
+
+function Resolve-RTRoutingLookupResult {
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Entry,
+
+        [Parameter(Mandatory)]
+        [string]$Table
+    )
+
+    switch ($Table) {
+        'specialist_dispatch' {
+            return $Entry.agent
+        }
+        'review_mode_routing' {
+            return $Entry.mode
+        }
+        'surface_identification' {
+            if ($Entry.ContainsKey('status_result_template')) {
+                return $Entry.status_result_template
+            }
+
+            return $Entry.tool_or_method
+        }
+        default {
+            return $null
+        }
+    }
+}
+
+function Test-RTWildcardMatch {
+    param(
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [object]$Patterns,
+
+        [Parameter(Mandatory)]
+        [string]$Value
+    )
+
+    $patternList = @()
+
+    if ($Patterns -is [string]) {
+        $patternList = @([string]$Patterns)
+    }
+    elseif ($null -ne $Patterns) {
+        $patternList = @($Patterns | ForEach-Object { [string]$_ })
+    }
+
+    foreach ($pattern in $patternList) {
+        if (-not $pattern) {
+            continue
+        }
+
+        if ($Value -like $pattern -or $pattern -eq $Value) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-RTRoutingEntryMatch {
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Entry,
+
+        [Parameter(Mandatory)]
+        [string]$Table,
+
+        [Parameter(Mandatory)]
+        [string]$Key,
+
+        [Parameter(Mandatory)]
+        [string]$Value
+    )
+
+    if ($Table -eq 'specialist_dispatch' -and $Key -eq 'FilePattern') {
+        if (-not $Entry.ContainsKey('file_patterns')) {
+            return $false
+        }
+
+        return Test-RTWildcardMatch -Patterns $Entry.file_patterns -Value $Value
+    }
+
+    $entryValue = Resolve-RTRoutingLookupEntry -Entry $Entry -Table $Table -Key $Key
+    if ($null -eq $entryValue) {
+        return $false
+    }
+
+    return [string]$entryValue -eq $Value
+}
+
+function Get-RTDefaultGateResult {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Gate
+    )
+
+    switch ($Gate) {
+        'scope_classification' {
+            return 'full'
+        }
+        'express_lane' {
+            return 'does_not_qualify'
+        }
+        'post_fix_trigger' {
+            return 'not_triggered'
+        }
+        default {
+            return $null
+        }
+    }
+}
+
+function Convert-RTGateOutcomeToPublicResult {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Gate,
+
+        [AllowNull()]
+        [string]$Outcome,
+
+        [Parameter(Mandatory)]
+        [bool]$Qualifies
+    )
+
+    switch ($Gate) {
+        'scope_classification' {
+            if ($Qualifies -and $Outcome) {
+                return $Outcome
+            }
+
+            return 'full'
+        }
+        'express_lane' {
+            if ($Qualifies) {
+                return 'qualifies'
+            }
+
+            return 'does_not_qualify'
+        }
+        'post_fix_trigger' {
+            if ($Qualifies) {
+                return 'triggered'
+            }
+
+            return 'not_triggered'
+        }
+        default {
+            return $Outcome
+        }
+    }
+}
+
+function Invoke-RoutingLookup {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Table,
+
+        [Parameter(Mandatory)]
+        [string]$Key,
+
+        [Parameter(Mandatory)]
+        [string]$Value
+    )
+
+    try {
+        $config = Read-RTJsonFile -Path (Get-RTConfigPath)
+    }
+    catch {
+        Write-Warning "Failed to read routing configuration: $($_.Exception.Message)"
+        return $null
+    }
+
+    if (-not $config.ContainsKey($Table)) {
+        throw "Routing table '$Table' was not found."
+    }
+
+    $tableDefinition = $config[$Table]
+    if (-not $tableDefinition.ContainsKey('entries')) {
+        return $null
+    }
+
+    foreach ($entry in $tableDefinition.entries) {
+        if (Test-RTRoutingEntryMatch -Entry $entry -Table $Table -Key $Key -Value $Value) {
+            return Resolve-RTRoutingLookupResult -Entry $entry -Table $Table
+        }
+    }
+
+    return $null
+}
+
+function Test-GateCriteria {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Gate,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Criteria
+    )
+
+    try {
+        $gateConfig = Read-RTJsonFile -Path (Get-RTGateCriteriaPath)
+    }
+    catch {
+        Write-Warning "Failed to read gate criteria configuration: $($_.Exception.Message)"
+        return Get-RTDefaultGateResult -Gate $Gate
+    }
+
+    if (-not $gateConfig.ContainsKey($Gate)) {
+        Write-Warning "Gate '$Gate' was not found in gate criteria configuration."
+        return Get-RTDefaultGateResult -Gate $Gate
+    }
+
+    $gateDefinition = $gateConfig[$Gate]
+    $criterionIds = @()
+
+    if ($gateDefinition.ContainsKey('criteria')) {
+        $criterionIds = @($gateDefinition.criteria | ForEach-Object { $_.id })
+    }
+    elseif ($gateDefinition.ContainsKey('trigger_conditions')) {
+        $criterionIds = @($gateDefinition.trigger_conditions | ForEach-Object { $_.id })
+    }
+
+    $usesAnySemantics = $gateDefinition.ContainsKey('trigger_logic') -and $gateDefinition.trigger_logic -eq 'any'
+    $qualifies = -not $usesAnySemantics
+
+    foreach ($criterionId in $criterionIds) {
+        $criterionSatisfied = $Criteria.ContainsKey($criterionId) -and [bool]$Criteria[$criterionId]
+
+        if ($usesAnySemantics) {
+            if ($criterionSatisfied) {
+                $qualifies = $true
+                break
+            }
+        }
+        elseif (-not $criterionSatisfied) {
+            $qualifies = $false
+            break
+        }
+    }
+
+    $outcome = if ($qualifies) {
+        if ($gateDefinition.ContainsKey('outcome_if_all_true')) {
+            [string]$gateDefinition.outcome_if_all_true
+        }
+        else {
+            $null
+        }
+    }
+    else {
+        if ($gateDefinition.ContainsKey('default_outcome')) {
+            [string]$gateDefinition.default_outcome
+        }
+        else {
+            $null
+        }
+    }
+
+    return Convert-RTGateOutcomeToPublicResult -Gate $Gate -Outcome $outcome -Qualifies $qualifies
+}

--- a/.github/skills/routing-tables/scripts/routing-tables-core.ps1
+++ b/.github/skills/routing-tables/scripts/routing-tables-core.ps1
@@ -1,8 +1,5 @@
 #Requires -Version 7.0
 
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-
 function Get-RTConfigPath {
     return Join-Path $PSScriptRoot '..\assets\routing-config.json'
 }
@@ -225,11 +222,15 @@ function Invoke-RoutingLookup {
         [string]$Table,
 
         [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string]$Key,
 
         [Parameter(Mandatory)]
         [string]$Value
     )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
 
     try {
         $config = Read-RTJsonFile -Path (Get-RTConfigPath)
@@ -265,6 +266,9 @@ function Test-GateCriteria {
         [Parameter(Mandatory)]
         [hashtable]$Criteria
     )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
 
     try {
         $gateConfig = Read-RTJsonFile -Path (Get-RTGateCriteriaPath)

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -8,7 +8,7 @@ This template supports two distribution models:
 
 | Model | How to Install | What You Get |
 |-------|---------------|--------------|
-| **Plugin** (VS Code 1.110+) | Add marketplace to settings + install from Extensions view | 14 agents, 32 skills, 9 slash commands (`/setup`, `/start-issue`, `/design`, `/plan`, `/implement`, `/review`, `/polish`, `/experience`, `/orchestrate`) — instantly available |
+| **Plugin** (VS Code 1.110+) | Add marketplace to settings + install from Extensions view | 14 agents, 33 skills, 9 slash commands (`/setup`, `/start-issue`, `/design`, `/plan`, `/implement`, `/review`, `/polish`, `/experience`, `/orchestrate`) — instantly available |
 | **Clone/Fork** | `git clone` or use as template | Everything above PLUS 6 shared instruction files (auto-loaded by VS Code), project templates, and examples |
 
 ### Plugin Installation

--- a/Documents/Design/skills-framework.md
+++ b/Documents/Design/skills-framework.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The skills framework provides domain-specific knowledge modules loaded on demand by agents from `.github/skills/`. Under the thin-agents/fat-skills direction for issue #344, skills hold reusable methodology and protocol content, while agents retain orchestration boundaries such as routing, identity, trigger points, and commit authority. The repository now ships 32 skills after moving reusable methodology out of agents without changing agent interfaces. Hub skills may be extended by project-specific supplement skills (named `{project}-{hub-skill-name}`) that layer additional constraints on top of their defaults.
+The skills framework provides domain-specific knowledge modules loaded on demand by agents from `.github/skills/`. Under the thin-agents/fat-skills direction for issue #344, skills hold reusable methodology and protocol content, while agents retain orchestration boundaries such as routing, identity, trigger points, and commit authority. The repository now ships 33 skills after moving reusable methodology out of agents without changing agent interfaces. Hub skills may be extended by project-specific supplement skills (named `{project}-{hub-skill-name}`) that layer additional constraints on top of their defaults.
 
 ---
 
@@ -33,7 +33,7 @@ Issue #344 changes the skills boundary from "skills are reference material" to "
 
 ## Skill Inventory Direction
 
-### Currently Shipped Inventory (32 Skills)
+### Currently Shipped Inventory (33 Skills)
 
 | Skill | Directory | Purpose |
 |-------|-----------|---------|
@@ -57,6 +57,7 @@ Issue #344 changes the skills boundary from "skills are reference material" to "
 | `refactoring-methodology` | `.github/skills/refactoring-methodology/` | Proactive refactoring workflow for touched files and nearby debt |
 | `research-methodology` | `.github/skills/research-methodology/` | Evidence-driven research methodology for technical analysis and recommendation building |
 | `review-judgment` | `.github/skills/review-judgment/` | Reusable single-shot review judgment methodology for scoring prosecution and defense ledgers |
+| `routing-tables` | `.github/skills/routing-tables/` | Concise reference for canonical routing metadata, enum values, and gate criteria shared between agents and deterministic consumers |
 | `session-startup` | `.github/skills/session-startup/` | Automatic startup cleanup guard for new conversations |
 | `skill-creator` | `.github/skills/skill-creator/` | Guide for creating new skills in this system with proper frontmatter format |
 | `software-architecture` | `.github/skills/software-architecture/` | Clean Architecture, SOLID principles, and architectural decision guidance |
@@ -98,6 +99,8 @@ description: What skill does. Use when {trigger conditions}. DO NOT USE FOR: {ne
 
 Supporting files (e.g., `patterns.md`, `playwright-setup.md`) may live alongside `SKILL.md` in the same directory. Skills provide knowledge and procedural guidance — they must NOT contain agent orchestration logic.
 
+Skills may also include optional `assets/` and `scripts/` subdirectories for supporting files. `assets/` holds static data such as JSON or YAML lookup tables, while `scripts/` holds deterministic helper scripts that consume or validate the shared skill data. This matches the current architecture rules and supports skills such as `routing-tables`, which ships both human-readable guidance and JSON routing assets.
+
 For issue #344, "must NOT contain agent orchestration logic" means skills do not decide which agent speaks next, when a trigger fires, whether a commit occurs, or how Code-Conductor advances between plan steps. Skills may contain the reusable protocol an agent follows once the agent has decided to invoke that skill.
 
 ---
@@ -108,6 +111,9 @@ For issue #344, "must NOT contain agent orchestration logic" means skills do not
 |--------|------|
 | Moved | `.claude/skills/*` → `.github/skills/*` |
 | Renamed | `.github/skills/tdd-workflow/` → `.github/skills/test-driven-development/` |
+| Created | `.github/skills/routing-tables/SKILL.md` |
+| Created | `.github/skills/routing-tables/assets/routing-config.json` |
+| Created | `.github/skills/routing-tables/assets/gate-criteria.json` |
 | Created | `.github/skills/webapp-testing/SKILL.md` |
 | Created | `.github/skills/webapp-testing/patterns.md` |
 | Created | `.github/skills/webapp-testing/playwright-setup.md` |
@@ -125,4 +131,4 @@ For issue #344, "must NOT contain agent orchestration logic" means skills do not
 - Each `SKILL.md` has valid frontmatter with `name` and `description`
 - `validate-architecture.ps1` checks `.github/skills` path
 - VS Code skill discovery works with `chat.useAgentSkills` enabled
-- Current shipped inventory is 32 skills, and all plugin plus documentation surfaces should describe that same count consistently
+- Current shipped inventory is 33 skills, and all plugin plus documentation surfaces should describe that same count consistently

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ A multi-agent workflow system for GitHub Copilot that orchestrates AI-assisted s
    ```
 
 2. **Install** — In the Extensions view (`Ctrl+Shift+X`), search `@agentPlugins copilot-orchestra` and install.
-3. **Use** — All 14 agents and 32 skills are immediately available in VS Code Chat.
+3. **Use** — All 14 agents and 33 skills are immediately available in VS Code Chat.
 
-**What's included in the plugin**: 14 agents, 32 skills, and 9 slash commands (`/setup`, `/start-issue`, `/design`, `/plan`, `/implement`, `/review`, `/polish`, `/experience`, `/orchestrate`).
+**What's included in the plugin**: 14 agents, 33 skills, and 9 slash commands (`/setup`, `/start-issue`, `/design`, `/plan`, `/implement`, `/review`, `/polish`, `/experience`, `/orchestrate`).
 
 **What requires clone/fork**: Instruction files (`.github/instructions/`) and project templates are not distributed via the plugin — they are auto-discovered by VS Code when you clone or fork the repo.
 


### PR DESCRIPTION
## Summary
- extract deterministic routing, enum, and gate metadata into the new `routing-tables` skill with JSON assets and a PowerShell helper
- update Code-Conductor and Code-Critic to reference the shared routing skill instead of duplicating inline tables
- extend validation and tests so skill scripts/assets are covered by `quick-validate` and the new routing contract suite

## Validation
- `pwsh -NoProfile -NonInteractive -File .github/scripts/quick-validate.ps1`
- `pwsh -NoProfile -NonInteractive -Command "Invoke-Pester '.github/scripts/Tests/routing-tables.Tests.ps1' -Output Minimal"`
- `pwsh -NoProfile -NonInteractive -Command "Invoke-Pester .github/scripts/Tests/ -Output Minimal"`
- `✅ CE Gate passed — intent match: strong`

## Follow-up
- repo-wide markdownlint debt tracked separately in #361
- broad `markdownlint-cli2 --fix "**/*.md"` failures were pre-existing outside the #346 change slice

Closes #346

## Summary by Sourcery

Centralize deterministic routing metadata and gate criteria into a new reusable routing-tables skill and wire agents, validation, and tests to consume the shared routing assets and helper scripts.

Enhancements:
- Introduce a routing-tables skill with JSON assets and PowerShell helpers to provide canonical routing configuration, enums, and gate criteria for agents and deterministic tools.
- Update Code-Conductor and Code-Critic agent definitions to delegate specialist dispatch, review-mode routing, CE surface mapping, enum usage, and gate logic to the shared routing-tables skill instead of inline tables.
- Extend quick-validate to analyze both core scripts and skill scripts, including JSON asset parse checks for skill data files.
- Document the expanded skills architecture to allow optional assets and scripts under skills, and describe the new layer model and routing-tables skill in design and architecture docs.
- Update plugin and customization documentation to reflect the increased skill count and inclusion of the routing-tables skill.

Tests:
- Add a routing-tables contract test suite that locks in deterministic behavior for routing lookups, gate evaluation semantics, config reload behavior, and taxonomy parity with the script safety contract.
- Broaden the script safety contract tests to cover skill scripts under .github/skills/**/scripts/ as production scripts with the same safety guarantees.