### PR TITLE
Issue #358: finalize architecture rules (layer model table, skill naming, regroup MAY permissions)

### DIFF
--- a/.github/architecture-rules.md
+++ b/.github/architecture-rules.md
@@ -24,8 +24,8 @@ These rules define the structural constraints for Copilot Orchestra. All agents 
 |-------|---------|---------------------|
 | **Top (fat)** | Skills — judgment, methodology, process, documentation, and supporting data loaded on demand | `.github/skills/` |
 | **Middle (thin)** | Harness — routing, context management, safety, and decision authority | Agent files (`.github/agents/`) |
-| **Bottom** | Application — deterministic same-input/same-output evaluation, concrete tools, consumer codebase | `.github/scripts/`, skill `scripts/`, VS Code tools, GitHub API |
-| **Resolvers** | Structured routing/context lookup data that helps load the right skill or content | Skill `assets/` (JSON/YAML), `.github/instructions/` |
+| **Bottom** | Application — deterministic same-input/same-output evaluation, concrete tools, consumer codebase | `.github/scripts/`, `.github/skills/{name}/scripts/`, VS Code tools, GitHub API |
+| **Resolvers** | Structured routing/context lookup data that helps load the right skill or content | `.github/skills/{name}/assets/` (JSON/YAML), `.github/instructions/` |
 
 ## Dependency Rules
 

--- a/.github/architecture-rules.md
+++ b/.github/architecture-rules.md
@@ -20,10 +20,12 @@ These rules define the structural constraints for Copilot Orchestra. All agents 
 
 ## Layer Model
 
-- Skills: Fat, on-demand methodology, judgment, documentation, and supporting data
-- Harness: Agent files keep routing, context, safety, and decision authority
-- Deterministic/Application bottom layer: Same-input, same-output evaluation and concrete tools/code
-- Resolvers: Structured context and routing data that helps load the right skill or content
+| Layer | Purpose | In Copilot Orchestra |
+|-------|---------|---------------------|
+| **Top (fat)** | Skills — judgment, methodology, process, documentation, and supporting data loaded on demand | `.github/skills/` |
+| **Middle (thin)** | Harness — routing, context management, safety, and decision authority | Agent files (`.github/agents/`) |
+| **Bottom** | Application — deterministic same-input/same-output evaluation, concrete tools, consumer codebase | `.github/scripts/`, skill `scripts/`, VS Code tools, GitHub API |
+| **Resolvers** | Structured routing/context lookup data that helps load the right skill or content | Skill `assets/` (JSON/YAML), `.github/instructions/` |
 
 ## Dependency Rules
 
@@ -34,14 +36,14 @@ These rules define the structural constraints for Copilot Orchestra. All agents 
 - Agents MAY load instructions from `.github/instructions/`
 - User-facing agents MAY delegate to internal agents as subagents
 - Skills MAY reference other skills or instructions by file path
+- Skills MAY contain static data files (JSON, YAML) in `assets/` and deterministic evaluation scripts in `scripts/` that agents invoke for routing decisions
+- Skills MAY contain reusable methodology and protocol content, including ordered workflows, checklists, decision heuristics, and evidence requirements that agents load on demand
 
 ### Forbidden
 
 - Internal agents (`user-invocable: false`) must NOT be directly user-invocable; they MAY appear in agent `handoffs` lists as subagents
 - Agents must NOT reference deleted agents (e.g., Plan-Architect, Issue-Designer) — validate with `grep`
 - Skills must NOT own orchestration boundaries such as user-turn routing, agent handoffs, commit authority, issue-state transitions, or Code-Conductor's step execution loop
-- Skills MAY contain static data files (JSON, YAML) in `assets/` and deterministic evaluation scripts in `scripts/` that agents invoke for routing decisions
-- Skills MAY contain reusable methodology and protocol content, including ordered workflows, checklists, decision heuristics, and evidence requirements that agents load on demand
 - Concrete boundary examples: Code-Conductor's validation ladder may live in a skill, but CE Gate orchestration and subagent routing stay in the agent; test-driven-development may hold Test-Writer methodology, but conditional delegation and execution flow stay in Test-Writer; session-startup, provenance-gate, and terminal-hygiene remain portable skills while the trigger points that invoke them stay in agents
 - The `guidance-complexity` D10 ceiling and prompt-facing guidance rules remain agent-only; issue #360 may move the measurement script and related tooling into the `guidance-measurement` skill without moving the rule set itself
 - Only Code-Conductor may auto-commit, and only after validation ladder and RC conformance gate pass; specialist agents must NOT commit; consumers may opt out via `## Commit Policy` section
@@ -72,6 +74,10 @@ Must live in `.github/instructions/`
 
 - Agent files: `{Agent-Name}.agent.md` (PascalCase with hyphens)
 - Skill directories: `{skill-name}/` (lowercase with hyphens)
+- Skill core libraries: `{name}-core.ps1` (mirrors `.github/scripts/lib/` — dot-sourced by CLI wrappers)
+- Skill CLI wrappers & standalone scripts: lowercase-with-hyphens, descriptive (e.g., `post-merge-cleanup.ps1`)
+- Skill helper modules: `{descriptive-name}-helpers.ps1` (non-Invoke-* utility functions)
+- Skill asset files: lowercase-with-hyphens, descriptive (e.g., `routing-config.json`, `gate-criteria.json`)
 - Instruction files: `{topic}.instructions.md` (lowercase with hyphens)
 - Design documents: `{domain-slug}.md` (lowercase with hyphens)
 


### PR DESCRIPTION
Closes #358.

## Summary

- **D1**: Replaced prose Layer Model with the canonical 4-row Garry Tan table (Top/Skills, Middle/Harness, Bottom/Application, Resolvers), preserving every concept from the prior prose as a cell value and adding concrete file-path examples per layer.
- **D2**: Added 4 naming-convention bullets for skill subdirectories matching the patterns already in use across all 18 existing skill scripts and 3 asset files. No existing files require rename.
- **D3**: Moved 2 MAY-permission rules from the **Forbidden** subsection (where they were misplaced as a side-finding during design) to the end of the **Allowed** subsection. Lines 45-50 remain in Forbidden as genuine NOT/MUST constraints.

Single-file change (`+12 / -6`); no source code, scripts, or tests touched.

## Pipeline notes

- **Experience-Owner** scoped #358 down after the provenance gate flagged that PR #362 already shipped most of the original AC. Customer framing, BDD scenarios S1-S4, and CE Gate readiness recorded in the issue body.
- **Solution-Designer** locked D1/D2/D3 wording. Lightweight self-review substituted for the full 3-pass adversarial pipeline given docs-only ~12-line scope (user-acknowledged deviation).
- **Issue-Planner** persisted plan to `.copilot-tracking/plan-issue-358.md` (gitignored). Filed [#373](https://github.com/Grimblaz/copilot-orchestra/issues/373) to reduce future plan-approval token cost.
- **Code-Conductor** executed in 3 edits + validation + CE Gate.

## CE Gate evidence

| Scenario | Class | Result | Evidence |
|---|---|---|---|
| S1: Layer model is canonical and scannable | `[auto]` | ✅ PASS | 4-row table at lines 23-28 |
| S2: Skill scripts have an authoritative naming rule | `[auto]` | ✅ PASS | Bullets at lines 77, 78, 79 (cores, CLI wrappers, helpers) |
| S3: Skill assets have an authoritative naming rule | `[auto]` | ✅ PASS | Bullet at line 80 |
| S4: Rules file feels authoritative, not aspirational | `[manual]` | ✅ PASS | End-to-end read: every artifact type has a naming pattern, every layer maps to a concrete location, dependency rules in correct subsections |

## Test plan

- [x] `pwsh -NoProfile -NonInteractive -File .github/scripts/quick-validate.ps1` → 11/11 PASS
- [x] All 18 existing skill scripts conform to the documented patterns (no rename required) — verified via Glob
- [x] All 3 existing skill assets conform — verified via Glob
- [x] `git diff main` shows changes to exactly one file: `.github/architecture-rules.md`
- [x] Pre-commit markdownlint hook passes

## Summary by Sourcery

Document the canonical architecture layer model, clarify skill capabilities, and formalize naming conventions for skill artifacts in the architecture rules documentation.

New Features:
- Introduce a canonical four-layer architecture table mapping each layer to its purpose and concrete repository locations.
- Add explicit naming conventions for skill core libraries, CLI wrappers, helper modules, and asset files.

Enhancements:
- Reclassify permissive skill content rules from the forbidden section into the allowed section to better reflect actual constraints.

Documentation:
- Update `.github/architecture-rules.md` to use a structured table for the layer model and to document authoritative naming and dependency rules for skills and assets.