### PR TITLE
chore(plugin): bump to 2.1.0 to expose Phase 1 Claude entry points

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.0.0"
+    "version": "2.1.0"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 14 specialized agents and 39 skills.",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Multi-agent workflow system for Claude Code. Pipeline-based agent orchestration: Issue → Design → Plan → Implement → Review → PR.",
   "author": {
     "name": "Grimblaz"


### PR DESCRIPTION
## Why

[#380](https://github.com/Grimblaz/agent-orchestra/pull/380) shipped the Phase 1 Claude Code entry points (`agents/experience-owner.md`, `solution-designer.md`, `issue-planner.md` + `commands/experience.md`, `design.md`, `plan.md`) — but kept the plugin version at `2.0.0`.

Claude Code's plugin cache is keyed by version: `~/.claude/plugins/cache/agent-orchestra/agent-orchestra/{version}/`. On a same-version update the cache is not invalidated, so existing installs never re-pull the plugin directory. I confirmed this locally — the cached `2.0.0` tree has no `commands/` directory and only the Copilot-style `.agent.md` files under `agents/`, exactly the pre-#380 snapshot.

## What

- `.claude-plugin/plugin.json` — version `2.0.0` → `2.1.0`
- `.claude-plugin/marketplace.json` — version `2.0.0` → `2.1.0` (both `metadata.version` and the plugins[0].version)

## Release notes for the user

After this lands on main, to pick up the new entry points:

```text
/plugin uninstall agent-orchestra
/plugin install agent-orchestra@agent-orchestra
```

Once reinstalled, `/experience`, `/design`, `/plan` appear in the slash-command picker and the Claude-native subagents resolve.

## Versioning rationale

Minor bump (`2.0.0` → `2.1.0`) rather than patch: new user-facing features (three slash commands + three subagents), additive only, no behavior changes to existing skills or Copilot flow.

## Test plan

- [ ] After merge, uninstall + reinstall locally; confirm `/experience`, `/design`, `/plan` appear.
- [ ] Invoke `/experience 369` and verify the shell dispatches correctly.

## Follow-up

Adding a release checklist (or automating the version bump when entry-point-affecting files change) would prevent recurrence. Can log as a separate issue if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the Claude plugin version to ensure Phase 1 Claude entry points are correctly exposed to users.

Build:
- Update .claude-plugin/plugin.json to version 2.1.0.
- Update .claude-plugin/marketplace.json metadata and plugin entry to version 2.1.0.