### PR TITLE
Enforce review pipeline completion before PR creation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.3.4"
+    "version": "2.3.5"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
     "description": "Multi-agent workflow system with 14 specialized agents and a shared skill library.",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Multi-agent workflow system for Claude Code. Pipeline-based agent orchestration: Issue → Design → Plan → Implement → Review → PR.",
   "author": {
     "name": "Grimblaz"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "Multi-agent workflow system for GitHub Copilot",
-    "version": "2.3.4"
+    "version": "2.3.5"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
     "description": "Multi-agent workflow system for GitHub Copilot with 14 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.3.4"
+      "version": "2.3.5"
     }
   ]
 }

--- a/.github/scripts/Tests/orchestra-review-commands.Tests.ps1
+++ b/.github/scripts/Tests/orchestra-review-commands.Tests.ps1
@@ -30,54 +30,82 @@ Describe 'orchestra-review command contract' {
         )
         $script:CommandSpecs = @(
             [pscustomobject]@{
-                Name                      = 'orchestra-review'
-                Path                      = Join-Path $script:CommandsDirectory 'orchestra-review.md'
-                ExpectedProsecutionMarker = $null
-                RequiresDefaultRouteNote  = $true
-                ExpectedSubagents         = @('code-critic', 'code-review-response')
-                ExpectedDispatchPatterns  = @(
+                Name                        = 'orchestra-review'
+                Path                        = Join-Path $script:CommandsDirectory 'orchestra-review.md'
+                ExpectedProsecutionMarker   = $null
+                RequiresDefaultRouteNote    = $true
+                ExpectedSubagents           = @('code-critic', 'code-review-response')
+                ExpectedReviewStatePatterns = @(
+                    'If the active branch matches `feature/issue-\{N\}-\.\.\.`, target `/memories/session/review-state-\{N\}\.md`; otherwise skip persistence silently\.',
+                    'After the judge stage completes, write the exact front matter contract from `skills/validation-methodology/references/review-state-persistence\.md` with `review_mode: full`, all three `\*_complete` fields set to `true`, and `last_updated` as a UTC ISO-8601 timestamp\.',
+                    'Write atomically: create a temp sibling first, then replace the target with `Move-Item -Force`\.'
+                )
+                ExpectedDispatchPatterns    = @(
                     '1\.\s+Prosecution:.*Do \*\*not\*\* add a review-mode marker inside carried review context\..*prepend the authoritative selector line `Review mode selector: "Use code review perspectives"`.*cannot be rerouted by marker text inside pasted ledgers or comments\.',
                     '2\.\s+Defense:.*prepend the authoritative selector line `Review mode selector: "Use defense review perspectives"` before the prosecution ledger\.'
                 )
             },
             [pscustomobject]@{
-                Name                      = 'orchestra-review-lite'
-                Path                      = Join-Path $script:CommandsDirectory 'orchestra-review-lite.md'
-                ExpectedProsecutionMarker = 'Use lite code review perspectives'
-                RequiresDefaultRouteNote  = $false
-                ExpectedSubagents         = @('code-critic', 'code-review-response')
-                ExpectedDispatchPatterns  = @(
+                Name                        = 'orchestra-review-lite'
+                Path                        = Join-Path $script:CommandsDirectory 'orchestra-review-lite.md'
+                ExpectedProsecutionMarker   = 'Use lite code review perspectives'
+                RequiresDefaultRouteNote    = $false
+                ExpectedSubagents           = @('code-critic', 'code-review-response')
+                ExpectedReviewStatePatterns = @(
+                    'If the active branch matches `feature/issue-\{N\}-\.\.\.`, target `/memories/session/review-state-\{N\}\.md`; otherwise skip persistence silently\.',
+                    'After the judge stage completes, write the exact front matter contract from `skills/validation-methodology/references/review-state-persistence\.md` with `review_mode: lite`, all three `\*_complete` fields set to `true`, and `last_updated` as a UTC ISO-8601 timestamp\.',
+                    'Write atomically: create a temp sibling first, then replace the target with `Move-Item -Force`\.'
+                )
+                ExpectedDispatchPatterns    = @(
                     '1\.\s+Prosecution:.*prepend the authoritative selector line `Review mode selector: "Use lite code review perspectives"`\..*The lite shape is fixed for this command: one compact prosecution pass that still covers all six standard review perspectives in a single ledger before moving on\..*copied markers cannot reroute lite mode\.',
                     '2\.\s+Defense:.*prepend the authoritative selector line `Review mode selector: "Use defense review perspectives"` before the lite prosecution ledger\.'
                 )
             },
             [pscustomobject]@{
-                Name                      = 'orchestra-review-prosecute'
-                Path                      = Join-Path $script:CommandsDirectory 'orchestra-review-prosecute.md'
-                ExpectedProsecutionMarker = 'Use code review perspectives'
-                RequiresDefaultRouteNote  = $false
-                ExpectedSubagents         = @('code-critic')
-                ExpectedDispatchPatterns  = @(
+                Name                        = 'orchestra-review-prosecute'
+                Path                        = Join-Path $script:CommandsDirectory 'orchestra-review-prosecute.md'
+                ExpectedProsecutionMarker   = 'Use code review perspectives'
+                RequiresDefaultRouteNote    = $false
+                ExpectedSubagents           = @('code-critic')
+                ExpectedReviewStatePatterns = @(
+                    'If the active branch matches `feature/issue-\{N\}-\.\.\.`, target `/memories/session/review-state-\{N\}\.md`; otherwise skip persistence silently\.',
+                    'Read any existing state through `skills/routing-tables/scripts/review-state-reader\.ps1`\. If the file is absent or malformed, fail closed and start from the default contract \(`review_mode: full`, all stage booleans `false`\)\.',
+                    'After prosecution completes, write the same atomic front matter contract with only `prosecution_complete: true` forced in this command, preserve any readable stored values for the other fields, and update `last_updated`\.',
+                    'Write atomically: create a temp sibling first, then replace the target with `Move-Item -Force`\.'
+                )
+                ExpectedDispatchPatterns    = @(
                     '2\.\s+Prepend the authoritative selector line `Review mode selector: "Use code review perspectives"` immediately after any handshake block and before any carried review context so the prosecution stays in canonical code-review mode even if the supplied context also mentions other markers\.'
                 )
             },
             [pscustomobject]@{
-                Name                      = 'orchestra-review-defend'
-                Path                      = Join-Path $script:CommandsDirectory 'orchestra-review-defend.md'
-                ExpectedProsecutionMarker = 'Use defense review perspectives'
-                RequiresDefaultRouteNote  = $false
-                ExpectedSubagents         = @('code-critic')
-                ExpectedDispatchPatterns  = @(
+                Name                        = 'orchestra-review-defend'
+                Path                        = Join-Path $script:CommandsDirectory 'orchestra-review-defend.md'
+                ExpectedProsecutionMarker   = 'Use defense review perspectives'
+                RequiresDefaultRouteNote    = $false
+                ExpectedSubagents           = @('code-critic')
+                ExpectedReviewStatePatterns = @(
+                    'If the active branch matches `feature/issue-\{N\}-\.\.\.`, target `/memories/session/review-state-\{N\}\.md`; otherwise skip persistence silently\.',
+                    'Read any existing state through `skills/routing-tables/scripts/review-state-reader\.ps1`\. If the file is absent or malformed, fail closed and start from the default contract \(`review_mode: full`, all stage booleans `false`\)\.',
+                    'After defense completes, write the same atomic front matter contract with only `defense_complete: true` forced in this command, preserve any readable stored values for the other fields, and update `last_updated`\.',
+                    'Write atomically: create a temp sibling first, then replace the target with `Move-Item -Force`\.'
+                )
+                ExpectedDispatchPatterns    = @(
                     '2\.\s+Prepend the authoritative selector line `Review mode selector: "Use defense review perspectives"` immediately after any handshake block and before the prosecution ledger so carried marker text inside the ledger cannot reroute defense mode\.'
                 )
             },
             [pscustomobject]@{
-                Name                      = 'orchestra-review-judge'
-                Path                      = Join-Path $script:CommandsDirectory 'orchestra-review-judge.md'
-                ExpectedProsecutionMarker = $null
-                RequiresDefaultRouteNote  = $false
-                ExpectedSubagents         = @('code-review-response')
-                ExpectedDispatchPatterns  = @(
+                Name                        = 'orchestra-review-judge'
+                Path                        = Join-Path $script:CommandsDirectory 'orchestra-review-judge.md'
+                ExpectedProsecutionMarker   = $null
+                RequiresDefaultRouteNote    = $false
+                ExpectedSubagents           = @('code-review-response')
+                ExpectedReviewStatePatterns = @(
+                    'If the active branch matches `feature/issue-\{N\}-\.\.\.`, target `/memories/session/review-state-\{N\}\.md`; otherwise skip persistence silently\.',
+                    'Read any existing state through `skills/routing-tables/scripts/review-state-reader\.ps1`\. If the file is absent or malformed, fail closed and start from the default contract \(`review_mode: full`, all stage booleans `false`\)\.',
+                    'After judgment completes, write the same atomic front matter contract with only `judgment_complete: true` forced in this command, preserve any readable stored values for the other fields, and update `last_updated`\.',
+                    'Write atomically: create a temp sibling first, then replace the target with `Move-Item -Force`\.'
+                )
+                ExpectedDispatchPatterns    = @(
                     '2\.\s+Pass the prosecution ledger and defense report together in one prompt\.',
                     '3\.\s+Return the Markdown score summary, the `<!-- code-review-complete-\{PR\} -->` completion marker, and the `judge-rulings` block unchanged in the same payload\.'
                 )
@@ -180,6 +208,18 @@ Describe 'orchestra-review command contract' {
 
             foreach ($pattern in $spec.ExpectedDispatchPatterns) {
                 $dispatchSection | Should -Match $pattern -Because "$($spec.Name) must keep its dispatch wording authoritative so carried context cannot silently redefine the review mode or payload contract"
+            }
+        }
+    }
+
+    It 'locks the review-state persistence wording for each review command' {
+        foreach ($spec in $script:CommandSpecs) {
+            $content = & $script:ReadContent -Path $spec.Path
+
+            $content | Should -Match '(?ms)^\*\*Review-state persistence\*\*:\s*\r?\n' -Because "$($spec.Name) must document review-state persistence"
+
+            foreach ($pattern in $spec.ExpectedReviewStatePatterns) {
+                $content | Should -Match $pattern -Because "$($spec.Name) must preserve its review-state persistence contract wording"
             }
         }
     }

--- a/.github/scripts/Tests/review-completion-gate.Tests.ps1
+++ b/.github/scripts/Tests/review-completion-gate.Tests.ps1
@@ -148,6 +148,19 @@ last_updated: 2026-04-24T14:00:00Z
 ---
 "@
             }
+            @{
+                Name    = 'non-utc iso timestamp'
+                Content = @"
+---
+issue_id: 417
+review_mode: full
+prosecution_complete: true
+defense_complete: false
+judgment_complete: false
+last_updated: 2026-04-24 14:00:00
+---
+"@
+            }
         )
 
         foreach ($case in $cases) {
@@ -156,6 +169,25 @@ last_updated: 2026-04-24T14:00:00Z
 
             Read-ReviewStateFile -Path $path | Should -BeNullOrEmpty -Because "$($case.Name) must fail closed"
         }
+    }
+
+    It 'fails closed when the review-state file issue_id does not match the requested issue' {
+        $sessionMemoryPath = Join-Path $script:TempRoot 'session-memory-mismatch'
+        New-Item -ItemType Directory -Path $sessionMemoryPath -Force | Out-Null
+        $statePath = Join-Path $sessionMemoryPath 'review-state-417.md'
+
+        @"
+---
+issue_id: 999
+review_mode: full
+prosecution_complete: true
+defense_complete: true
+judgment_complete: true
+last_updated: 2026-04-24T14:00:00Z
+---
+"@ | Set-Content -Path $statePath -Encoding UTF8
+
+        Read-ReviewStateByIssueId -IssueId 417 -SessionMemoryPath $sessionMemoryPath | Should -BeNullOrEmpty
     }
 
     It 'derives missing resume stages in order from a seeded review-state-417 file' {

--- a/.github/scripts/Tests/review-completion-gate.Tests.ps1
+++ b/.github/scripts/Tests/review-completion-gate.Tests.ps1
@@ -1,0 +1,174 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+Describe 'review completion gate contract' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        . (Join-Path $script:RepoRoot 'skills\routing-tables\scripts\routing-tables-core.ps1')
+        . (Join-Path $script:RepoRoot 'skills\routing-tables\scripts\review-state-reader.ps1')
+
+        $script:TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "pester-review-completion-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $script:TempRoot -Force | Out-Null
+
+        $script:WriteReviewState = {
+            param(
+                [string]$Path,
+                [string]$ReviewMode = 'full',
+                [bool]$ProsecutionComplete = $false,
+                [bool]$DefenseComplete = $false,
+                [bool]$JudgmentComplete = $false,
+                [string]$LastUpdated = '2026-04-24T14:00:00Z'
+            )
+
+            @"
+---
+issue_id: 417
+review_mode: $ReviewMode
+prosecution_complete: $($ProsecutionComplete.ToString().ToLowerInvariant())
+defense_complete: $($DefenseComplete.ToString().ToLowerInvariant())
+judgment_complete: $($JudgmentComplete.ToString().ToLowerInvariant())
+last_updated: $LastUpdated
+---
+"@ | Set-Content -Path $Path -Encoding UTF8
+        }
+
+        $script:GetMissingStages = {
+            param([hashtable]$State)
+
+            $missingStages = [System.Collections.Generic.List[string]]::new()
+            foreach ($stage in @('prosecution', 'defense', 'judgment')) {
+                $fieldName = '{0}_complete' -f $stage
+                if (-not ($State.Contains($fieldName) -and [bool]$State[$fieldName])) {
+                    [void]$missingStages.Add($stage)
+                }
+            }
+
+            return @($missingStages)
+        }
+    }
+
+    AfterAll {
+        Remove-Item -Path $script:TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'maps the full review_completion truth table across all eight stage permutations' {
+        $cases = @(
+            @{ Prosecution = $false; Defense = $false; Judgment = $false; Expected = 'incomplete' }
+            @{ Prosecution = $false; Defense = $false; Judgment = $true; Expected = 'incomplete' }
+            @{ Prosecution = $false; Defense = $true; Judgment = $false; Expected = 'incomplete' }
+            @{ Prosecution = $false; Defense = $true; Judgment = $true; Expected = 'incomplete' }
+            @{ Prosecution = $true; Defense = $false; Judgment = $false; Expected = 'incomplete' }
+            @{ Prosecution = $true; Defense = $false; Judgment = $true; Expected = 'incomplete' }
+            @{ Prosecution = $true; Defense = $true; Judgment = $false; Expected = 'incomplete' }
+            @{ Prosecution = $true; Defense = $true; Judgment = $true; Expected = 'complete' }
+        )
+
+        foreach ($case in $cases) {
+            $result = Test-GateCriteria -Gate 'review_completion' -Criteria @{
+                prosecution_complete = $case.Prosecution
+                defense_complete     = $case.Defense
+                judgment_complete    = $case.Judgment
+            }
+
+            $label = '({0},{1},{2})' -f [int]$case.Prosecution, [int]$case.Defense, [int]$case.Judgment
+            $result | Should -Be $case.Expected -Because "review_completion must fail closed for $label unless all three stages are true"
+        }
+    }
+
+    It 'treats review_mode as label-only metadata for a complete state in both full and lite modes' {
+        foreach ($reviewMode in @('full', 'lite')) {
+            $result = Test-GateCriteria -Gate 'review_completion' -Criteria @{
+                prosecution_complete = $true
+                defense_complete     = $true
+                judgment_complete    = $true
+                review_mode          = $reviewMode
+            }
+
+            $result | Should -Be 'complete' -Because "review_mode '$reviewMode' must not affect a complete review state"
+        }
+    }
+
+    It 'treats review_mode as label-only metadata for an incomplete state in both full and lite modes' {
+        foreach ($reviewMode in @('full', 'lite')) {
+            $result = Test-GateCriteria -Gate 'review_completion' -Criteria @{
+                prosecution_complete = $true
+                defense_complete     = $false
+                judgment_complete    = $true
+                review_mode          = $reviewMode
+            }
+
+            $result | Should -Be 'incomplete' -Because "review_mode '$reviewMode' must not mask a missing review stage"
+        }
+    }
+
+    It 'fails closed when the review-state file is missing' {
+        $missingPath = Join-Path $script:TempRoot 'review-state-missing.md'
+
+        Read-ReviewStateFile -Path $missingPath | Should -BeNullOrEmpty
+    }
+
+    It 'fails closed when the review-state file is malformed' {
+        $cases = @(
+            @{
+                Name    = 'missing required field'
+                Content = @"
+---
+issue_id: 417
+review_mode: full
+prosecution_complete: true
+defense_complete: false
+last_updated: 2026-04-24T14:00:00Z
+---
+"@
+            }
+            @{
+                Name    = 'invalid review mode'
+                Content = @"
+---
+issue_id: 417
+review_mode: partial
+prosecution_complete: true
+defense_complete: false
+judgment_complete: false
+last_updated: 2026-04-24T14:00:00Z
+---
+"@
+            }
+            @{
+                Name    = 'invalid boolean value'
+                Content = @"
+---
+issue_id: 417
+review_mode: full
+prosecution_complete: true
+defense_complete: maybe
+judgment_complete: false
+last_updated: 2026-04-24T14:00:00Z
+---
+"@
+            }
+        )
+
+        foreach ($case in $cases) {
+            $path = Join-Path $script:TempRoot ("review-state-malformed-{0}.md" -f ($case.Name -replace '\s+', '-'))
+            $case.Content | Set-Content -Path $path -Encoding UTF8
+
+            Read-ReviewStateFile -Path $path | Should -BeNullOrEmpty -Because "$($case.Name) must fail closed"
+        }
+    }
+
+    It 'derives missing resume stages in order from a seeded review-state-417 file' {
+        $sessionMemoryPath = Join-Path $script:TempRoot 'session-memory'
+        New-Item -ItemType Directory -Path $sessionMemoryPath -Force | Out-Null
+        $statePath = Join-Path $sessionMemoryPath 'review-state-417.md'
+
+        & $script:WriteReviewState -Path $statePath -ReviewMode 'full' -ProsecutionComplete $true -DefenseComplete $false -JudgmentComplete $false
+
+        $state = Read-ReviewStateByIssueId -IssueId 417 -SessionMemoryPath $sessionMemoryPath
+        $missingStages = & $script:GetMissingStages -State $state
+
+        $state | Should -Not -BeNullOrEmpty
+        $missingStages | Should -Be @('defense', 'judgment') -Because 'resume logic must re-enter missing stages in canonical order'
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Orchestra
 
-[![Version](https://img.shields.io/badge/version-v2.3.4-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v2.3.5-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development across specialized agents in GitHub Copilot and Claude Code.

--- a/agents/Code-Conductor.agent.md
+++ b/agents/Code-Conductor.agent.md
@@ -136,6 +136,7 @@ For terminal and validation execution guardrails, load `skills/terminal-hygiene/
 Any future pre-response trigger step runs **before** the Core Workflow, stays outside the numbered workflow list, and does not renumber, replace, or subsume Step 0. Issue Transition remains Step 0 and the first numbered workflow step after any pre-response trigger handling completes.
 
 <!-- markdownlint-disable-next-line MD029 -->
+
 0. **Issue Transition (Step 0, before implementation)**:
    - Cleanup note: The `session-startup` skill (loaded by pipeline-entry agents) detects stale tracking files from merged branches and prompts you at the start of your next conversation — cleanup requires one confirmation. If stale artifacts persist, run `pwsh "skills/session-startup/scripts/post-merge-cleanup.ps1" -IssueNumber {N} -FeatureBranch feature/issue-{N}-description` directly (path is relative to the agent-orchestra plugin or repo clone).
    - Optional planning lane: If scope/acceptance criteria changed or are ambiguous, call Issue-Planner to confirm whether plan updates are needed before execution.
@@ -282,6 +283,7 @@ When the user invokes hub mode for multiple issues at once (e.g., `@code-conduct
 
 4. **Create PR (MANDATORY, review-ready gate)**: After all steps complete (including documentation):
    - **End-to-end check**: Does this PR actually resolve the issue? Not "all steps executed" but "the feature works." Review the full diff against the issue's acceptance criteria.
+   - **Review Completion Gate**: Before any push or PR creation step, load `skills/validation-methodology/references/review-reconciliation.md`, read the current review-state per its lookup rules, build `Criteria` from `prosecution_complete`, `defense_complete`, and `judgment_complete`, and block PR creation on `Test-GateCriteria -Gate review_completion`. On failure, re-enter the missing review stages by default; use `#tool:vscode/askQuestions` only when automatic re-entry is infeasible.
    - **Scope check**: `git diff --name-status main..HEAD` (cross-branch diff — no built-in tool equivalent) must match planned scope (no unrelated files)
    - **Migration completeness check** (migration-type issues only — pattern replacement, rename/move, API migration; see Issue-Planner `<plan_style_guide>` for full definition): Run a final scan for remaining old-form references using `grep_search` with the old-pattern as `query` and an `includePattern` glob matching target files (e.g., `**/*.md`). Confirm result count is 0. Also use `file_search` with the same glob to confirm at least 1 file matches — a 0-match result with 0 files found indicates a misconfigured glob, not a clean repo. If `grep_search` cannot express the required filter (e.g., paths needing PowerShell `Where-Object -notmatch` exclusions), fall back to terminal `Get-ChildItem | Select-String` with documented rationale in an inline comment or annotation. If count is non-zero, fix remaining occurrences before proceeding. Include scan output as validation evidence in the PR body.
    - **Design doc (before pushing)**: Add or update a domain-based design document in `Documents/Design/`. Logic: (1) List existing files in `Documents/Design/`, excluding any `issue-{N}-*.md`-named files from domain-match candidates, (2) read their headings to find domain overlap with the current feature, (3) if exactly one match, delegate an **update** to Doc-Keeper targeting that file, (4) if two or more matches, prompt via `#tool:vscode/askQuestions`: "Multiple design docs match this feature — which should be updated?" and wait for selection before delegating, (5) if no match, delegate **creation** of a new `{domain-slug}.md` file to Doc-Keeper. **Legacy detection (idempotent)**: if `Documents/Design/` contains any `issue-{N}-*.md` pattern files, first run `gh issue list --search "Migrate Documents/Design/ to domain-based files" --state open --json number --jq length` — if the result is `0`, prompt the user via `#tool:vscode/askQuestions`: "Legacy per-issue design docs detected — create a cleanup issue to migrate them to domain-based files?" If confirmed, run `gh issue create --title "Migrate Documents/Design/ to domain-based files" --body "Legacy issue-{N}-*.md design files in Documents/Design/ should be consolidated into domain-based design files per the architecture-rules.md naming convention." --label "priority: medium"`, then continue with the current task. If result is `> 0`, skip creation silently.
@@ -289,7 +291,7 @@ When the user invokes hub mode for multiple issues at once (e.g., `@code-conduct
    - **Validation evidence**: run required validation commands from plan/repo instructions and capture pass results for PR body
    - `git push -u origin {branch-name}`
    - Create PR via `github-pull-request/*` tools or `gh pr create`
-   - PR body MUST include: summary, changed files, validation evidence, migration-scan result (migration-type issues only), CE Gate result, adversarial review score table, prosecution depth summary, pipeline metrics, process gaps found (if any), and `Closes #{issue}`
+   - PR body MUST include: summary, changed files, validation evidence, migration-scan result (migration-type issues only), Review Mode, CE Gate result, adversarial review score table, prosecution depth summary, pipeline metrics, process gaps found (if any), and `Closes #{issue}`
 
 5. **Report Completion**: Summarize work done, link the PR URL, and hand off to user for review
 
@@ -324,10 +326,13 @@ Load `skills/routing-tables/SKILL.md` for the canonical specialist-dispatch mapp
 Load and follow these references:
 
 - `skills/validation-methodology/references/review-reconciliation.md`
+- `skills/validation-methodology/references/review-state-persistence.md`
 - `skills/validation-methodology/references/post-judgment-routing.md`
 - `skills/code-review-intake/references/express-lane.md`
 
-Code-Conductor keeps only the orchestration boundary here: enter the correct review mode, apply express-lane routing only where the contract allows it, route post-judgment and post-fix outcomes, preserve any required calibration side effects, and proceed to the CE Gate in the documented sequence.
+Code-Conductor keeps only the orchestration boundary here: enter the correct review mode, apply express-lane routing only where the contract allows it, route post-judgment and post-fix outcomes, preserve any required calibration side effects, enforce the Review Completion Gate before PR creation, and proceed to the CE Gate in the documented sequence.
+
+If the Review Completion Gate fails, re-enter the missing review stage or stages by default. Escalate with `#tool:vscode/askQuestions` only when the missing-stage rerun is infeasible under the current context.
 
 GitHub-triggered review requests (`github review`, `review github`, `cr review`) still enter through the GitHub intake path described in the loaded references before the generic local review loop runs.
 

--- a/commands/orchestra-review-defend.md
+++ b/commands/orchestra-review-defend.md
@@ -12,6 +12,13 @@ Run only the Code-Critic defense stage against an existing prosecution ledger an
 1. Require a prosecution ledger in the supplied arguments or conversation context. If it is missing, use the `AskUserQuestion` tool.
 2. Gather any review target context that the defense pass needs for counter-evidence verification.
 
+**Review-state persistence**:
+
+1. If the active branch matches `feature/issue-{N}-...`, target `/memories/session/review-state-{N}.md`; otherwise skip persistence silently.
+2. Read any existing state through `skills/routing-tables/scripts/review-state-reader.ps1`. If the file is absent or malformed, fail closed and start from the default contract (`review_mode: full`, all stage booleans `false`).
+3. After defense completes, write the same atomic front matter contract with only `defense_complete: true` forced in this command, preserve any readable stored values for the other fields, and update `last_updated`.
+4. Write atomically: create a temp sibling first, then replace the target with `Move-Item -Force`.
+
 **Handshake preamble** (required for this `code-critic` dispatch, per `skills/subagent-env-handshake/SKILL.md`):
 
 1. Capture live parent-side working-tree state via the `Bash` tool. Run, in order:

--- a/commands/orchestra-review-judge.md
+++ b/commands/orchestra-review-judge.md
@@ -12,6 +12,13 @@ Run only the Code-Review-Response judge stage against existing prosecution and d
 1. Require both a prosecution ledger and a defense report in the supplied arguments or conversation context. If either is missing, use the `AskUserQuestion` tool.
 2. Gather any review target context that the judge needs for independent verification.
 
+**Review-state persistence**:
+
+1. If the active branch matches `feature/issue-{N}-...`, target `/memories/session/review-state-{N}.md`; otherwise skip persistence silently.
+2. Read any existing state through `skills/routing-tables/scripts/review-state-reader.ps1`. If the file is absent or malformed, fail closed and start from the default contract (`review_mode: full`, all stage booleans `false`).
+3. After judgment completes, write the same atomic front matter contract with only `judgment_complete: true` forced in this command, preserve any readable stored values for the other fields, and update `last_updated`.
+4. Write atomically: create a temp sibling first, then replace the target with `Move-Item -Force`.
+
 **Optional handshake context**:
 
 If the ingested ledgers make tree-grounded claims and you want the judge prompt to carry the parent's current repo state, you may construct the same `<!-- subagent-env-handshake v1 -->` block described in `commands/plan.md` and prepend it to the judge prompt. This is optional for `/orchestra:review-judge`: the `code-review-response` Claude shell does not run a Step 0 verifier, so the handshake is contextual only, not a gating precondition.

--- a/commands/orchestra-review-lite.md
+++ b/commands/orchestra-review-lite.md
@@ -12,6 +12,12 @@ Run the compact review pipeline: one all-perspectives prosecution pass, then def
 1. Resolve the review target from the arguments or the active PR context. If neither is available, use the `AskUserQuestion` tool.
 2. Gather the diff, linked issue or plan context, and any prior review ledger that should travel with the prosecution prompt.
 
+**Review-state persistence**:
+
+1. If the active branch matches `feature/issue-{N}-...`, target `/memories/session/review-state-{N}.md`; otherwise skip persistence silently.
+2. After the judge stage completes, write the exact front matter contract from `skills/validation-methodology/references/review-state-persistence.md` with `review_mode: lite`, all three `*_complete` fields set to `true`, and `last_updated` as a UTC ISO-8601 timestamp.
+3. Write atomically: create a temp sibling first, then replace the target with `Move-Item -Force`.
+
 **Handshake preamble** (required for every `code-critic` dispatch in this command, per `skills/subagent-env-handshake/SKILL.md`):
 
 1. Capture live parent-side working-tree state via the `Bash` tool. Run, in order:

--- a/commands/orchestra-review-prosecute.md
+++ b/commands/orchestra-review-prosecute.md
@@ -12,6 +12,13 @@ Run only the Code-Critic prosecution stage and return the resulting prosecution 
 1. Resolve the review target from the arguments or the active PR context. If neither is available, use the `AskUserQuestion` tool.
 2. Gather the diff, linked issue or plan context, and any prior review notes that should travel with the prosecution prompt.
 
+**Review-state persistence**:
+
+1. If the active branch matches `feature/issue-{N}-...`, target `/memories/session/review-state-{N}.md`; otherwise skip persistence silently.
+2. Read any existing state through `skills/routing-tables/scripts/review-state-reader.ps1`. If the file is absent or malformed, fail closed and start from the default contract (`review_mode: full`, all stage booleans `false`).
+3. After prosecution completes, write the same atomic front matter contract with only `prosecution_complete: true` forced in this command, preserve any readable stored values for the other fields, and update `last_updated`.
+4. Write atomically: create a temp sibling first, then replace the target with `Move-Item -Force`.
+
 **Handshake preamble** (required for this `code-critic` dispatch, per `skills/subagent-env-handshake/SKILL.md`):
 
 1. Capture live parent-side working-tree state via the `Bash` tool. Run, in order:

--- a/commands/orchestra-review.md
+++ b/commands/orchestra-review.md
@@ -12,6 +12,12 @@ Run the standard review pipeline: Code-Critic prosecution -> Code-Critic defense
 1. Resolve the review target from the arguments or the active PR context. If neither is available, use the `AskUserQuestion` tool.
 2. Gather the diff, linked issue or plan context, and any prior review ledger that should travel with the prosecution prompt.
 
+**Review-state persistence**:
+
+1. If the active branch matches `feature/issue-{N}-...`, target `/memories/session/review-state-{N}.md`; otherwise skip persistence silently.
+2. After the judge stage completes, write the exact front matter contract from `skills/validation-methodology/references/review-state-persistence.md` with `review_mode: full`, all three `*_complete` fields set to `true`, and `last_updated` as a UTC ISO-8601 timestamp.
+3. Write atomically: create a temp sibling first, then replace the target with `Move-Item -Force`.
+
 **Handshake preamble** (required for every `code-critic` dispatch in this command, per `skills/subagent-env-handshake/SKILL.md`):
 
 1. Capture live parent-side working-tree state via the `Bash` tool. Run, in order:

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "Multi-agent workflow system for GitHub Copilot. Pipeline-based agent orchestration: Issue → Design → Plan → Implement → Review → PR.",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "author": {
     "name": "Grimblaz"
   },

--- a/skills/calibration-pipeline/references/metrics-schema.md
+++ b/skills/calibration-pipeline/references/metrics-schema.md
@@ -12,7 +12,12 @@ Always include a `## Pipeline Metrics` section in the PR body with a hidden HTML
 ## Pipeline Metrics
 
 <!-- pipeline-metrics
-metrics_version: 2
+metrics_version: 3
+review_mode: {full|lite}
+stages_run:
+  prosecution: {true|false}
+  defense: {true|false}
+  judgment: {true|false}
 prosecution_findings: {N}
 pass_1_findings: {N}
 pass_2_findings: {N}
@@ -76,7 +81,7 @@ findings:
 
 ## Top-Level Field Reference
 
-`0` for numeric fields when the stage ran but found nothing. `n/a` for categorical fields when the stage was skipped entirely (e.g., `ce_gate_result: not-applicable`, `ce_gate_intent: n/a` when `ce_gate: false`). `ce_gate_defects_found: n/a` when the CE Gate did not run (`ce_gate: false` or `⏭️ CE Gate not applicable`). For proxy prosecution (GitHub review intake): `pass_1_findings`, `pass_2_findings`, `pass_3_findings` → `n/a` (3-pass structure replaced by proxy pass); route total findings count to `prosecution_findings` only. `postfix_*` numeric fields default to `0` when post-fix review was triggered but found nothing; `n/a` when not triggered (`postfix_triggered: false`). Set `postfix_triggered: true` when trigger conditions are met and post-fix prosecution executes (regardless of whether any findings were accepted). New optimization fields: `express_lane_count`, `batch_dispatch_calls`, `batch_dispatch_findings`, `rate_limit_retries` default to `0` when the stage ran; `n/a` when the relevant phase was not active for the current review mode (e.g., `express_lane_count: n/a` for proxy, CE, or design review; `batch_dispatch_calls`/`batch_dispatch_findings: n/a` only for review modes where specialist dispatch is not active — such as standalone design-review flows that stop after prosecution). `postfix_passes` defaults to `n/a` when post-fix review was not triggered; `1` or `2` to reflect actual passes run. `rate_limit_deferred` defaults to `false`. `prosecution_depth_light` and `prosecution_depth_skip` default to empty lists `[]` when no categories are at those depths. `prosecution_depth_override` defaults to `false`. `prosecution_depth_reactivations` defaults to `0` (no re-activation events written via `write-calibration-entry.ps1 -ReactivationEventJson` during this PR; incremented by the Post-Judgment and CE/Proxy re-activation detection steps).
+`0` for numeric fields when the stage ran but found nothing. `n/a` for categorical fields when the stage was skipped entirely (e.g., `ce_gate_result: not-applicable`, `ce_gate_intent: n/a` when `ce_gate: false`). `review_mode` defaults to `full` for older metrics blocks that predate `metrics_version: 3`. `stages_run` defaults to all `true` for pre-v3 metrics because older PR-body metrics only represented completed review pipelines. `ce_gate_defects_found: n/a` when the CE Gate did not run (`ce_gate: false` or `⏭️ CE Gate not applicable`). For proxy prosecution (GitHub review intake): `pass_1_findings`, `pass_2_findings`, `pass_3_findings` → `n/a` (3-pass structure replaced by proxy pass); route total findings count to `prosecution_findings` only. `postfix_*` numeric fields default to `0` when post-fix review was triggered but found nothing; `n/a` when not triggered (`postfix_triggered: false`). Set `postfix_triggered: true` when trigger conditions are met and post-fix prosecution executes (regardless of whether any findings were accepted). New optimization fields: `express_lane_count`, `batch_dispatch_calls`, `batch_dispatch_findings`, `rate_limit_retries` default to `0` when the stage ran; `n/a` when the relevant phase was not active for the current review mode (e.g., `express_lane_count: n/a` for proxy, CE, or design review; `batch_dispatch_calls`/`batch_dispatch_findings: n/a` only for review modes where specialist dispatch is not active — such as standalone design-review flows that stop after prosecution). `postfix_passes` defaults to `n/a` when post-fix review was not triggered; `1` or `2` to reflect actual passes run. `rate_limit_deferred` defaults to `false`. `prosecution_depth_light` and `prosecution_depth_skip` default to empty lists `[]` when no categories are at those depths. `prosecution_depth_override` defaults to `false`. `prosecution_depth_reactivations` defaults to `0` (no re-activation events written via `write-calibration-entry.ps1 -ReactivationEventJson` during this PR; incremented by the Post-Judgment and CE/Proxy re-activation detection steps).
 
 ### Calibration Data Write (VS Code Copilot only)
 

--- a/skills/customer-experience/references/orchestration-protocol.md
+++ b/skills/customer-experience/references/orchestration-protocol.md
@@ -78,6 +78,26 @@ Read the `Class` value (`[auto]` or `[manual]`) from the plan's `[CE GATE]` step
 | S1  | Functional | [auto]   | ✅ Passed | {brief description} | Runner |
 | S2  | Intent     | [manual] | ✅ Passed | {brief description} | EO     |
 
+### PR Body Review Mode
+
+Always include a visible `## Review Mode` section in the PR body.
+
+Use this text for the standard path:
+
+```markdown
+## Review Mode
+
+Full review pipeline completed: 3 prosecution passes, 1 defense pass, 1 judge pass.
+```
+
+Use this text for the abbreviated path:
+
+```markdown
+## Review Mode
+
+Lite review pipeline completed via `/orchestra:review-lite`: 1 compact prosecution pass, 1 defense pass, 1 judge pass.
+```
+
 ### PR Body Adversarial Review Scores
 
 Always include the adversarial review score summary table from the judge's score summary output:
@@ -91,6 +111,8 @@ Always include the adversarial review score summary table from the judge's score
 | CE Review       | {pts} pts ({N} sustained) | {pts} pts ({N} disproved, {N} rejected) | {N} ruling(s) |
 | Post-fix Review | {pts} pts ({N} sustained) | {pts} pts ({N} disproved, {N} rejected) | {N} ruling(s) |
 ```
+
+For lite review mode, replace the `Code Review` row label with `Code Review (lite)`. The CE Review and Post-fix Review row labels stay unchanged.
 
 If a stage did not run (e.g., CE Gate not applicable, post-fix review not triggered), note it as `⏭️ N/A`.
 

--- a/skills/routing-tables/SKILL.md
+++ b/skills/routing-tables/SKILL.md
@@ -23,10 +23,11 @@ This skill is the human-readable companion to the routing data in `assets/routin
 - `skill_mapping`: delegation guidance from Code-Conductor's Skill Mapping table; this is a reference list, not a strict deterministic router
 - `enums`: canonical current enum values used by review and routing outputs
 
-`assets/gate-criteria.json` contains three top-level sections:
+`assets/gate-criteria.json` contains four top-level sections:
 
 - `scope_classification`: abbreviated-vs-full pipeline gate criteria and tier table
 - `express_lane`: low-risk fix gate criteria for routing findings directly to a specialist
+- `review_completion`: pre-PR review-completion gate that requires prosecution, defense, and judgment completion to all be recorded as true for the current review cycle
 - `post_fix_trigger`: conditions that require post-fix targeted prosecution after accepted review fixes
 
 ## Specialist Dispatch
@@ -73,11 +74,13 @@ Scope classification is an AND gate: all five abbreviated-tier criteria must hol
 
 Express lane is also an AND gate. A finding must be low severity, strictly mechanical, non-logic-changing, test-neutral, backward-compatible with respect to stored IDs and schema, and limited to one file. It only applies to main review and post-fix review routing, and Tier 1 re-validation is still required after the fix lands.
 
+Review completion is an AND gate. It fails closed unless the current review cycle records all three stage booleans as true: `prosecution_complete`, `defense_complete`, and `judgment_complete`. `review_mode` is tracked alongside the state as label metadata, but it is not part of the gate criteria.
+
 Post-fix targeted prosecution uses OR semantics for its trigger conditions: one accepted critical or high finding is enough, and any accepted fix that modifies control flow is also enough. If no findings were accepted and applied, the post-fix review is skipped.
 
 ## Interpretation Rules
 
-Use exact current values from the JSON assets when a mode, enum, or routing value needs to be preserved across prompts or scripts. Match review markers literally. For specialist dispatch file routing, use explicit `file_patterns` keys instead of parsing prose. Treat `skill_mapping` as explanatory metadata, not a replacement for human judgment. Treat `scope_classification` and `express_lane` as all-criteria gates, while `post_fix_trigger` activates when any trigger condition is met.
+Use exact current values from the JSON assets when a mode, enum, or routing value needs to be preserved across prompts or scripts. Match review markers literally. For specialist dispatch file routing, use explicit `file_patterns` keys instead of parsing prose. Treat `skill_mapping` as explanatory metadata, not a replacement for human judgment. Treat `scope_classification`, `express_lane`, and `review_completion` as all-criteria gates, while `post_fix_trigger` activates when any trigger condition is met.
 
 When an entry includes prose qualifiers, preserve them rather than compressing them away. The goal of these files is stable extraction of current rules, not reinterpretation of the orchestration policy.
 

--- a/skills/routing-tables/assets/gate-criteria.json
+++ b/skills/routing-tables/assets/gate-criteria.json
@@ -98,6 +98,27 @@
     ],
     "revalidation_required": "Tier 1 re-validation required after the specialist applies an express-lane fix."
   },
+  "review_completion": {
+    "source": "agents/Code-Conductor.agent.md",
+    "all_must_hold": true,
+    "outcome_if_all_true": "complete",
+    "default_outcome": "incomplete",
+    "criteria": [
+      {
+        "id": "prosecution_complete",
+        "text": "Prosecution stage completion is recorded and true for the current review cycle"
+      },
+      {
+        "id": "defense_complete",
+        "text": "Defense stage completion is recorded and true for the current review cycle"
+      },
+      {
+        "id": "judgment_complete",
+        "text": "Judgment stage completion is recorded and true for the current review cycle"
+      }
+    ],
+    "default_rule": "Fail closed when any required stage is absent, unset, or false; only a fully recorded prosecution, defense, and judgment sequence yields complete."
+  },
   "post_fix_trigger": {
     "source": "agents/Code-Conductor.agent.md",
     "recursion_guard": "This step is never triggered by another post-fix prosecution - only by a main review cycle (code review or GitHub intake proxy prosecution).",

--- a/skills/routing-tables/scripts/review-state-reader.ps1
+++ b/skills/routing-tables/scripts/review-state-reader.ps1
@@ -82,8 +82,18 @@ function Read-ReviewStateFile {
         return $null
     }
 
-    $lastUpdated = [datetime]::MinValue
-    if (-not [datetime]::TryParse([string]$state.last_updated, [ref]$lastUpdated)) {
+    $lastUpdated = [datetimeoffset]::MinValue
+    $timestampStyles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+    $lastUpdatedText = [string]$state.last_updated
+    if ($lastUpdatedText -notmatch '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,7})?(?:Z|\+00:00)$') {
+        return $null
+    }
+
+    if (-not [datetimeoffset]::TryParse($lastUpdatedText, [System.Globalization.CultureInfo]::InvariantCulture, $timestampStyles, [ref]$lastUpdated)) {
+        return $null
+    }
+
+    if ($lastUpdated.Offset -ne [timespan]::Zero) {
         return $null
     }
 
@@ -110,5 +120,10 @@ function Read-ReviewStateByIssueId {
         return $null
     }
 
-    return Read-ReviewStateFile -Path $path
+    $state = Read-ReviewStateFile -Path $path
+    if ($null -eq $state -or $state.issue_id -ne $IssueId) {
+        return $null
+    }
+
+    return $state
 }

--- a/skills/routing-tables/scripts/review-state-reader.ps1
+++ b/skills/routing-tables/scripts/review-state-reader.ps1
@@ -1,0 +1,114 @@
+#Requires -Version 7.0
+
+function Get-ReviewStateFilePath {
+    param(
+        [Parameter(Mandatory)]
+        [int]$IssueId,
+
+        [string]$SessionMemoryPath = '/memories/session'
+    )
+
+    if ($IssueId -lt 1 -or [string]::IsNullOrWhiteSpace($SessionMemoryPath)) {
+        return $null
+    }
+
+    return Join-Path -Path $SessionMemoryPath -ChildPath ("review-state-{0}.md" -f $IssueId)
+}
+
+function Read-ReviewStateFile {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+
+    $content = Get-Content -LiteralPath $Path -Raw -ErrorAction SilentlyContinue
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        return $null
+    }
+
+    $frontMatterMatch = [regex]::Match($content, '^(?:---\r?\n)(.*?)(?:\r?\n---)(?:\r?\n|$)', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+    if (-not $frontMatterMatch.Success) {
+        return $null
+    }
+
+    $requiredFields = @(
+        'issue_id',
+        'review_mode',
+        'prosecution_complete',
+        'defense_complete',
+        'judgment_complete',
+        'last_updated'
+    )
+
+    $state = [ordered]@{}
+    foreach ($line in ($frontMatterMatch.Groups[1].Value -split "`r?`n")) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $parts = $line -split ':', 2
+        if ($parts.Count -ne 2) {
+            return $null
+        }
+
+        $state[$parts[0].Trim()] = $parts[1].Trim()
+    }
+
+    foreach ($field in $requiredFields) {
+        if (-not $state.Contains($field) -or [string]::IsNullOrWhiteSpace([string]$state[$field])) {
+            return $null
+        }
+    }
+
+    $issueId = 0
+    if (-not [int]::TryParse([string]$state.issue_id, [ref]$issueId)) {
+        return $null
+    }
+
+    $parsedBooleans = @{}
+    foreach ($field in @('prosecution_complete', 'defense_complete', 'judgment_complete')) {
+        switch ([string]$state[$field]) {
+            'true' { $parsedBooleans[$field] = $true }
+            'false' { $parsedBooleans[$field] = $false }
+            default { return $null }
+        }
+    }
+
+    if ([string]$state.review_mode -notin @('full', 'lite')) {
+        return $null
+    }
+
+    $lastUpdated = [datetime]::MinValue
+    if (-not [datetime]::TryParse([string]$state.last_updated, [ref]$lastUpdated)) {
+        return $null
+    }
+
+    return [ordered]@{
+        issue_id             = $issueId
+        review_mode          = [string]$state.review_mode
+        prosecution_complete = $parsedBooleans.prosecution_complete
+        defense_complete     = $parsedBooleans.defense_complete
+        judgment_complete    = $parsedBooleans.judgment_complete
+        last_updated         = [string]$state.last_updated
+    }
+}
+
+function Read-ReviewStateByIssueId {
+    param(
+        [Parameter(Mandatory)]
+        [int]$IssueId,
+
+        [string]$SessionMemoryPath = '/memories/session'
+    )
+
+    $path = Get-ReviewStateFilePath -IssueId $IssueId -SessionMemoryPath $SessionMemoryPath
+    if ([string]::IsNullOrWhiteSpace($path)) {
+        return $null
+    }
+
+    return Read-ReviewStateFile -Path $path
+}

--- a/skills/validation-methodology/references/review-reconciliation.md
+++ b/skills/validation-methodology/references/review-reconciliation.md
@@ -2,7 +2,7 @@
 
 This reference owns the reusable review-reconciliation mechanics extracted from Code-Conductor.
 
-See [post-judgment-routing.md](post-judgment-routing.md) for the paired post-judgment re-activation summary and routing index, and [../../code-review-intake/references/express-lane.md](../../code-review-intake/references/express-lane.md) for the canonical R6 express-lane gate.
+See [post-judgment-routing.md](post-judgment-routing.md) for the paired post-judgment re-activation summary and routing index, [review-state-persistence.md](review-state-persistence.md) for the pre-PR review-state contract, and [../../code-review-intake/references/express-lane.md](../../code-review-intake/references/express-lane.md) for the canonical R6 express-lane gate.
 
 ## Review Reconciliation Loop
 
@@ -82,6 +82,17 @@ After the merged ledger is finalized:
 3. Do not implement accepted fixes until the prosecution, defense, and judgment sequence completes.
 
 If the owning agent supports an express lane for strictly mechanical low-severity findings, partition those findings only after the merged prosecution ledger is available. The owning agent still owns whether express lane exists and how routed findings are dispatched. See [../../code-review-intake/references/express-lane.md](../../code-review-intake/references/express-lane.md).
+
+### Review Completion Gate
+
+Fire this gate immediately before PR creation and on any post-review resume path that intends to continue toward PR creation.
+
+- Pre-PR lookup reads `/memories/session/review-state-{ID}.md` only.
+- Post-PR resume lookup may read, in order: the durable review comment, `<!-- pipeline-metrics -->`, then session memory.
+- The caller owns criteria construction for `Test-GateCriteria -Gate review_completion`. Build `Criteria` from the three stage booleans only. `review_mode` is label-only metadata and is not part of the criteria.
+- The caller also owns the missing-stage list. Build it from the `false` stage booleans in stage order: prosecution, defense, judgment.
+- On failure, emit the exact string `❌ Review pipeline incomplete — {missing stages}`.
+- Default recovery is automatic re-entry into the missing stage or stages. Use `askQuestions` only when automatic re-entry is infeasible because required context, ledgers, or user-choice input is missing.
 
 ### GitHub Review Intake & Judgment
 

--- a/skills/validation-methodology/references/review-state-persistence.md
+++ b/skills/validation-methodology/references/review-state-persistence.md
@@ -1,0 +1,36 @@
+# Review-State Persistence
+
+This reference owns the pre-PR review-state persistence contract extracted from Code-Conductor.
+
+## Session Memory Location
+
+When the active branch matches `feature/issue-{N}-...`, persist review state to `/memories/session/review-state-{N}.md`. If no branch match exists, silently skip persistence.
+
+Pre-PR review-state lookup reads session memory only. Post-PR resume lookup may instead use the durable review comment, then `<!-- pipeline-metrics -->`, then session memory.
+
+## File Shape
+
+Persist the exact YAML front matter fields below in this order:
+
+```markdown
+---
+issue_id: {N}
+review_mode: {full|lite}
+prosecution_complete: {true|false}
+defense_complete: {true|false}
+judgment_complete: {true|false}
+last_updated: {UTC ISO-8601 timestamp}
+---
+```
+
+## Write Contract
+
+- Composite commands `/orchestra:review` and `/orchestra:review-lite` write complete review-state after the judge stage completes.
+- Individual commands `/orchestra:review-prosecute`, `/orchestra:review-defend`, and `/orchestra:review-judge` write only their own stage boolean while preserving the other stored booleans when a readable state file already exists.
+- When an individual command creates the file from scratch, default missing booleans to `false` and `review_mode` to `full`.
+- `review_mode` is label-only metadata. It does not participate in `Test-GateCriteria` criteria construction.
+- All writes are atomic: write a temp sibling first, then replace the target with `Move-Item -Force`.
+
+## Reader Contract
+
+Use `skills/routing-tables/scripts/review-state-reader.ps1` for file reads. The reader fails closed by returning `$null` when the file is absent or malformed.


### PR DESCRIPTION
## Summary

- add a fail-closed `review_completion` gate and wire its required Code-Conductor enforcement wording into the review-to-PR flow
- define review-state persistence for full, lite, and per-stage review commands, plus a reusable PowerShell reader for `review-state-{issue}.md`
- extend the PR-body contract docs for `Review Mode` and `metrics_version: 3`, then lock the new behavior with focused Pester coverage

## Changed Files

- `agents/Code-Conductor.agent.md`
- `commands/orchestra-review.md`
- `commands/orchestra-review-lite.md`
- `commands/orchestra-review-prosecute.md`
- `commands/orchestra-review-defend.md`
- `commands/orchestra-review-judge.md`
- `skills/routing-tables/assets/gate-criteria.json`
- `skills/routing-tables/SKILL.md`
- `skills/routing-tables/scripts/review-state-reader.ps1`
- `skills/validation-methodology/references/review-reconciliation.md`
- `skills/validation-methodology/references/review-state-persistence.md`
- `skills/calibration-pipeline/references/metrics-schema.md`
- `skills/customer-experience/references/orchestration-protocol.md`
- `.github/scripts/Tests/review-completion-gate.Tests.ps1`
- `.github/scripts/Tests/orchestra-review-commands.Tests.ps1`
- version bump files: `plugin.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.github/plugin/marketplace.json`, `README.md`

## Validation Evidence

- `pwsh -NoProfile -NonInteractive -Command 'Invoke-Pester .github/scripts/Tests/review-completion-gate.Tests.ps1,.github/scripts/Tests/orchestra-review-commands.Tests.ps1,.github/scripts/Tests/routing-tables.Tests.ps1 -Output Minimal'`
  - Passed: 25, Failed: 0
- `pwsh -NoProfile -NonInteractive -Command 'Select-String -Path @("plugin.json", ".claude-plugin/plugin.json", ".github/plugin/marketplace.json", ".claude-plugin/marketplace.json", "README.md") -Pattern "2\.3\.5"'`
  - Verified patch bump landed across the version-bearing files
- Repo-wide `markdownlint-cli2 --fix "**/*.md"` / `.github/scripts/quick-validate.ps1`
  - Not clean due pre-existing markdownlint debt outside this issue slice; issue-417 focused tests remained green

## Review Mode

Manual implementation session. This PR adds the `Review Mode` and review-completion contract for future Code-Conductor-generated PRs; this manually-authored PR body is not itself the output of `/orchestra:review` or `/orchestra:review-lite`.

## CE Gate Result

⏭️ CE Gate not applicable — this change is orchestration/docs/tests only and does not alter a customer runtime surface.

## Adversarial Review Scores

| Stage | Prosecution | Defense | Judgment |
| --- | --- | --- | --- |
| Code Review | ⏭️ N/A | ⏭️ N/A | ⏭️ N/A |
| CE Review | ⏭️ N/A | ⏭️ N/A | ⏭️ N/A |
| Post-fix Review | ⏭️ N/A | ⏭️ N/A | ⏭️ N/A |

## Prosecution Depth Summary

⏭️ N/A — no adversarial prosecution pass was executed for this manually-authored implementation PR.

## Pipeline Metrics

Not emitted for this manually-authored PR body. Issue 417 implements the required `metrics_version: 3`, `review_mode`, and `stages_run` contract for future Code-Conductor-generated PRs.

## Process Gaps Found

- repo-wide markdownlint currently reports unrelated baseline violations, so the broad markdown/quick-validate gate could not complete cleanly during this issue-417 implementation session

Closes #417

## Summary by Sourcery

Enforce a fail-closed review completion gate before PR creation, backed by persisted per-issue review state and updated metrics/schema contracts.

New Features:
- Introduce a review completion routing gate that requires prosecution, defense, and judgment stages to be recorded as complete before allowing PR creation.
- Add a reusable review-state reader script and YAML front-matter contract for per-issue review-state persistence across full, lite, and per-stage review commands.
- Extend PR body structure with a mandatory Review Mode section and new metrics_version: 3 fields capturing review mode and stages run.

Enhancements:
- Document and wire Code-Conductor orchestration steps to consult review-state and enforce the review completion gate as part of the pre-PR workflow.
- Clarify orchestration and routing-table documentation to treat review_completion as an AND gate and reference the new review-state persistence contract.

Build:
- Bump plugin and documentation version metadata to v2.3.5 across marketplace and plugin manifests and the README badge.

Documentation:
- Add and update reference docs describing review-state persistence, review completion gating, PR Review Mode wording, and updated pipeline metrics schema.

Tests:
- Add focused Pester tests to lock the review completion gate truth table, review-state reader behavior, and review command documentation for review-state persistence.
- Extend existing orchestra-review command tests to validate the new review-state persistence wording.

Chores:
- Introduce a shared PowerShell helper for safely reading review-state files from session memory.