### PR TITLE
feat(frame): add symmetry and predicate frame validator

### DIFF
--- a/.github/scripts/Tests/frame-predicate.Tests.ps1
+++ b/.github/scripts/Tests/frame-predicate.Tests.ps1
@@ -188,6 +188,29 @@ Describe 'ConvertTo-FVPredicate' -Tag 'unit' {
             $values | Should -Contain 'metadata.priority'
         }
 
+        It 'accepts documented parse-only frame DSL predicate <Predicate>' -ForEach @(
+            @{ Predicate = 'scope.isReReview'; ExpectedKinds = @('Identifier'); ExpectedValues = @('scope.isReReview') }
+            @{ Predicate = "changeset.touches('src/ui/**')"; ExpectedKinds = @('Call', 'Literal'); ExpectedValues = @('changeset.touches', 'src/ui/**') }
+            @{ Predicate = 'not changeset.touchesSource()'; ExpectedKinds = @('Not', 'Call'); ExpectedValues = @('changeset.touchesSource') }
+            @{ Predicate = "changeset.touches('docs/**') and changeset.behaviorChanged()"; ExpectedKinds = @('Logical', 'Call'); ExpectedValues = @('AND', 'changeset.touches', 'docs/**', 'changeset.behaviorChanged') }
+        ) {
+            param($Predicate, $ExpectedKinds, $ExpectedValues)
+
+            $ast = ConvertTo-FVPredicate -Predicate $Predicate
+
+            & $script:AssertAst -Result $ast
+            $kinds = & $script:GetAstKinds -Node $ast
+            $values = & $script:GetAstScalarValues -Node $ast
+
+            foreach ($expectedKind in $ExpectedKinds) {
+                $kinds | Should -Contain $expectedKind
+            }
+
+            foreach ($expectedValue in $ExpectedValues) {
+                $values | Should -Contain $expectedValue
+            }
+        }
+
         It 'does not perform semantic field validation in parse-only mode' {
             $ast = ConvertTo-FVPredicate -Predicate "unknown.future_field == 'anything'"
 
@@ -197,6 +220,17 @@ Describe 'ConvertTo-FVPredicate' -Tag 'unit' {
 
             $kinds | Should -Contain 'Comparison'
             $values | Should -Contain 'unknown.future_field'
+        }
+
+        It 'does not perform semantic function validation in parse-only mode' {
+            $ast = ConvertTo-FVPredicate -Predicate "unknown.futureFunction('anything')"
+
+            & $script:AssertAst -Result $ast
+            $kinds = & $script:GetAstKinds -Node $ast
+            $values = & $script:GetAstScalarValues -Node $ast
+
+            $kinds | Should -Contain 'Call'
+            $values | Should -Contain 'unknown.futureFunction'
         }
 
         It 'accepts <LiteralType> literals' -ForEach @(

--- a/.github/scripts/Tests/frame-predicate.Tests.ps1
+++ b/.github/scripts/Tests/frame-predicate.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'ConvertTo-FVPredicate' -Tag 'unit' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:LibFile = Join-Path $script:RepoRoot '.github\scripts\lib\frame-predicate-core.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot '.github/scripts/lib/frame-predicate-core.ps1'
         . $script:LibFile
 
         $script:GetAstKinds = {
@@ -186,6 +186,17 @@ Describe 'ConvertTo-FVPredicate' -Tag 'unit' {
             $kinds | Should -Contain 'Comparison'
             $values | Should -Contain 'adapter.kind'
             $values | Should -Contain 'metadata.priority'
+        }
+
+        It 'does not perform semantic field validation in parse-only mode' {
+            $ast = ConvertTo-FVPredicate -Predicate "unknown.future_field == 'anything'"
+
+            & $script:AssertAst -Result $ast
+            $kinds = & $script:GetAstKinds -Node $ast
+            $values = & $script:GetAstScalarValues -Node $ast
+
+            $kinds | Should -Contain 'Comparison'
+            $values | Should -Contain 'unknown.future_field'
         }
 
         It 'accepts <LiteralType> literals' -ForEach @(

--- a/.github/scripts/Tests/frame-predicate.Tests.ps1
+++ b/.github/scripts/Tests/frame-predicate.Tests.ps1
@@ -1,0 +1,257 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Pester 5 tests for frame predicate parsing.
+
+.DESCRIPTION
+    Contract under test:
+      ConvertTo-FVPredicate parses well-formed frame predicates into an AST
+      and returns parse error objects with Position and Message for malformed
+      predicates. These tests verify parse shape only; semantic validation such
+      as field existence, literal allowed values, and type consistency belongs
+      to issue #428.
+#>
+
+Describe 'ConvertTo-FVPredicate' -Tag 'unit' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:LibFile = Join-Path $script:RepoRoot '.github\scripts\lib\frame-predicate-core.ps1'
+        . $script:LibFile
+
+        $script:GetAstKinds = {
+            param($Node)
+
+            $kinds = [System.Collections.Generic.List[string]]::new()
+            $visit = {
+                param($Value)
+
+                if ($null -eq $Value) {
+                    return
+                }
+
+                if ($Value -is [string] -or $Value -is [ValueType]) {
+                    return
+                }
+
+                if ($Value -is [System.Collections.IEnumerable]) {
+                    foreach ($item in $Value) {
+                        & $visit $item
+                    }
+                    return
+                }
+
+                $kindProperty = $Value.PSObject.Properties['Kind']
+                if ($null -ne $kindProperty) {
+                    $kinds.Add([string]$kindProperty.Value)
+                }
+
+                foreach ($property in @($Value.PSObject.Properties)) {
+                    if ($property.Name -ne 'Kind') {
+                        & $visit $property.Value
+                    }
+                }
+            }
+
+            & $visit $Node
+            return $kinds.ToArray()
+        }
+
+        $script:GetAstScalarValues = {
+            param($Node)
+
+            $values = [System.Collections.Generic.List[object]]::new()
+            $visit = {
+                param($Value)
+
+                if ($null -eq $Value) {
+                    return
+                }
+
+                if ($Value -is [string] -or $Value -is [ValueType]) {
+                    $values.Add($Value)
+                    return
+                }
+
+                if ($Value -is [System.Collections.IEnumerable]) {
+                    foreach ($item in $Value) {
+                        & $visit $item
+                    }
+                    return
+                }
+
+                foreach ($property in @($Value.PSObject.Properties)) {
+                    & $visit $property.Value
+                }
+            }
+
+            & $visit $Node
+            return $values.ToArray()
+        }
+
+        $script:AssertAst = {
+            param($Result)
+
+            $Result | Should -Not -BeNullOrEmpty
+            $Result.PSObject.Properties['Kind'] | Should -Not -BeNullOrEmpty
+            $Result.Kind | Should -Not -Be 'ParseError'
+        }
+
+        $script:AssertParseError = {
+            param(
+                $Result,
+                [int]$Position,
+                [string]$MessagePattern
+            )
+
+            $Result | Should -Not -BeNullOrEmpty
+            $Result.PSObject.Properties['Kind'] | Should -Not -BeNullOrEmpty
+            $Result.PSObject.Properties['Position'] | Should -Not -BeNullOrEmpty
+            $Result.PSObject.Properties['Message'] | Should -Not -BeNullOrEmpty
+            $Result.Kind | Should -Be 'ParseError'
+            $Result.Position | Should -Be $Position
+            $Result.Message | Should -Not -BeNullOrEmpty
+            $Result.Message | Should -Match $MessagePattern
+        }
+    }
+
+    It 'ships the in-process frame predicate parser library' {
+        $script:LibFile | Should -Exist
+        Get-Command ConvertTo-FVPredicate -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+
+    Context 'well-formed predicates' {
+
+        It 'returns a comparison AST for comparator <Operator>' -ForEach @(
+            @{ Predicate = "port == 'experience'"; Operator = '==' }
+            @{ Predicate = "port != 'review'"; Operator = '!=' }
+            @{ Predicate = 'score < 3'; Operator = '<' }
+            @{ Predicate = 'score > 1'; Operator = '>' }
+            @{ Predicate = 'score <= 10'; Operator = '<=' }
+            @{ Predicate = 'score >= 0'; Operator = '>=' }
+            @{ Predicate = "port in ['experience', 'review']"; Operator = 'in' }
+        ) {
+            param($Predicate, $Operator)
+
+            $ast = ConvertTo-FVPredicate -Predicate $Predicate
+
+            & $script:AssertAst -Result $ast
+            $kinds = & $script:GetAstKinds -Node $ast
+            $values = & $script:GetAstScalarValues -Node $ast
+
+            $kinds | Should -Contain 'Comparison'
+            $kinds | Should -Contain 'Identifier'
+            $kinds | Should -Contain 'Literal'
+            $values | Should -Contain $Operator
+        }
+
+        It 'returns a logical AST for <Operator> predicates' -ForEach @(
+            @{ Predicate = "port == 'experience' AND status == 'stable'"; Operator = 'AND' }
+            @{ Predicate = "port == 'experience' OR status == 'experimental'"; Operator = 'OR' }
+        ) {
+            param($Predicate, $Operator)
+
+            $ast = ConvertTo-FVPredicate -Predicate $Predicate
+
+            & $script:AssertAst -Result $ast
+            $kinds = & $script:GetAstKinds -Node $ast
+            $values = & $script:GetAstScalarValues -Node $ast
+
+            $kinds | Should -Contain 'Logical'
+            $kinds | Should -Contain 'Comparison'
+            $values | Should -Contain $Operator
+        }
+
+        It 'returns a NOT AST when a predicate negates a comparison' {
+            $ast = ConvertTo-FVPredicate -Predicate "NOT port == 'deprecated'"
+
+            & $script:AssertAst -Result $ast
+            $kinds = & $script:GetAstKinds -Node $ast
+
+            $kinds | Should -Contain 'Not'
+            $kinds | Should -Contain 'Comparison'
+            $kinds | Should -Contain 'Identifier'
+            $kinds | Should -Contain 'Literal'
+        }
+
+        It 'accepts dotted paths inside grouped predicates' {
+            $ast = ConvertTo-FVPredicate -Predicate "(adapter.kind == 'agent' AND metadata.priority >= 2)"
+
+            & $script:AssertAst -Result $ast
+            $kinds = & $script:GetAstKinds -Node $ast
+            $values = & $script:GetAstScalarValues -Node $ast
+
+            $kinds | Should -Contain 'Logical'
+            $kinds | Should -Contain 'Comparison'
+            $values | Should -Contain 'adapter.kind'
+            $values | Should -Contain 'metadata.priority'
+        }
+
+        It 'accepts <LiteralType> literals' -ForEach @(
+            @{ LiteralType = 'string'; Predicate = "port == 'experience'"; ExpectedValue = 'experience' }
+            @{ LiteralType = 'number'; Predicate = 'score >= 2.5'; ExpectedValue = '2.5' }
+            @{ LiteralType = 'boolean'; Predicate = 'enabled == true'; ExpectedValue = $true }
+            @{ LiteralType = 'array'; Predicate = "port in ['experience', 'review', true, 3]"; ExpectedValue = 'Array' }
+        ) {
+            param($LiteralType, $Predicate, $ExpectedValue)
+
+            $ast = ConvertTo-FVPredicate -Predicate $Predicate
+
+            & $script:AssertAst -Result $ast
+            $kinds = & $script:GetAstKinds -Node $ast
+            $values = & $script:GetAstScalarValues -Node $ast
+
+            $kinds | Should -Contain 'Literal'
+            $values | Should -Contain $ExpectedValue
+        }
+    }
+
+    Context 'malformed predicates' {
+
+        It 'returns parse error details for <Case>' -ForEach @(
+            @{
+                Case           = 'trailing operator'
+                Predicate      = "port == 'experience' AND"
+                Position       = 21
+                MessagePattern = 'Trailing operator'
+            }
+            @{
+                Case           = 'unbalanced parens'
+                Predicate      = "(port == 'experience'"
+                Position       = 0
+                MessagePattern = "Unclosed '\('"
+            }
+            @{
+                Case           = 'missing right-hand side'
+                Predicate      = 'port =='
+                Position       = 7
+                MessagePattern = 'Missing right-hand literal'
+            }
+            @{
+                Case           = 'double operator'
+                Predicate      = "port == == 'experience'"
+                Position       = 8
+                MessagePattern = 'Expected literal'
+            }
+            @{
+                Case           = 'consecutive operators'
+                Predicate      = "port == 'experience' AND OR status == 'stable'"
+                Position       = 25
+                MessagePattern = 'Unexpected operator'
+            }
+            @{
+                Case           = 'invalid hyphenated identifier'
+                Predicate      = "port-name == 'experience'"
+                Position       = 4
+                MessagePattern = "Unexpected character '-'"
+            }
+        ) {
+            param($Case, $Predicate, $Position, $MessagePattern)
+
+            $result = ConvertTo-FVPredicate -Predicate $Predicate
+
+            & $script:AssertParseError -Result $result -Position $Position -MessagePattern $MessagePattern
+        }
+    }
+}

--- a/.github/scripts/Tests/frame-validate.Tests.ps1
+++ b/.github/scripts/Tests/frame-validate.Tests.ps1
@@ -1,0 +1,232 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Pester 5 unit tests for frame validator checks.
+
+.DESCRIPTION
+    Contract under test:
+      Test-FVAdapterSymmetry verifies adapter provides declarations against
+      frame/ports/*.yaml filename stems, with a graceful informational pass
+      when the port catalog is absent.
+
+      Test-FVPredicateParse verifies applies-when predicates are parseable.
+      These are per-check unit tests only; Invoke-FrameValidate contract tests
+      and quick-validate integration tests belong to later plan steps.
+#>
+
+Describe 'Frame validator check functions' -Tag 'unit' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:LibFile = Join-Path $script:RepoRoot '.github\scripts\lib\frame-validate-core.ps1'
+        . $script:LibFile
+
+        $script:AssertCheckResult = {
+            param(
+                [Parameter(Mandatory)]$Result,
+                [Parameter(Mandatory)][string]$ExpectedName
+            )
+
+            $Result | Should -Not -BeNullOrEmpty
+            $propertyNames = @($Result.PSObject.Properties | Select-Object -ExpandProperty Name)
+            ($propertyNames -join ',') | Should -Be 'Name,Passed,Detail'
+            $Result.Name | Should -Be $ExpectedName
+            ($Result.Passed -is [bool]) | Should -BeTrue
+            ($Result.Detail -is [string]) | Should -BeTrue
+        }
+
+        $script:NewFrameValidateFixture = {
+            param(
+                [string]$Root = "TestDrive:\fv-$([System.Guid]::NewGuid().ToString('N'))",
+                [string[]]$Ports = @('experience', 'review'),
+                [switch]$WithoutPortCatalog
+            )
+
+            $agentsDir = Join-Path $Root 'agents'
+            $skillDir = Join-Path $Root 'skills\test-skill'
+            $commandsDir = Join-Path $Root 'commands'
+
+            New-Item -ItemType Directory -Path $agentsDir -Force | Out-Null
+            New-Item -ItemType Directory -Path $skillDir -Force | Out-Null
+            New-Item -ItemType Directory -Path $commandsDir -Force | Out-Null
+
+            if (-not $WithoutPortCatalog) {
+                $portsDir = Join-Path $Root 'frame\ports'
+                New-Item -ItemType Directory -Path $portsDir -Force | Out-Null
+
+                foreach ($port in $Ports) {
+                    Set-Content -Path (Join-Path $portsDir "$port.yaml") -Value "description: $port" -Encoding utf8NoBOM
+                }
+            }
+
+            Set-Content -Path (Join-Path $skillDir 'SKILL.md') -Value @'
+---
+name: test-skill
+description: Test skill. Use when validating frame fixtures. DO NOT USE FOR: production.
+---
+
+# Test Skill
+
+## Gotchas
+
+None.
+'@ -Encoding utf8NoBOM
+
+            return $Root
+        }
+
+        $script:AddFrameAdapter = {
+            param(
+                [Parameter(Mandatory)][string]$Root,
+                [Parameter(Mandatory)][string]$RelativePath,
+                [string[]]$Provides = @(),
+                [string[]]$AppliesWhen = @()
+            )
+
+            $path = Join-Path $Root $RelativePath
+            New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
+
+            $lines = [System.Collections.Generic.List[string]]::new()
+            $lines.Add('---')
+            $lines.Add('name: frame-fixture-adapter')
+            $lines.Add('description: Frame validator fixture adapter.')
+
+            if ($Provides.Count -gt 0) {
+                $lines.Add('provides:')
+                foreach ($providedPort in $Provides) {
+                    $lines.Add("  - $providedPort")
+                }
+            }
+
+            foreach ($predicate in $AppliesWhen) {
+                $lines.Add("applies-when: $predicate")
+            }
+
+            $lines.Add('---')
+            $lines.Add('')
+            $lines.Add('# Fixture Adapter')
+
+            Set-Content -Path $path -Value ($lines.ToArray() -join [Environment]::NewLine) -Encoding utf8NoBOM
+            return $path
+        }
+    }
+
+    It 'ships the in-process frame validator library' {
+        $script:LibFile | Should -Exist
+        Get-Command Test-FVAdapterSymmetry -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        Get-Command Test-FVPredicateParse -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+
+    Context 'Test-FVAdapterSymmetry' {
+
+        It 'passes a clean adapter state' {
+            $root = & $script:NewFrameValidateFixture
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\valid.agent.md' -Provides @('experience', 'review') | Out-Null
+
+            $result = Test-FVAdapterSymmetry -RootPath $root
+
+            & $script:AssertCheckResult -Result $result -ExpectedName 'AdapterSymmetry'
+            $result.Passed | Should -BeTrue
+            $result.Detail | Should -Be ''
+        }
+
+        It 'fails a single dangling provides declaration' {
+            $root = & $script:NewFrameValidateFixture -Ports @('experience')
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\bad.agent.md' -Provides @('typo-port') | Out-Null
+
+            $result = Test-FVAdapterSymmetry -RootPath $root
+
+            & $script:AssertCheckResult -Result $result -ExpectedName 'AdapterSymmetry'
+            $result.Passed | Should -BeFalse
+            $result.Detail | Should -Match '1 invalid provides declaration'
+            $result.Detail | Should -Match 'agents/bad\.agent\.md'
+            $result.Detail | Should -Match "provides 'typo-port'"
+            $result.Detail | Should -Match 'valid ports: experience'
+        }
+
+        It 'fails multiple dangling provides declarations across adapter surfaces' {
+            $root = & $script:NewFrameValidateFixture -Ports @('experience', 'review')
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\bad-agent.agent.md' -Provides @('missing-agent-port') | Out-Null
+            & $script:AddFrameAdapter -Root $root -RelativePath 'skills\test-skill\SKILL.md' -Provides @('missing-skill-port') | Out-Null
+            & $script:AddFrameAdapter -Root $root -RelativePath 'commands\bad-command.md' -Provides @('missing-command-port') | Out-Null
+
+            $result = Test-FVAdapterSymmetry -RootPath $root
+
+            & $script:AssertCheckResult -Result $result -ExpectedName 'AdapterSymmetry'
+            $result.Passed | Should -BeFalse
+            $result.Detail | Should -Match '3 invalid provides declaration'
+            $result.Detail | Should -Match 'agents/bad-agent\.agent\.md'
+            $result.Detail | Should -Match 'missing-agent-port'
+            $result.Detail | Should -Match 'skills/test-skill/SKILL\.md'
+            $result.Detail | Should -Match 'missing-skill-port'
+            $result.Detail | Should -Match 'commands/bad-command\.md'
+            $result.Detail | Should -Match 'missing-command-port'
+        }
+
+        It 'passes with informational detail when the frame port catalog is absent' {
+            $root = & $script:NewFrameValidateFixture -WithoutPortCatalog
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\dangling.agent.md' -Provides @('anything') | Out-Null
+
+            $result = Test-FVAdapterSymmetry -RootPath $root
+
+            & $script:AssertCheckResult -Result $result -ExpectedName 'AdapterSymmetry'
+            $result.Passed | Should -BeTrue
+            $result.Detail | Should -Match 'frame/ports missing'
+            $result.Detail | Should -Match 'adapter symmetry skipped'
+        }
+    }
+
+    Context 'Test-FVPredicateParse' {
+
+        It 'passes well-formed predicates from adapter frontmatter' {
+            $root = & $script:NewFrameValidateFixture
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\predicate-agent.agent.md' -AppliesWhen @("port == 'experience' AND score >= 2") | Out-Null
+            & $script:AddFrameAdapter -Root $root -RelativePath 'skills\test-skill\SKILL.md' -AppliesWhen @("NOT adapter.kind == 'deprecated'") | Out-Null
+            & $script:AddFrameAdapter -Root $root -RelativePath 'commands\predicate-command.md' -AppliesWhen @("port in ['experience', 'review']") | Out-Null
+
+            $result = Test-FVPredicateParse -RootPath $root
+
+            & $script:AssertCheckResult -Result $result -ExpectedName 'PredicateParse'
+            $result.Passed | Should -BeTrue
+            $result.Detail | Should -Be ''
+        }
+
+        It 'fails a malformed predicate for <Case>' -ForEach @(
+            @{
+                Case      = 'trailing operator'
+                Predicate = "port == 'experience' AND"
+            }
+            @{
+                Case      = 'unbalanced parens'
+                Predicate = "(port == 'experience'"
+            }
+            @{
+                Case      = 'missing right-hand side'
+                Predicate = 'port =='
+            }
+            @{
+                Case      = 'double operator'
+                Predicate = "port == == 'experience'"
+            }
+            @{
+                Case      = 'consecutive operator'
+                Predicate = "port == 'experience' AND OR status == 'stable'"
+            }
+        ) {
+            param($Case, $Predicate)
+
+            $root = & $script:NewFrameValidateFixture
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\bad-predicate.agent.md' -AppliesWhen @($Predicate) | Out-Null
+
+            $result = Test-FVPredicateParse -RootPath $root
+
+            & $script:AssertCheckResult -Result $result -ExpectedName 'PredicateParse'
+            $result.Passed | Should -BeFalse
+            $result.Detail | Should -Match '1 applies-when parse error'
+            $result.Detail | Should -Match 'agents/bad-predicate\.agent\.md'
+            $result.Detail | Should -Match ([regex]::Escape($Predicate))
+            $result.Detail | Should -Match 'parse error at position'
+        }
+    }
+}

--- a/.github/scripts/Tests/frame-validate.Tests.ps1
+++ b/.github/scripts/Tests/frame-validate.Tests.ps1
@@ -146,6 +146,19 @@ None.
             return $path
         }
 
+        $script:AddFrameAdapterRaw = {
+            param(
+                [Parameter(Mandatory)][string]$Root,
+                [Parameter(Mandatory)][string]$RelativePath,
+                [Parameter(Mandatory)][string]$Content
+            )
+
+            $path = & $script:JoinFrameValidateTestPath -Root $Root -RelativePath $RelativePath
+            New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
+            Set-Content -Path $path -Value $Content -Encoding utf8NoBOM
+            return $path
+        }
+
         $script:NewQuickValidateSupportFixture = {
             param([Parameter(Mandatory)][string]$Root)
 
@@ -269,6 +282,67 @@ None.
             $result.Detail | Should -Be ''
         }
 
+        It 'accepts valid YAML scalar comments, inline arrays, indented lists, block scalars, and escaped double quotes' {
+            $root = & $script:NewFrameValidateFixture -Ports @('experience', 'review')
+
+            & $script:AddFrameAdapterRaw -Root $root -RelativePath 'agents\commented-scalar.agent.md' -Content @'
+---
+name: commented-scalar
+provides: review # comment
+applies-when: changeset.totalLines < 200 # comment
+---
+
+# Commented Scalar
+'@ | Out-Null
+
+            & $script:AddFrameAdapterRaw -Root $root -RelativePath 'commands\inline-array.md' -Content @'
+---
+name: inline-array
+provides: [experience, review] # comment
+applies-when: "port == \"experience\""
+---
+
+# Inline Array
+'@ | Out-Null
+
+            & $script:AddFrameAdapterRaw -Root $root -RelativePath 'skills\test-skill\SKILL.md' -Content @'
+---
+name: test-skill
+description: Test skill. Use when validating frame fixtures. DO NOT USE FOR: production.
+provides: # comment
+  - experience
+  - review # comment
+applies-when: >-
+  changeset.touches('docs/**') and changeset.behaviorChanged()
+---
+
+# Test Skill
+
+## Gotchas
+
+None.
+'@ | Out-Null
+
+            & $script:AddFrameAdapterRaw -Root $root -RelativePath 'skills\test-skill\adapters\literal-block.md' -Content @'
+---
+name: literal-block
+provides: experience
+applies-when: |+
+  not changeset.touchesSource()
+---
+
+# Literal Block
+'@ | Out-Null
+
+            $result = Invoke-FrameValidate -RootPath $root
+
+            & $script:AssertAggregateResult -Result $result -ExpectedPassCount 2 -ExpectedFailCount 0 -ExpectedExitCode 0
+            foreach ($check in @($result.Results)) {
+                $check.Passed | Should -BeTrue
+                $check.Detail | Should -Be ''
+            }
+        }
+
         It 'fails a malformed predicate for <Case>' -ForEach @(
             @{
                 Case      = 'trailing operator'
@@ -371,6 +445,60 @@ None.
             $predicate.Detail | Should -Match 'agents/missing-catalog\.agent\.md'
             $predicate.Detail | Should -Match ([regex]::Escape("port == 'experience' AND"))
         }
+
+        It 'reports a comment-only applies-when as a file-specific predicate parse error' {
+            $root = & $script:NewFrameValidateFixture -Ports @('experience')
+            & $script:AddFrameAdapterRaw -Root $root -RelativePath 'agents\comment-only.agent.md' -Content @'
+---
+name: comment-only
+provides: experience
+applies-when: # TODO
+---
+
+# Comment Only
+'@ | Out-Null
+
+            $result = Invoke-FrameValidate -RootPath $root
+
+            & $script:AssertAggregateResult -Result $result -ExpectedPassCount 1 -ExpectedFailCount 1 -ExpectedExitCode 1
+            $symmetry = $result.Results | Where-Object { $_.Name -eq 'AdapterSymmetry' }
+            $predicate = $result.Results | Where-Object { $_.Name -eq 'PredicateParse' }
+
+            & $script:AssertCheckResult -Result $symmetry -ExpectedName 'AdapterSymmetry'
+            $symmetry.Passed | Should -BeTrue
+            $symmetry.Detail | Should -Be ''
+
+            & $script:AssertCheckResult -Result $predicate -ExpectedName 'PredicateParse'
+            $predicate.Passed | Should -BeFalse
+            $predicate.Detail | Should -Match '1 applies-when parse error'
+            $predicate.Detail | Should -Match 'agents/comment-only\.agent\.md'
+            $predicate.Detail | Should -Match ([regex]::Escape("applies-when ''; parse error at position 0: Predicate is required."))
+            $predicate.Detail | Should -Not -Match 'Cannot bind argument to parameter'
+        }
+
+        It 'scans skill adapter variant files for malformed declarations' {
+            $root = & $script:NewFrameValidateFixture -Ports @('experience')
+            & $script:AddFrameAdapterRaw -Root $root -RelativePath 'skills\test-skill\adapters\broken-variant.md' -Content @'
+---
+name: broken-variant
+provides: missing-port
+applies-when: port ==
+---
+
+# Broken Variant
+'@ | Out-Null
+
+            $result = Invoke-FrameValidate -RootPath $root
+
+            & $script:AssertAggregateResult -Result $result -ExpectedPassCount 0 -ExpectedFailCount 2 -ExpectedExitCode 1
+            $symmetry = $result.Results | Where-Object { $_.Name -eq 'AdapterSymmetry' }
+            $predicate = $result.Results | Where-Object { $_.Name -eq 'PredicateParse' }
+
+            $symmetry.Detail | Should -Match 'skills/test-skill/adapters/broken-variant\.md'
+            $symmetry.Detail | Should -Match "provides 'missing-port'"
+            $predicate.Detail | Should -Match 'skills/test-skill/adapters/broken-variant\.md'
+            $predicate.Detail | Should -Match ([regex]::Escape('port =='))
+        }
     }
 
     Context 'Invoke-QuickValidate integration' {
@@ -404,6 +532,28 @@ None.
             $result.SkipCount | Should -Be 0
             $result.TotalCount | Should -Be @($result.Results).Count
             $result.PassCount | Should -Be ($result.TotalCount - 1)
+        }
+
+        It 'prints detail for a passing frame validator check when adapter symmetry is skipped' {
+            Mock Get-Module { return @{ Name = 'PSScriptAnalyzer'; Version = '1.22.0' } } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
+
+            $root = & $script:NewFrameValidateFixture -WithoutPortCatalog
+            $support = & $script:NewQuickValidateSupportFixture -Root $root
+
+            $result = Invoke-QuickValidate `
+                -RootPath $root `
+                -GuidanceComplexityScriptPath $support.GuidanceComplexityScriptPath `
+                -PSScriptAnalyzerSettingsPath $support.PSScriptAnalyzerSettingsPath `
+                -ScriptsPath $support.ScriptsPath `
+                -InformationVariable infoOutput
+
+            $frameValidator = @($result.Results | Where-Object { $_.Name -eq 'FrameValidator' })
+            $frameValidator | Should -HaveCount 1
+            $frameValidator[0].Passed | Should -BeTrue
+            $frameValidator[0].Detail | Should -Match 'AdapterSymmetry: frame/ports missing; adapter symmetry skipped'
+
+            $output = ($infoOutput | ForEach-Object { [string]$_.MessageData }) -join "`n"
+            $output | Should -Match '\[PASS\] FrameValidator.*adapter symmetry skipped'
         }
     }
 }

--- a/.github/scripts/Tests/frame-validate.Tests.ps1
+++ b/.github/scripts/Tests/frame-validate.Tests.ps1
@@ -10,9 +10,9 @@
       frame/ports/*.yaml filename stems, with a graceful informational pass
       when the port catalog is absent.
 
-      Test-FVPredicateParse verifies applies-when predicates are parseable.
-      These are per-check unit tests only; Invoke-FrameValidate contract tests
-      and quick-validate integration tests belong to later plan steps.
+            Test-FVPredicateParse verifies applies-when predicates are parseable.
+            Invoke-FrameValidate contract tests exercise aggregate behavior across
+            the checks. Quick-validate integration tests belong to a later plan step.
 #>
 
 Describe 'Frame validator check functions' -Tag 'unit' {
@@ -34,6 +34,25 @@ Describe 'Frame validator check functions' -Tag 'unit' {
             $Result.Name | Should -Be $ExpectedName
             ($Result.Passed -is [bool]) | Should -BeTrue
             ($Result.Detail -is [string]) | Should -BeTrue
+        }
+
+        $script:AssertAggregateResult = {
+            param(
+                [Parameter(Mandatory)]$Result,
+                [Parameter(Mandatory)][int]$ExpectedPassCount,
+                [Parameter(Mandatory)][int]$ExpectedFailCount,
+                [Parameter(Mandatory)][int]$ExpectedExitCode
+            )
+
+            $Result | Should -Not -BeNullOrEmpty
+            $propertyNames = @($Result.PSObject.Properties | Select-Object -ExpandProperty Name)
+            ($propertyNames -join ',') | Should -Be 'Results,PassCount,FailCount,TotalCount,ExitCode'
+            @($Result.Results) | Should -HaveCount 2
+            @($Result.Results | Select-Object -ExpandProperty Name) | Should -Be @('AdapterSymmetry', 'PredicateParse')
+            $Result.PassCount | Should -Be $ExpectedPassCount
+            $Result.FailCount | Should -Be $ExpectedFailCount
+            $Result.TotalCount | Should -Be 2
+            $Result.ExitCode | Should -Be $ExpectedExitCode
         }
 
         $script:NewFrameValidateFixture = {
@@ -227,6 +246,72 @@ None.
             $result.Detail | Should -Match 'agents/bad-predicate\.agent\.md'
             $result.Detail | Should -Match ([regex]::Escape($Predicate))
             $result.Detail | Should -Match 'parse error at position'
+        }
+    }
+
+    Context 'Invoke-FrameValidate' {
+
+        It 'passes against the current repository state in symmetry-only mode' {
+            $result = Invoke-FrameValidate -RootPath $script:RepoRoot
+
+            & $script:AssertAggregateResult -Result $result -ExpectedPassCount 2 -ExpectedFailCount 0 -ExpectedExitCode 0
+            foreach ($check in @($result.Results)) {
+                & $script:AssertCheckResult -Result $check -ExpectedName $check.Name
+                $check.Passed | Should -BeTrue
+                $check.Detail | Should -Be ''
+            }
+        }
+
+        It 'aggregates invalid provides declarations and malformed predicates from a post-428 adapter fixture' {
+            $root = & $script:NewFrameValidateFixture -Ports @('experience', 'review', 'implement-code')
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\valid.agent.md' -Provides @('experience') -AppliesWhen @("port == 'experience'") | Out-Null
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\typo-provides.agent.md' -Provides @('experiense') -AppliesWhen @("port == 'experience'") | Out-Null
+            & $script:AddFrameAdapter -Root $root -RelativePath 'commands\nonexistent-port.md' -Provides @('future-only-port') | Out-Null
+            & $script:AddFrameAdapter -Root $root -RelativePath 'skills\test-skill\SKILL.md' -Provides @('review') -AppliesWhen @("port == 'review' AND") | Out-Null
+
+            $result = Invoke-FrameValidate -RootPath $root
+
+            & $script:AssertAggregateResult -Result $result -ExpectedPassCount 0 -ExpectedFailCount 2 -ExpectedExitCode 1
+            $symmetry = $result.Results | Where-Object { $_.Name -eq 'AdapterSymmetry' }
+            $predicate = $result.Results | Where-Object { $_.Name -eq 'PredicateParse' }
+
+            & $script:AssertCheckResult -Result $symmetry -ExpectedName 'AdapterSymmetry'
+            $symmetry.Passed | Should -BeFalse
+            $symmetry.Detail | Should -Match '2 invalid provides declaration'
+            $symmetry.Detail | Should -Match 'agents/typo-provides\.agent\.md'
+            $symmetry.Detail | Should -Match "provides 'experiense'"
+            $symmetry.Detail | Should -Match 'commands/nonexistent-port\.md'
+            $symmetry.Detail | Should -Match "provides 'future-only-port'"
+            $symmetry.Detail | Should -Match 'valid ports: experience, implement-code, review'
+
+            & $script:AssertCheckResult -Result $predicate -ExpectedName 'PredicateParse'
+            $predicate.Passed | Should -BeFalse
+            $predicate.Detail | Should -Match '1 applies-when parse error'
+            $predicate.Detail | Should -Match 'skills/test-skill/SKILL\.md'
+            $predicate.Detail | Should -Match ([regex]::Escape("port == 'review' AND"))
+            $predicate.Detail | Should -Match 'parse error at position'
+        }
+
+        It 'keeps predicate parsing active when the frame port catalog is absent' {
+            $root = & $script:NewFrameValidateFixture -WithoutPortCatalog
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\missing-catalog.agent.md' -Provides @('anything') -AppliesWhen @("port == 'experience' AND") | Out-Null
+
+            $result = Invoke-FrameValidate -RootPath $root
+
+            & $script:AssertAggregateResult -Result $result -ExpectedPassCount 1 -ExpectedFailCount 1 -ExpectedExitCode 1
+            $symmetry = $result.Results | Where-Object { $_.Name -eq 'AdapterSymmetry' }
+            $predicate = $result.Results | Where-Object { $_.Name -eq 'PredicateParse' }
+
+            & $script:AssertCheckResult -Result $symmetry -ExpectedName 'AdapterSymmetry'
+            $symmetry.Passed | Should -BeTrue
+            $symmetry.Detail | Should -Match 'frame/ports missing'
+            $symmetry.Detail | Should -Match 'adapter symmetry skipped'
+
+            & $script:AssertCheckResult -Result $predicate -ExpectedName 'PredicateParse'
+            $predicate.Passed | Should -BeFalse
+            $predicate.Detail | Should -Match '1 applies-when parse error'
+            $predicate.Detail | Should -Match 'agents/missing-catalog\.agent\.md'
+            $predicate.Detail | Should -Match ([regex]::Escape("port == 'experience' AND"))
         }
     }
 }

--- a/.github/scripts/Tests/frame-validate.Tests.ps1
+++ b/.github/scripts/Tests/frame-validate.Tests.ps1
@@ -12,7 +12,7 @@
 
             Test-FVPredicateParse verifies applies-when predicates are parseable.
             Invoke-FrameValidate contract tests exercise aggregate behavior across
-            the checks. Quick-validate integration tests belong to a later plan step.
+            the checks. Quick-validate integration tests exercise the CI aggregate wire.
 #>
 
 Describe 'Frame validator check functions' -Tag 'unit' {
@@ -20,7 +20,9 @@ Describe 'Frame validator check functions' -Tag 'unit' {
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         $script:LibFile = Join-Path $script:RepoRoot '.github\scripts\lib\frame-validate-core.ps1'
+        $script:QuickValidateLibFile = Join-Path $script:RepoRoot '.github\scripts\lib\quick-validate-core.ps1'
         . $script:LibFile
+        . $script:QuickValidateLibFile
 
         $script:AssertCheckResult = {
             param(
@@ -128,6 +130,25 @@ None.
 
             Set-Content -Path $path -Value ($lines.ToArray() -join [Environment]::NewLine) -Encoding utf8NoBOM
             return $path
+        }
+
+        $script:NewQuickValidateSupportFixture = {
+            param([Parameter(Mandatory)][string]$Root)
+
+            $configDir = Join-Path $Root '.github\config'
+            New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+
+            $complexityScriptPath = Join-Path $Root 'mock-measure-guidance-complexity.ps1'
+            Set-Content -Path $complexityScriptPath -Value 'Write-Output ''{"agents_over_ceiling":[]}''' -Encoding utf8NoBOM
+
+            $settingsPath = Join-Path $configDir 'PSScriptAnalyzerSettings.psd1'
+            Set-Content -Path $settingsPath -Value '@{ IncludeRules = @() }' -Encoding utf8NoBOM
+
+            return [PSCustomObject]@{
+                GuidanceComplexityScriptPath  = $complexityScriptPath
+                PSScriptAnalyzerSettingsPath = $settingsPath
+                ScriptsPath                  = Join-Path $Root '.github\scripts'
+            }
         }
     }
 
@@ -312,6 +333,40 @@ None.
             $predicate.Detail | Should -Match '1 applies-when parse error'
             $predicate.Detail | Should -Match 'agents/missing-catalog\.agent\.md'
             $predicate.Detail | Should -Match ([regex]::Escape("port == 'experience' AND"))
+        }
+    }
+
+    Context 'Invoke-QuickValidate integration' {
+
+        It 'surfaces frame validator failure through quick-validate aggregation' {
+            Mock Get-Module { return @{ Name = 'PSScriptAnalyzer'; Version = '1.22.0' } } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
+
+            $root = & $script:NewFrameValidateFixture -Ports @('experience')
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\typo-provides.agent.md' -Provides @('experiense') -AppliesWhen @("port == 'experience'") | Out-Null
+            $support = & $script:NewQuickValidateSupportFixture -Root $root
+
+            $result = Invoke-QuickValidate `
+                -RootPath $root `
+                -GuidanceComplexityScriptPath $support.GuidanceComplexityScriptPath `
+                -PSScriptAnalyzerSettingsPath $support.PSScriptAnalyzerSettingsPath `
+                -ScriptsPath $support.ScriptsPath
+
+            $frameValidator = @($result.Results | Where-Object { $_.Name -eq 'FrameValidator' })
+            $frameValidator | Should -HaveCount 1
+            $frameValidator[0].Passed | Should -BeFalse
+            $frameValidator[0].Detail | Should -Match 'AdapterSymmetry'
+            $frameValidator[0].Detail | Should -Match '1 invalid provides declaration'
+            $frameValidator[0].Detail | Should -Match 'agents/typo-provides\.agent\.md'
+            $frameValidator[0].Detail | Should -Match "provides 'experiense'"
+
+            $psAnalyzer = $result.Results | Where-Object { $_.Name -eq 'PSScriptAnalyzer' }
+            $psAnalyzer.Passed | Should -BeTrue
+            @($result.Results | Where-Object { $_.Passed -eq $false } | Select-Object -ExpandProperty Name) | Should -Be @('FrameValidator')
+            $result.ExitCode | Should -Be 1
+            $result.FailCount | Should -Be 1
+            $result.SkipCount | Should -Be 0
+            $result.TotalCount | Should -Be @($result.Results).Count
+            $result.PassCount | Should -Be ($result.TotalCount - 1)
         }
     }
 }

--- a/.github/scripts/Tests/frame-validate.Tests.ps1
+++ b/.github/scripts/Tests/frame-validate.Tests.ps1
@@ -10,19 +10,33 @@
       frame/ports/*.yaml filename stems, with a graceful informational pass
       when the port catalog is absent.
 
-            Test-FVPredicateParse verifies applies-when predicates are parseable.
-            Invoke-FrameValidate contract tests exercise aggregate behavior across
-            the checks. Quick-validate integration tests exercise the CI aggregate wire.
+    Test-FVPredicateParse verifies applies-when predicates are parseable.
+    Invoke-FrameValidate contract tests exercise aggregate behavior across
+    the checks. Quick-validate integration tests exercise the CI aggregate wire.
 #>
 
 Describe 'Frame validator check functions' -Tag 'unit' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:LibFile = Join-Path $script:RepoRoot '.github\scripts\lib\frame-validate-core.ps1'
-        $script:QuickValidateLibFile = Join-Path $script:RepoRoot '.github\scripts\lib\quick-validate-core.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot '.github/scripts/lib/frame-validate-core.ps1'
+        $script:QuickValidateLibFile = Join-Path $script:RepoRoot '.github/scripts/lib/quick-validate-core.ps1'
         . $script:LibFile
         . $script:QuickValidateLibFile
+
+        $script:JoinFrameValidateTestPath = {
+            param(
+                [Parameter(Mandatory)][string]$Root,
+                [Parameter(Mandatory)][string]$RelativePath
+            )
+
+            $path = $Root
+            foreach ($part in @($RelativePath -split '[\\/]' | Where-Object { $_.Length -gt 0 })) {
+                $path = Join-Path -Path $path -ChildPath $part
+            }
+
+            return $path
+        }
 
         $script:AssertCheckResult = {
             param(
@@ -64,16 +78,16 @@ Describe 'Frame validator check functions' -Tag 'unit' {
                 [switch]$WithoutPortCatalog
             )
 
-            $agentsDir = Join-Path $Root 'agents'
-            $skillDir = Join-Path $Root 'skills\test-skill'
-            $commandsDir = Join-Path $Root 'commands'
+            $agentsDir = & $script:JoinFrameValidateTestPath -Root $Root -RelativePath 'agents'
+            $skillDir = & $script:JoinFrameValidateTestPath -Root $Root -RelativePath 'skills/test-skill'
+            $commandsDir = & $script:JoinFrameValidateTestPath -Root $Root -RelativePath 'commands'
 
             New-Item -ItemType Directory -Path $agentsDir -Force | Out-Null
             New-Item -ItemType Directory -Path $skillDir -Force | Out-Null
             New-Item -ItemType Directory -Path $commandsDir -Force | Out-Null
 
             if (-not $WithoutPortCatalog) {
-                $portsDir = Join-Path $Root 'frame\ports'
+                $portsDir = & $script:JoinFrameValidateTestPath -Root $Root -RelativePath 'frame/ports'
                 New-Item -ItemType Directory -Path $portsDir -Force | Out-Null
 
                 foreach ($port in $Ports) {
@@ -105,7 +119,7 @@ None.
                 [string[]]$AppliesWhen = @()
             )
 
-            $path = Join-Path $Root $RelativePath
+            $path = & $script:JoinFrameValidateTestPath -Root $Root -RelativePath $RelativePath
             New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
 
             $lines = [System.Collections.Generic.List[string]]::new()
@@ -135,7 +149,7 @@ None.
         $script:NewQuickValidateSupportFixture = {
             param([Parameter(Mandatory)][string]$Root)
 
-            $configDir = Join-Path $Root '.github\config'
+            $configDir = & $script:JoinFrameValidateTestPath -Root $Root -RelativePath '.github/config'
             New-Item -ItemType Directory -Path $configDir -Force | Out-Null
 
             $complexityScriptPath = Join-Path $Root 'mock-measure-guidance-complexity.ps1'
@@ -147,7 +161,7 @@ None.
             return [PSCustomObject]@{
                 GuidanceComplexityScriptPath  = $complexityScriptPath
                 PSScriptAnalyzerSettingsPath = $settingsPath
-                ScriptsPath                  = Join-Path $Root '.github\scripts'
+                ScriptsPath                  = & $script:JoinFrameValidateTestPath -Root $Root -RelativePath '.github/scripts'
             }
         }
     }
@@ -163,6 +177,29 @@ None.
         It 'passes a clean adapter state' {
             $root = & $script:NewFrameValidateFixture
             & $script:AddFrameAdapter -Root $root -RelativePath 'agents\valid.agent.md' -Provides @('experience', 'review') | Out-Null
+
+            $result = Test-FVAdapterSymmetry -RootPath $root
+
+            & $script:AssertCheckResult -Result $result -ExpectedName 'AdapterSymmetry'
+            $result.Passed | Should -BeTrue
+            $result.Detail | Should -Be ''
+        }
+
+        It 'does not require every port to have an adapter declaration' {
+            $root = & $script:NewFrameValidateFixture -Ports @('experience', 'review')
+
+            $result = Test-FVAdapterSymmetry -RootPath $root
+
+            & $script:AssertCheckResult -Result $result -ExpectedName 'AdapterSymmetry'
+            $result.Passed | Should -BeTrue
+            $result.Detail | Should -Be ''
+        }
+
+        It 'uses frame port filename stems without reading YAML body names' {
+            $root = & $script:NewFrameValidateFixture -Ports @('experience')
+            $portFile = & $script:JoinFrameValidateTestPath -Root $root -RelativePath 'frame/ports/experience.yaml'
+            Set-Content -Path $portFile -Value 'name: not-the-port-name' -Encoding utf8NoBOM
+            & $script:AddFrameAdapter -Root $root -RelativePath 'agents\stem-port.agent.md' -Provides @('experience') | Out-Null
 
             $result = Test-FVAdapterSymmetry -RootPath $root
 

--- a/.github/scripts/frame-validate.ps1
+++ b/.github/scripts/frame-validate.ps1
@@ -1,0 +1,18 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string]$RootPath
+)
+
+. "$PSScriptRoot/lib/frame-validate-core.ps1"
+
+$result = Invoke-FrameValidate @PSBoundParameters
+
+foreach ($check in @($result.Results)) {
+    $prefix = if ($check.Passed) { '[PASS]' } else { '[FAIL]' }
+    $detail = if ($check.Detail) { " - $($check.Detail)" } else { '' }
+    Write-Output "$prefix $($check.Name)$detail"
+}
+
+Write-Output "Frame-validate: $($result.PassCount)/$($result.TotalCount) checks passed"
+exit $result.ExitCode

--- a/.github/scripts/lib/frame-predicate-core.ps1
+++ b/.github/scripts/lib/frame-predicate-core.ps1
@@ -356,6 +356,20 @@ function New-FVIdentifierNode {
     }
 }
 
+function New-FVCallNode {
+    param(
+        [Parameter(Mandatory)]$NameToken,
+        [AllowEmptyCollection()][object[]]$Arguments
+    )
+
+    return [PSCustomObject]@{
+        Kind      = 'Call'
+        Name      = $NameToken.Value
+        Arguments = [object[]]$Arguments
+        Position  = $NameToken.Position
+    }
+}
+
 function New-FVScalarLiteralNode {
     param(
         [Parameter(Mandatory)][string]$LiteralType,
@@ -544,7 +558,7 @@ function ConvertTo-FVPrimaryExpression {
             return $expression
         }
         'Identifier' {
-            return (ConvertTo-FVComparison -State $State)
+            return (ConvertTo-FVIdentifierExpression -State $State)
         }
         'LogicalOperator' {
             return (New-FVParseError -Position $current.Position -Message "Unexpected operator '$($current.Value)'.")
@@ -561,13 +575,96 @@ function ConvertTo-FVPrimaryExpression {
     }
 }
 
-function ConvertTo-FVComparison {
+function ConvertTo-FVIdentifierExpression {
     param([Parameter(Mandatory)]$State)
 
-    $leftToken = Move-FVToken -State $State
+    $identifierToken = Move-FVToken -State $State
+    $left = New-FVIdentifierNode -Token $identifierToken
+    $current = Get-FVCurrentToken -State $State
+
+    if ($current.Kind -eq 'LParen') {
+        $left = ConvertTo-FVCallExpression -State $State -NameToken $identifierToken
+        if (Test-FVParseError -Value $left) { return $left }
+
+        $current = Get-FVCurrentToken -State $State
+        if ($current.Kind -eq 'Comparator') {
+            return (New-FVParseError -Position $current.Position -Message 'Expected logical operator or end of predicate after function call.')
+        }
+    }
+
+    if ($current.Kind -eq 'Comparator') {
+        return (ConvertTo-FVComparison -State $State -Left $left)
+    }
+
+    return $left
+}
+
+function ConvertTo-FVCallExpression {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)]$NameToken
+    )
+
+    $openToken = Move-FVToken -State $State
+    $arguments = [System.Collections.Generic.List[object]]::new()
+    $current = Get-FVCurrentToken -State $State
+
+    if ($current.Kind -eq 'RParen') {
+        $null = Move-FVToken -State $State
+        return (New-FVCallNode -NameToken $NameToken -Arguments $arguments.ToArray())
+    }
+
+    while ($true) {
+        $current = Get-FVCurrentToken -State $State
+        if ($current.Kind -eq 'EOF') {
+            return (New-FVParseError -Position $openToken.Position -Message "Unclosed '('.")
+        }
+
+        if ($current.Kind -in @('Comma', 'RParen')) {
+            return (New-FVParseError -Position $current.Position -Message 'Expected literal in function call.')
+        }
+
+        $argument = ConvertTo-FVLiteral -State $State -Context 'Expected literal in function call.'
+        if (Test-FVParseError -Value $argument) { return $argument }
+        $arguments.Add($argument)
+
+        $current = Get-FVCurrentToken -State $State
+        if ($current.Kind -eq 'Comma') {
+            $commaToken = Move-FVToken -State $State
+            $next = Get-FVCurrentToken -State $State
+            if ($next.Kind -eq 'EOF') {
+                return (New-FVParseError -Position $openToken.Position -Message "Unclosed '('.")
+            }
+
+            if ($next.Kind -eq 'RParen') {
+                return (New-FVParseError -Position $commaToken.Position -Message "Expected literal after ','.")
+            }
+
+            continue
+        }
+
+        if ($current.Kind -eq 'RParen') {
+            $null = Move-FVToken -State $State
+            return (New-FVCallNode -NameToken $NameToken -Arguments $arguments.ToArray())
+        }
+
+        if ($current.Kind -eq 'EOF') {
+            return (New-FVParseError -Position $openToken.Position -Message "Unclosed '('.")
+        }
+
+        return (New-FVParseError -Position $current.Position -Message "Expected ',' or ')' in function call.")
+    }
+}
+
+function ConvertTo-FVComparison {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)]$Left
+    )
+
     $current = Get-FVCurrentToken -State $State
     if ($current.Kind -ne 'Comparator') {
-        return (New-FVParseError -Position $current.Position -Message "Expected comparator after identifier '$($leftToken.Value)'.")
+        return (New-FVParseError -Position $current.Position -Message "Expected comparator after identifier '$($Left.Name)'.")
     }
 
     $operatorToken = Move-FVToken -State $State
@@ -580,7 +677,7 @@ function ConvertTo-FVComparison {
         return $literal
     }
 
-    return (New-FVComparisonNode -Left (New-FVIdentifierNode -Token $leftToken) -Operator $operatorToken.Value -Right $literal -Position $operatorToken.Position)
+    return (New-FVComparisonNode -Left $Left -Operator $operatorToken.Value -Right $literal -Position $operatorToken.Position)
 }
 
 function ConvertTo-FVLiteral {
@@ -706,6 +803,26 @@ function Test-FVExpressionStructure {
         'Not' {
             $operandResult = Test-FVExpressionStructure -Node $Node.Operand
             if (Test-FVParseError -Value $operandResult) { return $operandResult }
+            return $true
+        }
+        'Identifier' {
+            if ([string]::IsNullOrWhiteSpace($Node.Name)) {
+                return (New-FVParseError -Position $Node.Position -Message 'Internal parser error: identifier name is required.')
+            }
+
+            return $true
+        }
+        'Call' {
+            if ([string]::IsNullOrWhiteSpace($Node.Name)) {
+                return (New-FVParseError -Position $Node.Position -Message 'Internal parser error: function name is required.')
+            }
+
+            foreach ($argument in @($Node.Arguments)) {
+                if ($null -eq $argument -or $argument.Kind -ne 'Literal') {
+                    return (New-FVParseError -Position $Node.Position -Message 'Internal parser error: function arguments must be literals.')
+                }
+            }
+
             return $true
         }
         default {

--- a/.github/scripts/lib/frame-predicate-core.ps1
+++ b/.github/scripts/lib/frame-predicate-core.ps1
@@ -73,6 +73,165 @@ function Test-FVIdentifierPart {
     )
 }
 
+function Get-FVSingleCharacterTokenKind {
+    param([char]$Character)
+
+    switch ([string]$Character) {
+        '(' { return 'LParen' }
+        ')' { return 'RParen' }
+        '[' { return 'LBracket' }
+        ']' { return 'RBracket' }
+        ',' { return 'Comma' }
+        default { return $null }
+    }
+}
+
+function New-FVTokenReadResult {
+    param(
+        [Parameter(Mandatory)]$Value,
+        [Parameter(Mandatory)][int]$NextIndex
+    )
+
+    return [PSCustomObject]@{
+        Value     = $Value
+        NextIndex = $NextIndex
+    }
+}
+
+function Read-FVQuotedStringToken {
+    param(
+        [Parameter(Mandatory)][string]$Predicate,
+        [Parameter(Mandatory)][int]$StartIndex
+    )
+
+    $quote = $Predicate[$StartIndex]
+    $index = $StartIndex + 1
+    $builder = [System.Text.StringBuilder]::new()
+    $closed = $false
+
+    while ($index -lt $Predicate.Length) {
+        $current = $Predicate[$index]
+        if ($current -eq [char]92) {
+            if ($index + 1 -ge $Predicate.Length) {
+                return (New-FVTokenReadResult -Value (New-FVParseError -Position $StartIndex -Message 'Unterminated string literal.') -NextIndex $index)
+            }
+
+            [void]$builder.Append($Predicate[$index + 1])
+            $index += 2
+            continue
+        }
+
+        if ($current -eq $quote) {
+            $index++
+            $closed = $true
+            break
+        }
+
+        [void]$builder.Append($current)
+        $index++
+    }
+
+    if (-not $closed) {
+        return (New-FVTokenReadResult -Value (New-FVParseError -Position $StartIndex -Message 'Unterminated string literal.') -NextIndex $index)
+    }
+
+    $token = New-FVToken -Kind 'String' -Value $builder.ToString() -Position $StartIndex -Length ($index - $StartIndex)
+    return (New-FVTokenReadResult -Value $token -NextIndex $index)
+}
+
+function Read-FVNumberToken {
+    param(
+        [Parameter(Mandatory)][string]$Predicate,
+        [Parameter(Mandatory)][int]$StartIndex
+    )
+
+    $index = $StartIndex
+    if ($Predicate[$index] -eq [char]'-') {
+        $index++
+    }
+
+    while ($index -lt $Predicate.Length -and [char]::IsDigit($Predicate[$index])) {
+        $index++
+    }
+
+    if ($index -lt $Predicate.Length -and $Predicate[$index] -eq [char]'.' -and $index + 1 -lt $Predicate.Length -and [char]::IsDigit($Predicate[$index + 1])) {
+        $index++
+        while ($index -lt $Predicate.Length -and [char]::IsDigit($Predicate[$index])) {
+            $index++
+        }
+    }
+
+    if ($index -lt $Predicate.Length -and $Predicate[$index] -in @([char]'e', [char]'E')) {
+        $exponentStart = $index
+        $index++
+        if ($index -lt $Predicate.Length -and $Predicate[$index] -in @([char]'+', [char]'-')) {
+            $index++
+        }
+
+        if ($index -ge $Predicate.Length -or -not [char]::IsDigit($Predicate[$index])) {
+            return (New-FVTokenReadResult -Value (New-FVParseError -Position $exponentStart -Message 'Malformed number literal.') -NextIndex $index)
+        }
+
+        while ($index -lt $Predicate.Length -and [char]::IsDigit($Predicate[$index])) {
+            $index++
+        }
+    }
+
+    $number = $Predicate.Substring($StartIndex, $index - $StartIndex)
+    $token = New-FVToken -Kind 'Number' -Value $number -Position $StartIndex -Length ($index - $StartIndex)
+    return (New-FVTokenReadResult -Value $token -NextIndex $index)
+}
+
+function New-FVIdentifierOrKeywordToken {
+    param(
+        [Parameter(Mandatory)][string]$Identifier,
+        [Parameter(Mandatory)][int]$Position,
+        [Parameter(Mandatory)][int]$Length
+    )
+
+    switch ($Identifier.ToUpperInvariant()) {
+        'AND' { return (New-FVToken -Kind 'LogicalOperator' -Value 'AND' -Position $Position -Length $Length) }
+        'OR' { return (New-FVToken -Kind 'LogicalOperator' -Value 'OR' -Position $Position -Length $Length) }
+        'NOT' { return (New-FVToken -Kind 'Not' -Value 'NOT' -Position $Position -Length $Length) }
+        'IN' { return (New-FVToken -Kind 'Comparator' -Value 'in' -Position $Position -Length $Length) }
+        'TRUE' { return (New-FVToken -Kind 'Boolean' -Value $true -Position $Position -Length $Length) }
+        'FALSE' { return (New-FVToken -Kind 'Boolean' -Value $false -Position $Position -Length $Length) }
+        default { return (New-FVToken -Kind 'Identifier' -Value $Identifier -Position $Position -Length $Length) }
+    }
+}
+
+function Read-FVIdentifierOrKeywordToken {
+    param(
+        [Parameter(Mandatory)][string]$Predicate,
+        [Parameter(Mandatory)][int]$StartIndex
+    )
+
+    $index = $StartIndex + 1
+    while ($index -lt $Predicate.Length) {
+        $current = $Predicate[$index]
+        if (Test-FVIdentifierPart -Character $current) {
+            $index++
+            continue
+        }
+
+        if ($current -eq [char]'.') {
+            $index++
+            if ($index -ge $Predicate.Length -or -not (Test-FVIdentifierStart -Character $Predicate[$index])) {
+                return (New-FVTokenReadResult -Value (New-FVParseError -Position $index -Message "Expected identifier segment after '.'.") -NextIndex $index)
+            }
+
+            $index++
+            continue
+        }
+
+        break
+    }
+
+    $identifier = $Predicate.Substring($StartIndex, $index - $StartIndex)
+    $token = New-FVIdentifierOrKeywordToken -Identifier $identifier -Position $StartIndex -Length ($index - $StartIndex)
+    return (New-FVTokenReadResult -Value $token -NextIndex $index)
+}
+
 function Get-FVTokens {
     [CmdletBinding()]
     param([AllowNull()][string]$Predicate)
@@ -93,32 +252,9 @@ function Get-FVTokens {
             continue
         }
 
-        if ($character -eq [char]'(') {
-            $tokens.Add((New-FVToken -Kind 'LParen' -Value '(' -Position $index -Length 1))
-            $index++
-            continue
-        }
-
-        if ($character -eq [char]')') {
-            $tokens.Add((New-FVToken -Kind 'RParen' -Value ')' -Position $index -Length 1))
-            $index++
-            continue
-        }
-
-        if ($character -eq [char]'[') {
-            $tokens.Add((New-FVToken -Kind 'LBracket' -Value '[' -Position $index -Length 1))
-            $index++
-            continue
-        }
-
-        if ($character -eq [char]']') {
-            $tokens.Add((New-FVToken -Kind 'RBracket' -Value ']' -Position $index -Length 1))
-            $index++
-            continue
-        }
-
-        if ($character -eq [char]',') {
-            $tokens.Add((New-FVToken -Kind 'Comma' -Value ',' -Position $index -Length 1))
+        $singleCharacterTokenKind = Get-FVSingleCharacterTokenKind -Character $character
+        if ($singleCharacterTokenKind) {
+            $tokens.Add((New-FVToken -Kind $singleCharacterTokenKind -Value ([string]$character) -Position $index -Length 1))
             $index++
             continue
         }
@@ -147,136 +283,29 @@ function Get-FVTokens {
         }
 
         if ($character -eq [char]34 -or $character -eq [char]39) {
-            $quote = $character
-            $start = $index
-            $index++
-            $builder = [System.Text.StringBuilder]::new()
-            $closed = $false
+            $readResult = Read-FVQuotedStringToken -Predicate $Predicate -StartIndex $index
+            if (Test-FVParseError -Value $readResult.Value) { return $readResult.Value }
 
-            while ($index -lt $length) {
-                $current = $Predicate[$index]
-                if ($current -eq [char]92) {
-                    if ($index + 1 -ge $length) {
-                        return (New-FVParseError -Position $start -Message 'Unterminated string literal.')
-                    }
-
-                    [void]$builder.Append($Predicate[$index + 1])
-                    $index += 2
-                    continue
-                }
-
-                if ($current -eq $quote) {
-                    $index++
-                    $closed = $true
-                    break
-                }
-
-                [void]$builder.Append($current)
-                $index++
-            }
-
-            if (-not $closed) {
-                return (New-FVParseError -Position $start -Message 'Unterminated string literal.')
-            }
-
-            $tokens.Add((New-FVToken -Kind 'String' -Value $builder.ToString() -Position $start -Length ($index - $start)))
+            $tokens.Add($readResult.Value)
+            $index = $readResult.NextIndex
             continue
         }
 
         if (($character -eq [char]'-' -and $index + 1 -lt $length -and [char]::IsDigit($Predicate[$index + 1])) -or [char]::IsDigit($character)) {
-            $start = $index
-            if ($character -eq [char]'-') {
-                $index++
-            }
+            $readResult = Read-FVNumberToken -Predicate $Predicate -StartIndex $index
+            if (Test-FVParseError -Value $readResult.Value) { return $readResult.Value }
 
-            while ($index -lt $length -and [char]::IsDigit($Predicate[$index])) {
-                $index++
-            }
-
-            if ($index -lt $length -and $Predicate[$index] -eq [char]'.' -and $index + 1 -lt $length -and [char]::IsDigit($Predicate[$index + 1])) {
-                $index++
-                while ($index -lt $length -and [char]::IsDigit($Predicate[$index])) {
-                    $index++
-                }
-            }
-
-            if ($index -lt $length -and $Predicate[$index] -in @([char]'e', [char]'E')) {
-                $exponentStart = $index
-                $index++
-                if ($index -lt $length -and $Predicate[$index] -in @([char]'+', [char]'-')) {
-                    $index++
-                }
-
-                if ($index -ge $length -or -not [char]::IsDigit($Predicate[$index])) {
-                    return (New-FVParseError -Position $exponentStart -Message 'Malformed number literal.')
-                }
-
-                while ($index -lt $length -and [char]::IsDigit($Predicate[$index])) {
-                    $index++
-                }
-            }
-
-            $number = $Predicate.Substring($start, $index - $start)
-            $tokens.Add((New-FVToken -Kind 'Number' -Value $number -Position $start -Length ($index - $start)))
+            $tokens.Add($readResult.Value)
+            $index = $readResult.NextIndex
             continue
         }
 
         if (Test-FVIdentifierStart -Character $character) {
-            $start = $index
-            $index++
+            $readResult = Read-FVIdentifierOrKeywordToken -Predicate $Predicate -StartIndex $index
+            if (Test-FVParseError -Value $readResult.Value) { return $readResult.Value }
 
-            while ($index -lt $length) {
-                $current = $Predicate[$index]
-                if (Test-FVIdentifierPart -Character $current) {
-                    $index++
-                    continue
-                }
-
-                if ($current -eq [char]'.') {
-                    $index++
-                    if ($index -ge $length -or -not (Test-FVIdentifierStart -Character $Predicate[$index])) {
-                        return (New-FVParseError -Position $index -Message "Expected identifier segment after '.'.")
-                    }
-                    $index++
-                    continue
-                }
-
-                break
-            }
-
-            $identifier = $Predicate.Substring($start, $index - $start)
-            $keyword = $identifier.ToUpperInvariant()
-            if ($keyword -eq 'AND') {
-                $tokens.Add((New-FVToken -Kind 'LogicalOperator' -Value 'AND' -Position $start -Length ($index - $start)))
-                continue
-            }
-
-            if ($keyword -eq 'OR') {
-                $tokens.Add((New-FVToken -Kind 'LogicalOperator' -Value 'OR' -Position $start -Length ($index - $start)))
-                continue
-            }
-
-            if ($keyword -eq 'NOT') {
-                $tokens.Add((New-FVToken -Kind 'Not' -Value 'NOT' -Position $start -Length ($index - $start)))
-                continue
-            }
-
-            if ($keyword -eq 'IN') {
-                $tokens.Add((New-FVToken -Kind 'Comparator' -Value 'in' -Position $start -Length ($index - $start)))
-                continue
-            }
-
-            if ($keyword -eq 'TRUE') {
-                $tokens.Add((New-FVToken -Kind 'Boolean' -Value $true -Position $start -Length ($index - $start)))
-                continue
-            }
-
-            if ($keyword -eq 'FALSE') {
-                $tokens.Add((New-FVToken -Kind 'Boolean' -Value $false -Position $start -Length ($index - $start)))
-                continue
-            }
-
-            $tokens.Add((New-FVToken -Kind 'Identifier' -Value $identifier -Position $start -Length ($index - $start)))
+            $tokens.Add($readResult.Value)
+            $index = $readResult.NextIndex
             continue
         }
 

--- a/.github/scripts/lib/frame-predicate-core.ps1
+++ b/.github/scripts/lib/frame-predicate-core.ps1
@@ -1,0 +1,724 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Library for frame predicate parsing. Dot-source and call ConvertTo-FVPredicate.
+#>
+
+function New-FVParseError {
+    param(
+        [Parameter(Mandatory)][int]$Position,
+        [Parameter(Mandatory)][string]$Message
+    )
+
+    return [PSCustomObject]@{
+        Kind     = 'ParseError'
+        Position = $Position
+        Message  = $Message
+    }
+}
+
+function Test-FVParseError {
+    param($Value)
+
+    return (
+        $null -ne $Value -and
+        $null -ne $Value.PSObject.Properties['Kind'] -and
+        $Value.Kind -eq 'ParseError'
+    )
+}
+
+function New-FVToken {
+    param(
+        [Parameter(Mandatory)][string]$Kind,
+        [AllowNull()]$Value,
+        [Parameter(Mandatory)][int]$Position,
+        [Parameter(Mandatory)][int]$Length
+    )
+
+    return [PSCustomObject]@{
+        Kind     = $Kind
+        Value    = $Value
+        Position = $Position
+        Length   = $Length
+    }
+}
+
+function New-FVTokenStream {
+    param([object[]]$Tokens)
+
+    return [PSCustomObject]@{
+        Kind   = 'TokenStream'
+        Tokens = [object[]]$Tokens
+    }
+}
+
+function Test-FVIdentifierStart {
+    param([char]$Character)
+
+    $code = [int][char]$Character
+    return (
+        ($code -ge [int][char]'A' -and $code -le [int][char]'Z') -or
+        ($code -ge [int][char]'a' -and $code -le [int][char]'z') -or
+        $Character -eq [char]'_'
+    )
+}
+
+function Test-FVIdentifierPart {
+    param([char]$Character)
+
+    $code = [int][char]$Character
+    return (
+        (Test-FVIdentifierStart -Character $Character) -or
+        ($code -ge [int][char]'0' -and $code -le [int][char]'9')
+    )
+}
+
+function Get-FVTokens {
+    [CmdletBinding()]
+    param([AllowNull()][string]$Predicate)
+
+    if ($null -eq $Predicate -or [string]::IsNullOrWhiteSpace($Predicate)) {
+        return (New-FVParseError -Position 0 -Message 'Predicate is required.')
+    }
+
+    $tokens = [System.Collections.Generic.List[object]]::new()
+    $length = $Predicate.Length
+    $index = 0
+
+    while ($index -lt $length) {
+        $character = $Predicate[$index]
+
+        if ([char]::IsWhiteSpace($character)) {
+            $index++
+            continue
+        }
+
+        if ($character -eq [char]'(') {
+            $tokens.Add((New-FVToken -Kind 'LParen' -Value '(' -Position $index -Length 1))
+            $index++
+            continue
+        }
+
+        if ($character -eq [char]')') {
+            $tokens.Add((New-FVToken -Kind 'RParen' -Value ')' -Position $index -Length 1))
+            $index++
+            continue
+        }
+
+        if ($character -eq [char]'[') {
+            $tokens.Add((New-FVToken -Kind 'LBracket' -Value '[' -Position $index -Length 1))
+            $index++
+            continue
+        }
+
+        if ($character -eq [char]']') {
+            $tokens.Add((New-FVToken -Kind 'RBracket' -Value ']' -Position $index -Length 1))
+            $index++
+            continue
+        }
+
+        if ($character -eq [char]',') {
+            $tokens.Add((New-FVToken -Kind 'Comma' -Value ',' -Position $index -Length 1))
+            $index++
+            continue
+        }
+
+        if ($index + 1 -lt $length) {
+            $twoCharacterOperator = $Predicate.Substring($index, 2)
+            if ($twoCharacterOperator -in @('==', '!=', '<=', '>=')) {
+                $tokens.Add((New-FVToken -Kind 'Comparator' -Value $twoCharacterOperator -Position $index -Length 2))
+                $index += 2
+                continue
+            }
+        }
+
+        if ($character -in @([char]'<', [char]'>')) {
+            $tokens.Add((New-FVToken -Kind 'Comparator' -Value ([string]$character) -Position $index -Length 1))
+            $index++
+            continue
+        }
+
+        if ($character -eq [char]'=') {
+            return (New-FVParseError -Position $index -Message "Unexpected '='. Did you mean '=='?")
+        }
+
+        if ($character -eq [char]'!') {
+            return (New-FVParseError -Position $index -Message "Unexpected '!'. Did you mean '!='?")
+        }
+
+        if ($character -eq [char]34 -or $character -eq [char]39) {
+            $quote = $character
+            $start = $index
+            $index++
+            $builder = [System.Text.StringBuilder]::new()
+            $closed = $false
+
+            while ($index -lt $length) {
+                $current = $Predicate[$index]
+                if ($current -eq [char]92) {
+                    if ($index + 1 -ge $length) {
+                        return (New-FVParseError -Position $start -Message 'Unterminated string literal.')
+                    }
+
+                    [void]$builder.Append($Predicate[$index + 1])
+                    $index += 2
+                    continue
+                }
+
+                if ($current -eq $quote) {
+                    $index++
+                    $closed = $true
+                    break
+                }
+
+                [void]$builder.Append($current)
+                $index++
+            }
+
+            if (-not $closed) {
+                return (New-FVParseError -Position $start -Message 'Unterminated string literal.')
+            }
+
+            $tokens.Add((New-FVToken -Kind 'String' -Value $builder.ToString() -Position $start -Length ($index - $start)))
+            continue
+        }
+
+        if (($character -eq [char]'-' -and $index + 1 -lt $length -and [char]::IsDigit($Predicate[$index + 1])) -or [char]::IsDigit($character)) {
+            $start = $index
+            if ($character -eq [char]'-') {
+                $index++
+            }
+
+            while ($index -lt $length -and [char]::IsDigit($Predicate[$index])) {
+                $index++
+            }
+
+            if ($index -lt $length -and $Predicate[$index] -eq [char]'.' -and $index + 1 -lt $length -and [char]::IsDigit($Predicate[$index + 1])) {
+                $index++
+                while ($index -lt $length -and [char]::IsDigit($Predicate[$index])) {
+                    $index++
+                }
+            }
+
+            if ($index -lt $length -and $Predicate[$index] -in @([char]'e', [char]'E')) {
+                $exponentStart = $index
+                $index++
+                if ($index -lt $length -and $Predicate[$index] -in @([char]'+', [char]'-')) {
+                    $index++
+                }
+
+                if ($index -ge $length -or -not [char]::IsDigit($Predicate[$index])) {
+                    return (New-FVParseError -Position $exponentStart -Message 'Malformed number literal.')
+                }
+
+                while ($index -lt $length -and [char]::IsDigit($Predicate[$index])) {
+                    $index++
+                }
+            }
+
+            $number = $Predicate.Substring($start, $index - $start)
+            $tokens.Add((New-FVToken -Kind 'Number' -Value $number -Position $start -Length ($index - $start)))
+            continue
+        }
+
+        if (Test-FVIdentifierStart -Character $character) {
+            $start = $index
+            $index++
+
+            while ($index -lt $length) {
+                $current = $Predicate[$index]
+                if (Test-FVIdentifierPart -Character $current) {
+                    $index++
+                    continue
+                }
+
+                if ($current -eq [char]'.') {
+                    $index++
+                    if ($index -ge $length -or -not (Test-FVIdentifierStart -Character $Predicate[$index])) {
+                        return (New-FVParseError -Position $index -Message "Expected identifier segment after '.'.")
+                    }
+                    $index++
+                    continue
+                }
+
+                break
+            }
+
+            $identifier = $Predicate.Substring($start, $index - $start)
+            $keyword = $identifier.ToUpperInvariant()
+            if ($keyword -eq 'AND') {
+                $tokens.Add((New-FVToken -Kind 'LogicalOperator' -Value 'AND' -Position $start -Length ($index - $start)))
+                continue
+            }
+
+            if ($keyword -eq 'OR') {
+                $tokens.Add((New-FVToken -Kind 'LogicalOperator' -Value 'OR' -Position $start -Length ($index - $start)))
+                continue
+            }
+
+            if ($keyword -eq 'NOT') {
+                $tokens.Add((New-FVToken -Kind 'Not' -Value 'NOT' -Position $start -Length ($index - $start)))
+                continue
+            }
+
+            if ($keyword -eq 'IN') {
+                $tokens.Add((New-FVToken -Kind 'Comparator' -Value 'in' -Position $start -Length ($index - $start)))
+                continue
+            }
+
+            if ($keyword -eq 'TRUE') {
+                $tokens.Add((New-FVToken -Kind 'Boolean' -Value $true -Position $start -Length ($index - $start)))
+                continue
+            }
+
+            if ($keyword -eq 'FALSE') {
+                $tokens.Add((New-FVToken -Kind 'Boolean' -Value $false -Position $start -Length ($index - $start)))
+                continue
+            }
+
+            $tokens.Add((New-FVToken -Kind 'Identifier' -Value $identifier -Position $start -Length ($index - $start)))
+            continue
+        }
+
+        return (New-FVParseError -Position $index -Message "Unexpected character '$character'.")
+    }
+
+    $tokens.Add((New-FVToken -Kind 'EOF' -Value '' -Position $length -Length 0))
+    return (New-FVTokenStream -Tokens $tokens.ToArray())
+}
+
+function New-FVParserState {
+    param([Parameter(Mandatory)][object[]]$Tokens)
+
+    return [PSCustomObject]@{
+        Tokens = [object[]]$Tokens
+        Index  = 0
+    }
+}
+
+function Get-FVCurrentToken {
+    param([Parameter(Mandatory)]$State)
+
+    if ($State.Index -ge $State.Tokens.Count) {
+        return $State.Tokens[$State.Tokens.Count - 1]
+    }
+
+    return $State.Tokens[$State.Index]
+}
+
+function Move-FVToken {
+    param([Parameter(Mandatory)]$State)
+
+    $token = Get-FVCurrentToken -State $State
+    if ($State.Index -lt ($State.Tokens.Count - 1)) {
+        $State.Index = $State.Index + 1
+    }
+
+    return $token
+}
+
+function New-FVIdentifierNode {
+    param([Parameter(Mandatory)]$Token)
+
+    return [PSCustomObject]@{
+        Kind     = 'Identifier'
+        Name     = $Token.Value
+        Position = $Token.Position
+    }
+}
+
+function New-FVScalarLiteralNode {
+    param(
+        [Parameter(Mandatory)][string]$LiteralType,
+        [AllowNull()]$Value,
+        [Parameter(Mandatory)][int]$Position
+    )
+
+    return [PSCustomObject]@{
+        Kind        = 'Literal'
+        LiteralType = $LiteralType
+        Value       = $Value
+        Position    = $Position
+    }
+}
+
+function New-FVArrayLiteralNode {
+    param(
+        [Parameter(Mandatory)][object[]]$Items,
+        [Parameter(Mandatory)][int]$Position
+    )
+
+    return [PSCustomObject]@{
+        Kind        = 'Literal'
+        LiteralType = 'Array'
+        Items       = [object[]]$Items
+        Position    = $Position
+    }
+}
+
+function New-FVComparisonNode {
+    param(
+        [Parameter(Mandatory)]$Left,
+        [Parameter(Mandatory)][string]$Operator,
+        [Parameter(Mandatory)]$Right,
+        [Parameter(Mandatory)][int]$Position
+    )
+
+    return [PSCustomObject]@{
+        Kind     = 'Comparison'
+        Left     = $Left
+        Operator = $Operator
+        Right    = $Right
+        Position = $Position
+    }
+}
+
+function New-FVLogicalNode {
+    param(
+        [Parameter(Mandatory)][string]$Operator,
+        [Parameter(Mandatory)]$Left,
+        [Parameter(Mandatory)]$Right,
+        [Parameter(Mandatory)][int]$Position
+    )
+
+    return [PSCustomObject]@{
+        Kind     = 'Logical'
+        Operator = $Operator
+        Left     = $Left
+        Right    = $Right
+        Position = $Position
+    }
+}
+
+function New-FVNotNode {
+    param(
+        [Parameter(Mandatory)]$Operand,
+        [Parameter(Mandatory)][int]$Position
+    )
+
+    return [PSCustomObject]@{
+        Kind     = 'Not'
+        Operand  = $Operand
+        Position = $Position
+    }
+}
+
+function ConvertTo-FVExpression {
+    param([Parameter(Mandatory)]$State)
+
+    return (ConvertTo-FVOrExpression -State $State)
+}
+
+function ConvertTo-FVLogicalChainExpression {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][string]$Operator,
+        [Parameter(Mandatory)][scriptblock]$OperandParser
+    )
+
+    $left = & $OperandParser $State
+    if (Test-FVParseError -Value $left) { return $left }
+
+    while ($true) {
+        $current = Get-FVCurrentToken -State $State
+        if ($current.Kind -ne 'LogicalOperator' -or $current.Value -ne $Operator) {
+            break
+        }
+
+        $operatorToken = Move-FVToken -State $State
+        $rightStartIndex = $State.Index
+        $right = & $OperandParser $State
+        if (Test-FVParseError -Value $right) {
+            $current = Get-FVCurrentToken -State $State
+            if ($current.Kind -eq 'EOF' -and $State.Index -eq $rightStartIndex) {
+                return (New-FVParseError -Position $operatorToken.Position -Message "Trailing operator '$($operatorToken.Value)'.")
+            }
+
+            return $right
+        }
+
+        $left = New-FVLogicalNode -Operator $operatorToken.Value -Left $left -Right $right -Position $operatorToken.Position
+    }
+
+    return $left
+}
+
+function ConvertTo-FVOrExpression {
+    param([Parameter(Mandatory)]$State)
+
+    return (ConvertTo-FVLogicalChainExpression -State $State -Operator 'OR' -OperandParser {
+        param($ParserState)
+        ConvertTo-FVAndExpression -State $ParserState
+    })
+}
+
+function ConvertTo-FVAndExpression {
+    param([Parameter(Mandatory)]$State)
+
+    return (ConvertTo-FVLogicalChainExpression -State $State -Operator 'AND' -OperandParser {
+        param($ParserState)
+        ConvertTo-FVUnaryExpression -State $ParserState
+    })
+}
+
+function ConvertTo-FVUnaryExpression {
+    param([Parameter(Mandatory)]$State)
+
+    $current = Get-FVCurrentToken -State $State
+    if ($current.Kind -ne 'Not') {
+        return (ConvertTo-FVPrimaryExpression -State $State)
+    }
+
+    $notToken = Move-FVToken -State $State
+    $next = Get-FVCurrentToken -State $State
+    if ($next.Kind -eq 'EOF') {
+        return (New-FVParseError -Position $notToken.Position -Message "Missing operand after 'NOT'.")
+    }
+
+    if ($next.Kind -eq 'Not') {
+        return (New-FVParseError -Position $next.Position -Message "Unexpected 'NOT' after 'NOT'.")
+    }
+
+    if ($next.Kind -in @('LogicalOperator', 'Comparator', 'RParen', 'Comma', 'RBracket')) {
+        return (New-FVParseError -Position $next.Position -Message "Expected comparison after 'NOT'.")
+    }
+
+    $operand = ConvertTo-FVUnaryExpression -State $State
+    if (Test-FVParseError -Value $operand) { return $operand }
+
+    return (New-FVNotNode -Operand $operand -Position $notToken.Position)
+}
+
+function ConvertTo-FVPrimaryExpression {
+    param([Parameter(Mandatory)]$State)
+
+    $current = Get-FVCurrentToken -State $State
+    switch ($current.Kind) {
+        'EOF' {
+            return (New-FVParseError -Position $current.Position -Message 'Expected comparison.')
+        }
+        'LParen' {
+            $openToken = Move-FVToken -State $State
+            $expression = ConvertTo-FVExpression -State $State
+            if (Test-FVParseError -Value $expression) { return $expression }
+
+            $closeToken = Get-FVCurrentToken -State $State
+            if ($closeToken.Kind -eq 'EOF') {
+                return (New-FVParseError -Position $openToken.Position -Message "Unclosed '('.")
+            }
+
+            if ($closeToken.Kind -ne 'RParen') {
+                return (New-FVParseError -Position $closeToken.Position -Message "Expected ')'.")
+            }
+
+            $null = Move-FVToken -State $State
+            return $expression
+        }
+        'Identifier' {
+            return (ConvertTo-FVComparison -State $State)
+        }
+        'LogicalOperator' {
+            return (New-FVParseError -Position $current.Position -Message "Unexpected operator '$($current.Value)'.")
+        }
+        'Comparator' {
+            return (New-FVParseError -Position $current.Position -Message "Unexpected comparator '$($current.Value)'.")
+        }
+        'RParen' {
+            return (New-FVParseError -Position $current.Position -Message "Unexpected ')'.")
+        }
+        default {
+            return (New-FVParseError -Position $current.Position -Message "Expected identifier or '('.")
+        }
+    }
+}
+
+function ConvertTo-FVComparison {
+    param([Parameter(Mandatory)]$State)
+
+    $leftToken = Move-FVToken -State $State
+    $current = Get-FVCurrentToken -State $State
+    if ($current.Kind -ne 'Comparator') {
+        return (New-FVParseError -Position $current.Position -Message "Expected comparator after identifier '$($leftToken.Value)'.")
+    }
+
+    $operatorToken = Move-FVToken -State $State
+    $literal = ConvertTo-FVLiteral -State $State -Context "Expected literal after '$($operatorToken.Value)'."
+    if (Test-FVParseError -Value $literal) {
+        if ((Get-FVCurrentToken -State $State).Kind -eq 'EOF') {
+            return (New-FVParseError -Position (Get-FVCurrentToken -State $State).Position -Message "Missing right-hand literal for '$($operatorToken.Value)'.")
+        }
+
+        return $literal
+    }
+
+    return (New-FVComparisonNode -Left (New-FVIdentifierNode -Token $leftToken) -Operator $operatorToken.Value -Right $literal -Position $operatorToken.Position)
+}
+
+function ConvertTo-FVLiteral {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][string]$Context
+    )
+
+    $current = Get-FVCurrentToken -State $State
+    switch ($current.Kind) {
+        'String' {
+            $token = Move-FVToken -State $State
+            return (New-FVScalarLiteralNode -LiteralType 'String' -Value $token.Value -Position $token.Position)
+        }
+        'Number' {
+            $token = Move-FVToken -State $State
+            return (New-FVScalarLiteralNode -LiteralType 'Number' -Value $token.Value -Position $token.Position)
+        }
+        'Boolean' {
+            $token = Move-FVToken -State $State
+            return (New-FVScalarLiteralNode -LiteralType 'Boolean' -Value $token.Value -Position $token.Position)
+        }
+        'LBracket' {
+            return (ConvertTo-FVArrayLiteral -State $State)
+        }
+        default {
+            return (New-FVParseError -Position $current.Position -Message $Context)
+        }
+    }
+}
+
+function ConvertTo-FVArrayLiteral {
+    param([Parameter(Mandatory)]$State)
+
+    $openToken = Move-FVToken -State $State
+    $items = [System.Collections.Generic.List[object]]::new()
+    $current = Get-FVCurrentToken -State $State
+
+    if ($current.Kind -eq 'RBracket') {
+        $null = Move-FVToken -State $State
+        return (New-FVArrayLiteralNode -Items $items.ToArray() -Position $openToken.Position)
+    }
+
+    while ($true) {
+        $current = Get-FVCurrentToken -State $State
+        if ($current.Kind -eq 'EOF') {
+            return (New-FVParseError -Position $openToken.Position -Message "Unclosed '['.")
+        }
+
+        if ($current.Kind -in @('Comma', 'RBracket')) {
+            return (New-FVParseError -Position $current.Position -Message 'Expected literal in array.')
+        }
+
+        $item = ConvertTo-FVLiteral -State $State -Context 'Expected literal in array.'
+        if (Test-FVParseError -Value $item) { return $item }
+        $items.Add($item)
+
+        $current = Get-FVCurrentToken -State $State
+        if ($current.Kind -eq 'Comma') {
+            $commaToken = Move-FVToken -State $State
+            $next = Get-FVCurrentToken -State $State
+            if ($next.Kind -eq 'EOF') {
+                return (New-FVParseError -Position $openToken.Position -Message "Unclosed '['.")
+            }
+
+            if ($next.Kind -eq 'RBracket') {
+                return (New-FVParseError -Position $commaToken.Position -Message "Expected literal after ','.")
+            }
+
+            continue
+        }
+
+        if ($current.Kind -eq 'RBracket') {
+            $null = Move-FVToken -State $State
+            return (New-FVArrayLiteralNode -Items $items.ToArray() -Position $openToken.Position)
+        }
+
+        if ($current.Kind -eq 'EOF') {
+            return (New-FVParseError -Position $openToken.Position -Message "Unclosed '['.")
+        }
+
+        return (New-FVParseError -Position $current.Position -Message "Expected ',' or ']' in array.")
+    }
+}
+
+function Test-FVExpressionStructure {
+    param([Parameter(Mandatory)]$Node)
+
+    if (Test-FVParseError -Value $Node) { return $Node }
+    if ($null -eq $Node -or $null -eq $Node.PSObject.Properties['Kind']) {
+        return (New-FVParseError -Position 0 -Message 'Internal parser error: missing AST node kind.')
+    }
+
+    switch ($Node.Kind) {
+        'Comparison' {
+            if ($null -eq $Node.Left -or $Node.Left.Kind -ne 'Identifier') {
+                return (New-FVParseError -Position $Node.Position -Message 'Internal parser error: comparison left side must be an identifier.')
+            }
+
+            if ($Node.Operator -notin @('==', '!=', '<', '>', '<=', '>=', 'in')) {
+                return (New-FVParseError -Position $Node.Position -Message "Internal parser error: unsupported comparator '$($Node.Operator)'.")
+            }
+
+            if ($null -eq $Node.Right -or $Node.Right.Kind -ne 'Literal') {
+                return (New-FVParseError -Position $Node.Position -Message 'Internal parser error: comparison right side must be a literal.')
+            }
+
+            return $true
+        }
+        'Logical' {
+            if ($Node.Operator -notin @('AND', 'OR')) {
+                return (New-FVParseError -Position $Node.Position -Message "Internal parser error: unsupported logical operator '$($Node.Operator)'.")
+            }
+
+            $leftResult = Test-FVExpressionStructure -Node $Node.Left
+            if (Test-FVParseError -Value $leftResult) { return $leftResult }
+
+            $rightResult = Test-FVExpressionStructure -Node $Node.Right
+            if (Test-FVParseError -Value $rightResult) { return $rightResult }
+
+            return $true
+        }
+        'Not' {
+            $operandResult = Test-FVExpressionStructure -Node $Node.Operand
+            if (Test-FVParseError -Value $operandResult) { return $operandResult }
+            return $true
+        }
+        default {
+            return (New-FVParseError -Position 0 -Message "Internal parser error: unknown AST node kind '$($Node.Kind)'.")
+        }
+    }
+}
+
+function ConvertTo-FVPredicate {
+    [CmdletBinding()]
+    param([AllowNull()][string]$Predicate)
+
+    $tokenStream = Get-FVTokens -Predicate $Predicate
+    if (Test-FVParseError -Value $tokenStream) { return $tokenStream }
+
+    $state = New-FVParserState -Tokens $tokenStream.Tokens
+    $expression = ConvertTo-FVExpression -State $state
+    if (Test-FVParseError -Value $expression) { return $expression }
+
+    $current = Get-FVCurrentToken -State $state
+    if ($current.Kind -ne 'EOF') {
+        switch ($current.Kind) {
+            'RParen' {
+                return (New-FVParseError -Position $current.Position -Message "Unexpected ')'.")
+            }
+            'LogicalOperator' {
+                return (New-FVParseError -Position $current.Position -Message "Unexpected operator '$($current.Value)'.")
+            }
+            'Comparator' {
+                return (New-FVParseError -Position $current.Position -Message "Unexpected comparator '$($current.Value)'.")
+            }
+            'Not' {
+                return (New-FVParseError -Position $current.Position -Message "Unexpected 'NOT'. Expected logical operator or end of predicate.")
+            }
+            default {
+                return (New-FVParseError -Position $current.Position -Message "Unexpected token '$($current.Value)'.")
+            }
+        }
+    }
+
+    $structureResult = Test-FVExpressionStructure -Node $expression
+    if (Test-FVParseError -Value $structureResult) { return $structureResult }
+
+    return $expression
+}

--- a/.github/scripts/lib/frame-validate-core.ps1
+++ b/.github/scripts/lib/frame-validate-core.ps1
@@ -215,7 +215,7 @@ function Get-FVProvidesDeclarationValues {
     param(
         [Parameter(Mandatory)][string[]]$Lines,
         [Parameter(Mandatory)][int]$LineIndex,
-        [Parameter(Mandatory)][string]$Value
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Value
     )
 
     if ($Value.Length -gt 0) {

--- a/.github/scripts/lib/frame-validate-core.ps1
+++ b/.github/scripts/lib/frame-validate-core.ps1
@@ -106,6 +106,13 @@ function Get-FVAdapterFiles {
             if (Test-Path -LiteralPath $skillFile) {
                 $files.Add((Get-Item -LiteralPath $skillFile))
             }
+
+            $adaptersPath = Join-Path -Path $directory.FullName -ChildPath 'adapters'
+            if (Test-Path -LiteralPath $adaptersPath) {
+                foreach ($file in @(Get-ChildItem -LiteralPath $adaptersPath -Filter '*.md' -File)) {
+                    $files.Add($file)
+                }
+            }
         }
     }
 
@@ -119,12 +126,88 @@ function Get-FVAdapterFiles {
     return @($files.ToArray() | Sort-Object -Property FullName)
 }
 
+function Remove-FVYamlTrailingComment {
+    param([AllowNull()][string]$Value)
+
+    if ($null -eq $Value) { return '' }
+
+    $quote = [char]0
+    for ($index = 0; $index -lt $Value.Length; $index++) {
+        $character = $Value[$index]
+
+        if ($quote -ne [char]0) {
+            if ($quote -eq [char]34 -and $character -eq [char]92) {
+                $index++
+                continue
+            }
+
+            if ($character -eq $quote) {
+                if ($quote -eq [char]39 -and $index + 1 -lt $Value.Length -and $Value[$index + 1] -eq [char]39) {
+                    $index++
+                    continue
+                }
+
+                $quote = [char]0
+            }
+
+            continue
+        }
+
+        if ($character -eq [char]34 -or $character -eq [char]39) {
+            $quote = $character
+            continue
+        }
+
+        if ($character -eq [char]'#' -and ($index -eq 0 -or [char]::IsWhiteSpace($Value[$index - 1]))) {
+            return $Value.Substring(0, $index).TrimEnd()
+        }
+    }
+
+    return $Value.TrimEnd()
+}
+
+function ConvertFrom-FVYamlDoubleQuotedScalar {
+    param([Parameter(Mandatory)][string]$Value)
+
+    $builder = [System.Text.StringBuilder]::new()
+    $index = 0
+    while ($index -lt $Value.Length) {
+        $character = $Value[$index]
+        if ($character -eq [char]92 -and $index + 1 -lt $Value.Length) {
+            $next = $Value[$index + 1]
+            switch ([string]$next) {
+                '"' { [void]$builder.Append([char]34) }
+                '\' { [void]$builder.Append([char]92) }
+                '/' { [void]$builder.Append('/') }
+                'n' { [void]$builder.Append("`n") }
+                'r' { [void]$builder.Append("`r") }
+                't' { [void]$builder.Append("`t") }
+                default { [void]$builder.Append($next) }
+            }
+
+            $index += 2
+            continue
+        }
+
+        [void]$builder.Append($character)
+        $index++
+    }
+
+    return $builder.ToString()
+}
+
+function Test-FVYamlBlockScalarIndicator {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Value)
+
+    return [regex]::IsMatch($Value, '^[|>][+-]?$')
+}
+
 function ConvertFrom-FVYamlScalar {
     param([AllowNull()][string]$Value)
 
     if ($null -eq $Value) { return '' }
 
-    $trimmed = $Value.Trim()
+    $trimmed = (Remove-FVYamlTrailingComment -Value $Value).Trim()
     if ($trimmed.Length -lt 2) { return $trimmed }
 
     if ($trimmed.StartsWith("'") -and $trimmed.EndsWith("'")) {
@@ -132,7 +215,7 @@ function ConvertFrom-FVYamlScalar {
     }
 
     if ($trimmed.StartsWith('"') -and $trimmed.EndsWith('"')) {
-        return $trimmed.Substring(1, $trimmed.Length - 2).Replace('\\"', '"')
+        return (ConvertFrom-FVYamlDoubleQuotedScalar -Value $trimmed.Substring(1, $trimmed.Length - 2))
     }
 
     return $trimmed
@@ -141,7 +224,7 @@ function ConvertFrom-FVYamlScalar {
 function Split-FVInlineValues {
     param([Parameter(Mandatory)][string]$Value)
 
-    $trimmed = $Value.Trim()
+    $trimmed = (Remove-FVYamlTrailingComment -Value $Value).Trim()
     if ($trimmed -eq '[]') { return [string[]]@() }
 
     if (-not ($trimmed.StartsWith('[') -and $trimmed.EndsWith(']'))) {
@@ -236,8 +319,9 @@ function Get-FVProvidesDeclarationValues {
         [Parameter(Mandatory)][AllowEmptyString()][string]$Value
     )
 
-    if ($Value.Length -gt 0) {
-        return [string[]]@(Split-FVInlineValues -Value $Value)
+    $normalizedValue = (Remove-FVYamlTrailingComment -Value $Value).Trim()
+    if ($normalizedValue.Length -gt 0) {
+        return [string[]]@(Split-FVInlineValues -Value $normalizedValue)
     }
 
     return [string[]]@(Get-FVIndentedListValues -Lines $Lines -StartIndex ($LineIndex + 1))
@@ -247,14 +331,15 @@ function Get-FVAppliesWhenDeclarationValue {
     param(
         [Parameter(Mandatory)][string[]]$Lines,
         [Parameter(Mandatory)][int]$LineIndex,
-        [Parameter(Mandatory)][string]$Value
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Value
     )
 
-    if ($Value -in @('|', '>')) {
+    $normalizedValue = (Remove-FVYamlTrailingComment -Value $Value).Trim()
+    if (Test-FVYamlBlockScalarIndicator -Value $normalizedValue) {
         return (Get-FVIndentedScalarValue -Lines $Lines -StartIndex ($LineIndex + 1))
     }
 
-    return (ConvertFrom-FVYamlScalar -Value $Value)
+    return (ConvertFrom-FVYamlScalar -Value $normalizedValue)
 }
 
 function Get-FVAdapterFrontmatter {

--- a/.github/scripts/lib/frame-validate-core.ps1
+++ b/.github/scripts/lib/frame-validate-core.ps1
@@ -1,0 +1,425 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Library for frame adapter validation. Dot-source and call Invoke-FrameValidate.
+#>
+
+$script:FVLibDir = Split-Path -Parent $PSCommandPath
+. (Join-Path -Path $script:FVLibDir -ChildPath 'frame-predicate-core.ps1')
+
+function New-FVCheckResult {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][bool]$Passed,
+        [AllowNull()][string]$Detail
+    )
+
+    return [PSCustomObject]@{
+        Name   = $Name
+        Passed = $Passed
+        Detail = if ($null -eq $Detail) { '' } else { $Detail }
+    }
+}
+
+function Resolve-FVRootPath {
+    param([AllowNull()][string]$RootPath)
+
+    if ($RootPath) {
+        return (Resolve-Path -LiteralPath $RootPath).Path
+    }
+
+    return (Resolve-Path -LiteralPath (Join-Path -Path $script:FVLibDir -ChildPath '../../..')).Path
+}
+
+function Get-FVRelativePath {
+    param(
+        [Parameter(Mandatory)][string]$RootPath,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    return ([System.IO.Path]::GetRelativePath($RootPath, $Path) -replace '\\', '/')
+}
+
+function Get-FVPortCatalog {
+    param([Parameter(Mandatory)][string]$RootPath)
+
+    $portsPath = Join-Path -Path $RootPath -ChildPath 'frame' -AdditionalChildPath 'ports'
+    if (-not (Test-Path -LiteralPath $portsPath)) {
+        return [PSCustomObject]@{
+            Exists = $false
+            Path   = $portsPath
+            Names  = [string[]]@()
+        }
+    }
+
+    $names = @(
+        Get-ChildItem -LiteralPath $portsPath -Filter '*.yaml' -File |
+            ForEach-Object { $_.BaseName } |
+            Sort-Object
+    )
+
+    return [PSCustomObject]@{
+        Exists = $true
+        Path   = $portsPath
+        Names  = [string[]]$names
+    }
+}
+
+function Get-FVAdapterFiles {
+    param([Parameter(Mandatory)][string]$RootPath)
+
+    $files = [System.Collections.Generic.List[System.IO.FileInfo]]::new()
+
+    $agentsPath = Join-Path -Path $RootPath -ChildPath 'agents'
+    if (Test-Path -LiteralPath $agentsPath) {
+        foreach ($file in @(Get-ChildItem -LiteralPath $agentsPath -Filter '*.agent.md' -File)) {
+            $files.Add($file)
+        }
+
+        foreach ($file in @(Get-ChildItem -LiteralPath $agentsPath -Filter '*.md' -File | Where-Object { $_.Name -notlike '*.agent.md' })) {
+            $files.Add($file)
+        }
+    }
+
+    $skillsPath = Join-Path -Path $RootPath -ChildPath 'skills'
+    if (Test-Path -LiteralPath $skillsPath) {
+        foreach ($directory in @(Get-ChildItem -LiteralPath $skillsPath -Directory)) {
+            $skillFile = Join-Path -Path $directory.FullName -ChildPath 'SKILL.md'
+            if (Test-Path -LiteralPath $skillFile) {
+                $files.Add((Get-Item -LiteralPath $skillFile))
+            }
+        }
+    }
+
+    $commandsPath = Join-Path -Path $RootPath -ChildPath 'commands'
+    if (Test-Path -LiteralPath $commandsPath) {
+        foreach ($file in @(Get-ChildItem -LiteralPath $commandsPath -Filter '*.md' -File)) {
+            $files.Add($file)
+        }
+    }
+
+    return $files.ToArray()
+}
+
+function ConvertFrom-FVYamlScalar {
+    param([AllowNull()][string]$Value)
+
+    if ($null -eq $Value) { return '' }
+
+    $trimmed = $Value.Trim()
+    if ($trimmed.Length -lt 2) { return $trimmed }
+
+    if ($trimmed.StartsWith("'") -and $trimmed.EndsWith("'")) {
+        return $trimmed.Substring(1, $trimmed.Length - 2).Replace("''", "'")
+    }
+
+    if ($trimmed.StartsWith('"') -and $trimmed.EndsWith('"')) {
+        return $trimmed.Substring(1, $trimmed.Length - 2).Replace('\\"', '"')
+    }
+
+    return $trimmed
+}
+
+function Split-FVInlineValues {
+    param([Parameter(Mandatory)][string]$Value)
+
+    $trimmed = $Value.Trim()
+    if ($trimmed -eq '[]') { return [string[]]@() }
+
+    if (-not ($trimmed.StartsWith('[') -and $trimmed.EndsWith(']'))) {
+        return [string[]]@((ConvertFrom-FVYamlScalar -Value $trimmed))
+    }
+
+    $inner = $trimmed.Substring(1, $trimmed.Length - 2)
+    $values = [System.Collections.Generic.List[string]]::new()
+    $builder = [System.Text.StringBuilder]::new()
+    $quote = [char]0
+
+    foreach ($character in $inner.ToCharArray()) {
+        if ($quote -ne [char]0) {
+            [void]$builder.Append($character)
+            if ($character -eq $quote) { $quote = [char]0 }
+            continue
+        }
+
+        if ($character -eq [char]34 -or $character -eq [char]39) {
+            $quote = $character
+            [void]$builder.Append($character)
+            continue
+        }
+
+        if ($character -eq [char]',') {
+            $item = ConvertFrom-FVYamlScalar -Value $builder.ToString()
+            if ($item.Length -gt 0) { $values.Add($item) }
+            $null = $builder.Clear()
+            continue
+        }
+
+        [void]$builder.Append($character)
+    }
+
+    $lastItem = ConvertFrom-FVYamlScalar -Value $builder.ToString()
+    if ($lastItem.Length -gt 0) { $values.Add($lastItem) }
+
+    return $values.ToArray()
+}
+
+function Test-FVTopLevelFrontmatterKey {
+    param([Parameter(Mandatory)][string]$Line)
+
+    return [regex]::IsMatch($Line, '^[A-Za-z0-9_-]+:\s*')
+}
+
+function Get-FVIndentedListValues {
+    param(
+        [Parameter(Mandatory)][string[]]$Lines,
+        [Parameter(Mandatory)][int]$StartIndex
+    )
+
+    $values = [System.Collections.Generic.List[string]]::new()
+    for ($lineIndex = $StartIndex; $lineIndex -lt $Lines.Count; $lineIndex++) {
+        $line = $Lines[$lineIndex]
+        if ([string]::IsNullOrWhiteSpace($line) -or $line.TrimStart().StartsWith('#')) { continue }
+        if (Test-FVTopLevelFrontmatterKey -Line $line) { break }
+
+        $match = [regex]::Match($line, '^\s*-\s*(?<value>.*?)\s*$')
+        if ($match.Success) {
+            $value = ConvertFrom-FVYamlScalar -Value $match.Groups['value'].Value
+            if ($value.Length -gt 0) { $values.Add($value) }
+        }
+    }
+
+    return $values.ToArray()
+}
+
+function Get-FVIndentedScalarValue {
+    param(
+        [Parameter(Mandatory)][string[]]$Lines,
+        [Parameter(Mandatory)][int]$StartIndex
+    )
+
+    $parts = [System.Collections.Generic.List[string]]::new()
+    for ($lineIndex = $StartIndex; $lineIndex -lt $Lines.Count; $lineIndex++) {
+        $line = $Lines[$lineIndex]
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        if (Test-FVTopLevelFrontmatterKey -Line $line) { break }
+
+        $part = $line.Trim()
+        if ($part.Length -gt 0) { $parts.Add($part) }
+    }
+
+    return ($parts -join ' ').Trim()
+}
+
+function Get-FVProvidesDeclarationValues {
+    param(
+        [Parameter(Mandatory)][string[]]$Lines,
+        [Parameter(Mandatory)][int]$LineIndex,
+        [Parameter(Mandatory)][string]$Value
+    )
+
+    if ($Value.Length -gt 0) {
+        return [string[]]@(Split-FVInlineValues -Value $Value)
+    }
+
+    return [string[]]@(Get-FVIndentedListValues -Lines $Lines -StartIndex ($LineIndex + 1))
+}
+
+function Get-FVAppliesWhenDeclarationValue {
+    param(
+        [Parameter(Mandatory)][string[]]$Lines,
+        [Parameter(Mandatory)][int]$LineIndex,
+        [Parameter(Mandatory)][string]$Value
+    )
+
+    if ($Value -in @('|', '>')) {
+        return (Get-FVIndentedScalarValue -Lines $Lines -StartIndex ($LineIndex + 1))
+    }
+
+    return (ConvertFrom-FVYamlScalar -Value $Value)
+}
+
+function Get-FVAdapterFrontmatter {
+    param([Parameter(Mandatory)][System.IO.FileInfo]$File)
+
+    $metadata = [PSCustomObject]@{
+        File        = $File
+        Provides    = [string[]]@()
+        AppliesWhen = [string[]]@()
+    }
+
+    $content = Get-Content -LiteralPath $File.FullName -Raw
+    $match = [regex]::Match($content, '(?ms)\A---\r?\n(?<yaml>.*?)\r?\n---(?:\r?\n|\z)')
+    if (-not $match.Success) { return $metadata }
+
+    $lines = [string[]]($match.Groups['yaml'].Value -split "`r?`n")
+    $provides = [System.Collections.Generic.List[string]]::new()
+    $appliesWhen = [System.Collections.Generic.List[string]]::new()
+
+    for ($lineIndex = 0; $lineIndex -lt $lines.Count; $lineIndex++) {
+        $line = $lines[$lineIndex]
+        if ([string]::IsNullOrWhiteSpace($line) -or $line.TrimStart().StartsWith('#')) { continue }
+
+        $keyMatch = [regex]::Match($line, '^(?<key>[A-Za-z0-9_-]+):(?<value>.*)$')
+        if (-not $keyMatch.Success) { continue }
+
+        $key = $keyMatch.Groups['key'].Value
+        $value = $keyMatch.Groups['value'].Value.Trim()
+
+        if ($key -eq 'provides') {
+            foreach ($providedPort in @(Get-FVProvidesDeclarationValues -Lines $lines -LineIndex $lineIndex -Value $value)) {
+                if ($providedPort.Length -gt 0) { $provides.Add($providedPort) }
+            }
+
+            continue
+        }
+
+        if ($key -eq 'applies-when') {
+            $appliesWhen.Add((Get-FVAppliesWhenDeclarationValue -Lines $lines -LineIndex $lineIndex -Value $value))
+        }
+    }
+
+    $metadata.Provides = [string[]]$provides.ToArray()
+    $metadata.AppliesWhen = [string[]]$appliesWhen.ToArray()
+
+    return $metadata
+}
+
+function Get-FVAdapterMetadata {
+    param([Parameter(Mandatory)][string]$RootPath)
+
+    return @(
+        foreach ($file in @(Get-FVAdapterFiles -RootPath $RootPath)) {
+            Get-FVAdapterFrontmatter -File $file
+        }
+    )
+}
+
+function Test-FVAdapterSymmetry {
+    [CmdletBinding()]
+    param(
+        [string]$RootPath,
+        [AllowNull()][object[]]$AdapterMetadata
+    )
+
+    $resolvedRoot = Resolve-FVRootPath -RootPath $RootPath
+    $catalog = Get-FVPortCatalog -RootPath $resolvedRoot
+
+    if (-not $catalog.Exists) {
+        $relativePortsPath = Get-FVRelativePath -RootPath $resolvedRoot -Path $catalog.Path
+        return (New-FVCheckResult -Name 'AdapterSymmetry' -Passed $true -Detail "$relativePortsPath missing; adapter symmetry skipped.")
+    }
+
+    $validPorts = [string[]]$catalog.Names
+    $validPortSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$validPorts, [System.StringComparer]::Ordinal)
+    $validPortDetail = if ($validPorts.Count -gt 0) { $validPorts -join ', ' } else { '(none)' }
+    $violations = [System.Collections.Generic.List[string]]::new()
+    $adapters = if ($PSBoundParameters.ContainsKey('AdapterMetadata')) { @($AdapterMetadata) } else { @(Get-FVAdapterMetadata -RootPath $resolvedRoot) }
+
+    foreach ($adapter in $adapters) {
+        $relativePath = Get-FVRelativePath -RootPath $resolvedRoot -Path $adapter.File.FullName
+        foreach ($providedPort in @($adapter.Provides)) {
+            if (-not $validPortSet.Contains($providedPort)) {
+                $violations.Add("$relativePath provides '$providedPort'; valid ports: $validPortDetail")
+            }
+        }
+    }
+
+    if ($violations.Count -eq 0) {
+        return (New-FVCheckResult -Name 'AdapterSymmetry' -Passed $true -Detail '')
+    }
+
+    return (New-FVCheckResult -Name 'AdapterSymmetry' -Passed $false -Detail "$($violations.Count) invalid provides declaration(s): $($violations -join '; ')")
+}
+
+function Test-FVPredicateParse {
+    [CmdletBinding()]
+    param(
+        [string]$RootPath,
+        [AllowNull()][object[]]$AdapterMetadata
+    )
+
+    $resolvedRoot = Resolve-FVRootPath -RootPath $RootPath
+    $violations = [System.Collections.Generic.List[string]]::new()
+    $adapters = if ($PSBoundParameters.ContainsKey('AdapterMetadata')) { @($AdapterMetadata) } else { @(Get-FVAdapterMetadata -RootPath $resolvedRoot) }
+
+    foreach ($adapter in $adapters) {
+        $relativePath = Get-FVRelativePath -RootPath $resolvedRoot -Path $adapter.File.FullName
+        foreach ($predicate in @($adapter.AppliesWhen)) {
+            try {
+                $result = ConvertTo-FVPredicate -Predicate $predicate
+                if (Test-FVParseError -Value $result) {
+                    $violations.Add("$relativePath applies-when '$predicate'; parse error at position $($result.Position): $($result.Message)")
+                }
+            }
+            catch {
+                $violations.Add("$relativePath applies-when '$predicate'; parse error at position 0: $_")
+            }
+        }
+    }
+
+    if ($violations.Count -eq 0) {
+        return (New-FVCheckResult -Name 'PredicateParse' -Passed $true -Detail '')
+    }
+
+    return (New-FVCheckResult -Name 'PredicateParse' -Passed $false -Detail "$($violations.Count) applies-when parse error(s): $($violations -join '; ')")
+}
+
+function Invoke-FrameValidate {
+    [CmdletBinding()]
+    param([string]$RootPath)
+
+    $ErrorActionPreference = 'Stop'
+    Set-StrictMode -Version Latest
+
+    try {
+        $resolvedRoot = Resolve-FVRootPath -RootPath $RootPath
+        $results = [System.Collections.Generic.List[PSCustomObject]]::new()
+        $adapterMetadataCache = [PSCustomObject]@{
+            Loaded = $false
+            Value  = [object[]]@()
+        }
+        $getAdapterMetadata = {
+            if (-not $adapterMetadataCache.Loaded) {
+                $adapterMetadataCache.Value = [object[]]@(Get-FVAdapterMetadata -RootPath $resolvedRoot)
+                $adapterMetadataCache.Loaded = $true
+            }
+
+            return $adapterMetadataCache.Value
+        }
+
+        foreach ($check in @(
+                @{ Name = 'AdapterSymmetry'; Script = { Test-FVAdapterSymmetry -RootPath $resolvedRoot -AdapterMetadata (& $getAdapterMetadata) } },
+                @{ Name = 'PredicateParse'; Script = { Test-FVPredicateParse -RootPath $resolvedRoot -AdapterMetadata (& $getAdapterMetadata) } }
+            )) {
+            try {
+                $results.Add((& $check.Script))
+            }
+            catch {
+                $results.Add((New-FVCheckResult -Name $check.Name -Passed $false -Detail "Error: $_"))
+            }
+        }
+
+        $passCount = @($results | Where-Object { $_.Passed -eq $true }).Count
+        $failCount = @($results | Where-Object { $_.Passed -eq $false }).Count
+        $totalCount = $results.Count
+        $exitCode = if ($failCount -gt 0) { 1 } else { 0 }
+
+        return [PSCustomObject]@{
+            Results    = $results.ToArray()
+            PassCount  = [int]$passCount
+            FailCount  = [int]$failCount
+            TotalCount = [int]$totalCount
+            ExitCode   = [int]$exitCode
+        }
+    }
+    catch {
+        return [PSCustomObject]@{
+            Results    = @((New-FVCheckResult -Name 'FrameValidate' -Passed $false -Detail "Error: $_"))
+            PassCount  = 0
+            FailCount  = 1
+            TotalCount = 1
+            ExitCode   = 1
+        }
+    }
+}

--- a/.github/scripts/lib/frame-validate-core.ps1
+++ b/.github/scripts/lib/frame-validate-core.ps1
@@ -21,6 +21,24 @@ function New-FVCheckResult {
     }
 }
 
+function New-FVAggregateResult {
+    param([AllowNull()][object[]]$Results)
+
+    $normalizedResults = if ($null -eq $Results) { @() } else { @($Results) }
+    $passCount = @($normalizedResults | Where-Object { $_.Passed -eq $true }).Count
+    $failCount = @($normalizedResults | Where-Object { $_.Passed -eq $false }).Count
+    $totalCount = $normalizedResults.Count
+    $exitCode = if ($failCount -gt 0) { 1 } else { 0 }
+
+    return [PSCustomObject]@{
+        Results    = [object[]]$normalizedResults
+        PassCount  = [int]$passCount
+        FailCount  = [int]$failCount
+        TotalCount = [int]$totalCount
+        ExitCode   = [int]$exitCode
+    }
+}
+
 function Resolve-FVRootPath {
     param([AllowNull()][string]$RootPath)
 
@@ -98,7 +116,7 @@ function Get-FVAdapterFiles {
         }
     }
 
-    return $files.ToArray()
+    return @($files.ToArray() | Sort-Object -Property FullName)
 }
 
 function ConvertFrom-FVYamlScalar {
@@ -400,26 +418,9 @@ function Invoke-FrameValidate {
             }
         }
 
-        $passCount = @($results | Where-Object { $_.Passed -eq $true }).Count
-        $failCount = @($results | Where-Object { $_.Passed -eq $false }).Count
-        $totalCount = $results.Count
-        $exitCode = if ($failCount -gt 0) { 1 } else { 0 }
-
-        return [PSCustomObject]@{
-            Results    = $results.ToArray()
-            PassCount  = [int]$passCount
-            FailCount  = [int]$failCount
-            TotalCount = [int]$totalCount
-            ExitCode   = [int]$exitCode
-        }
+        return (New-FVAggregateResult -Results $results.ToArray())
     }
     catch {
-        return [PSCustomObject]@{
-            Results    = @((New-FVCheckResult -Name 'FrameValidate' -Passed $false -Detail "Error: $_"))
-            PassCount  = 0
-            FailCount  = 1
-            TotalCount = 1
-            ExitCode   = 1
-        }
+        return (New-FVAggregateResult -Results @((New-FVCheckResult -Name 'FrameValidate' -Passed $false -Detail "Error: $_")))
     }
 }

--- a/.github/scripts/lib/quick-validate-core.ps1
+++ b/.github/scripts/lib/quick-validate-core.ps1
@@ -396,7 +396,8 @@ function Invoke-QuickValidate {
 
         foreach ($r in $results) {
             if ($r.Passed -eq $true) {
-                Write-Host "[PASS] $($r.Name)"
+                $detail = if (-not [string]::IsNullOrWhiteSpace($r.Detail)) { " — $($r.Detail)" } else { '' }
+                Write-Host "[PASS] $($r.Name)$detail"
             }
             elseif ($r.Passed -eq 'SKIP') {
                 Write-Host "[SKIP] $($r.Name) — $($r.Detail)"

--- a/.github/scripts/lib/quick-validate-core.ps1
+++ b/.github/scripts/lib/quick-validate-core.ps1
@@ -4,6 +4,9 @@
     Library for quick-validate logic. Dot-source this file and call Invoke-QuickValidate.
 #>
 
+$script:QVLibDir = Split-Path -Parent $PSCommandPath
+. (Join-Path -Path $script:QVLibDir -ChildPath 'frame-validate-core.ps1')
+
 function Resolve-QVContentPath {
     # Issue #367: resolve agents/ or skills/ at either the new repo-root location
     # or the legacy .github/ location, so validators run green mid-migration.
@@ -367,6 +370,23 @@ function Invoke-QuickValidate {
         # 11. SkillNameMatch
         try { $results.Add((Test-QVSkillNameMatch -RootPath $RootPath)) }
         catch { $results.Add([PSCustomObject]@{ Name = 'SkillNameMatch'; Passed = $false; Detail = "Error: $_" }) }
+        # 12. FrameValidator
+        try {
+            $fvResult = Invoke-FrameValidate -RootPath $RootPath
+            $fvDetails = @(
+                $fvResult.Results |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace($_.Detail) } |
+                    ForEach-Object { "$($_.Name): $($_.Detail)" }
+            )
+            $fvDetail = if ($fvDetails.Count -gt 0) { $fvDetails -join '; ' } elseif ($fvResult.FailCount -gt 0) { "$($fvResult.FailCount) frame validation check(s) failed" } else { '' }
+
+            $results.Add([PSCustomObject]@{
+                    Name   = 'FrameValidator'
+                    Passed = ($fvResult.FailCount -eq 0)
+                    Detail = $fvDetail
+                })
+        }
+        catch { $results.Add([PSCustomObject]@{ Name = 'FrameValidator'; Passed = $false; Detail = "Error: $_" }) }
 
         $passCount = @($results | Where-Object { $_.Passed -eq $true }).Count
         $failCount = @($results | Where-Object { $_.Passed -eq $false }).Count

--- a/Documents/Design/frame-architecture.md
+++ b/Documents/Design/frame-architecture.md
@@ -1,8 +1,8 @@
 # Design: Frame Architecture for Pipeline Enforcement
 
-> **Status**: Draft V2 — revised after walking the model against four historical PRs (#411, #415 post-thin/fat; #286, #338 pre-thin/fat). Audit findings folded into vocabulary, port list, and decision log. Ready to shape umbrella + sub-issues.
+> **Status**: Living V2 design — revised after walking the model against four historical PRs (#411, #415 post-thin/fat; #286, #338 pre-thin/fat). Audit findings remain the target architecture; current shipped behavior now includes the first frame validator slice.
 >
-> **Author context**: Drafted in the Experience-Owner role during exploratory framing. No GitHub issue exists yet.
+> **Author context**: Originally drafted in the Experience-Owner role during exploratory framing. Subsequent sub-issue work updates current-state sections as behavior ships.
 
 ---
 
@@ -163,11 +163,15 @@ produces-credit: review.{adapter}.{timestamp}
 ---
 ```
 
-Frame validator runs at session startup (or as a lint step):
+The current frame validator ships as `.github/scripts/frame-validate.ps1`, backed by `.github/scripts/lib/frame-validate-core.ps1` and `.github/scripts/lib/frame-predicate-core.ps1`. `quick-validate.ps1` aggregates it as `FrameValidator`, so the validator passes or fails with the existing structural validation suite rather than adding a separate CI lane.
 
-- Every adapter's `provides` value must match a port file in `frame/ports/`.
-- Every port must have ≥1 work-adapter, exactly one auto-N/A adapter (where applicable), and exactly one explicit-skip adapter.
-- Asymmetry is a hard error.
+The first shipped validator slice is intentionally symmetry-only plus predicate parse-only:
+
+- Port names come from `frame/ports/*.yaml` filename stems. The YAML body is opaque to the validator.
+- Adapter discovery scans `agents/*.agent.md`, `agents/*.md` excluding `.agent.md`, `commands/*.md`, `skills/*/SKILL.md`, and direct `skills/*/adapters/*.md` files.
+- Every discovered adapter `provides:` value must match a `frame/ports/*.yaml` stem. A port with no adapter declaration is allowed in this slice; coverage strictness waits until adapter declarations and enforcement semantics are in place.
+- If `frame/ports/` is missing, adapter symmetry passes with informational detail and predicate parsing still runs.
+- Frontmatter handling is deliberately lightweight. It accepts the scalar, inline-list, indented-list, comment, and block-scalar forms used by adapter declarations, but it is not a full YAML parser.
 
 ### Three adapter types per port
 
@@ -190,7 +194,7 @@ The pre-PR hook independently verifies via the credit. Selection logic is never 
 
 ### `applies-when` predicate language
 
-Declarative DSL evaluated by the hook against:
+Target enforcement evaluates the declarative DSL against:
 
 - `git diff` against the merge target (file list, line counts, paths)
 - Repo signals (file patterns, surface markers)
@@ -205,7 +209,7 @@ applies-when: not changeset.touchesSource()
 applies-when: changeset.touches('docs/**') and changeset.behaviorChanged()
 ```
 
-The grammar is small and deterministic. The hook evaluates it; the agent does not.
+The grammar is small and deterministic. Current validation is parse-only: it accepts comparisons, logical `AND`/`OR`/`NOT`, grouped expressions, dotted identifiers, bare boolean identifiers such as `scope.isReReview`, and function-call predicates with literal arguments such as `changeset.touches('docs/**')`. It rejects malformed syntax but does not validate field existence, function existence, or type consistency; those semantic checks are deferred to the evaluator work. The target hook evaluates valid predicates; the agent does not.
 
 ---
 
@@ -447,7 +451,7 @@ Order is intentional but flexible — actual priority will shift based on audit-
 | # | Sub-issue | Deliverable | Depends on |
 |---|---|---|---|
 | 1 | **Audit-only credit ledger from existing markers + pipeline-metrics v3 schema** | Schema doc, port files (17), back-deriver script, audit report. No enforcement. | — |
-| 2 | Frame validator (lint/CI step) | Walks `frame/ports/*.yaml` and adapter frontmatter; fails CI on asymmetry (port has no adapter, adapter declares non-existent port). | #1 |
+| 2 | Frame validator (lint/CI step) | Walks `frame/ports/*.yaml` and adapter frontmatter; fails CI when an adapter declares a non-existent port and when `applies-when` cannot parse. Missing adapters for existing ports are allowed until coverage enforcement ships. | #1 |
 | 3 | Adapter declarations in skill/agent frontmatter | All current skills/agents declare `provides: <port>` and `applies-when` predicates. Validator (#2) passes. | #1, #2 |
 | 4 | Pre-PR hook (warn-only mode) | Hook exists, reads PR body's pipeline-metrics v3 block, posts a comment listing missing/failed/inconclusive credits. **Does not block.** | #1, #3 |
 | 5 | Reify `review` port end-to-end with input-integrity check | Code-Review-Response writes the v3 credit on judge completion; integrity check verifies pass-block durability (closes #411-style gap). | #4 |


### PR DESCRIPTION
## Summary

- Adds the frame validator CLI and core libraries for symmetry-only adapter `provides:` validation and parse-only `applies-when` validation.
- Wires the validator into `quick-validate.ps1` as the `FrameValidator` structural check.
- Adds focused Pester coverage for predicate parsing, validator checks, quick-validate aggregation, YAML frontmatter forms, adapter variants, and current-repo symmetry-only behavior.
- Updates the frame architecture design doc to reflect the shipped validator slice.

## Changed Files

- `.github/scripts/frame-validate.ps1`
- `.github/scripts/lib/frame-validate-core.ps1`
- `.github/scripts/lib/frame-predicate-core.ps1`
- `.github/scripts/lib/quick-validate-core.ps1`
- `.github/scripts/Tests/frame-validate.Tests.ps1`
- `.github/scripts/Tests/frame-predicate.Tests.ps1`
- `Documents/Design/frame-architecture.md`

## Validation Evidence

- `Invoke-Pester .github/scripts/Tests/frame-validate.Tests.ps1, .github/scripts/Tests/frame-predicate.Tests.ps1 -Output Minimal` -> 49 passed, 0 failed
- `pwsh -NoProfile -NonInteractive -File .github/scripts/frame-validate.ps1` -> 2/2 checks passed
- `pwsh -NoProfile -NonInteractive -File .github/scripts/quick-validate.ps1` -> 12/12 checks passed
- `git diff --check origin/main...HEAD` -> no whitespace errors
- `Test-GateCriteria -Gate review_completion` -> pass
- `markdownlint-cli2 --fix "Documents/Design/frame-architecture.md"` -> passed for the touched design doc

Residual validation note: full `Invoke-Pester .github/scripts/Tests/ -Output Minimal` was attempted and exposed unrelated repository contract failures in Issue-Planner/CE prompt parity, Claude shell parity, and composite-skill reference discovery. Those files are outside this PR diff and were not widened into #427.

## Review Mode

Full review pipeline completed: 3 prosecution passes, 1 defense pass, 1 judge pass.

## CE Gate

✅ CE Gate passed — intent match: strong

Scenarios exercised:

- S1: typoed `provides:` field is caught by frame validation.
- S2: non-existent port references are rejected with valid-port detail.
- S3: malformed `applies-when` predicates fail parse-only validation with position/message detail.
- S4: current repo state passes in symmetry-only mode.

Track 2 outcome: Process-Review retrospective found no CE-blocking systemic gap. Follow-up issue #455 was created for stale rate-limit deferral freshness handling discovered during the workflow retrospective.

## Adversarial Review Scores

| Stage | Prosecutor | Defense | Judge rulings |
| --- | --- | --- | --- |
| Code Review | 26 pts (4 sustained) | 0 pts (0 disproved, 4 conceded) | 4 accepted |
| CE Review | 0 pts (0 sustained) | 0 pts (no disputed findings) | strong pass |
| Post-fix Review | 5 pts (1 sustained) | 0 pts (0 disproved, 1 conceded) | 1 accepted |

## Prosecution Depth Summary

Prosecution depth: 7 full, 0 light, 0 skip. Override active: false. Re-activated categories: none.

| Category | Depth | Rationale |
| --- | --- | --- |
| architecture | full | aggregate recommendation |
| security | full | aggregate recommendation |
| performance | full | aggregate recommendation |
| pattern | full | aggregate recommendation |
| implementation-clarity | full | aggregate recommendation |
| script-automation | full | aggregate recommendation |
| documentation-audit | full | aggregate recommendation |

## Pipeline Metrics

<!-- pipeline-metrics
metrics_version: 3
review_mode: full
stages_run:
  prosecution: true
  defense: true
  judgment: true
prosecution_findings: 4
pass_1_findings: 3
pass_2_findings: 1
pass_3_findings: 0
defense_disproved: 0
judge_accepted: 4
judge_rejected: 0
judge_deferred: 0
ce_gate_result: passed
ce_gate_intent: strong
ce_gate_defects_found: 0
rework_cycles: 1
postfix_triggered: true
postfix_prosecution_findings: 1
postfix_judge_accepted: 1
postfix_judge_rejected: 0
postfix_judge_deferred: 0
postfix_defense_disproved: 0
postfix_rework_cycles: 1
express_lane_count: 0
postfix_passes: 2
batch_dispatch_calls: 2
batch_dispatch_findings: 5
rate_limit_retries: 1
rate_limit_deferred: true
prosecution_depth_light: []
prosecution_depth_skip: []
prosecution_depth_override: false
prosecution_depth_reactivations: 0
findings:
  - id: F1
    category: script-automation
    severity: high
    points: 10
    pass: 1
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: main
  - id: F2
    category: architecture
    severity: high
    points: 10
    pass: 1
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: main
  - id: F3
    category: script-automation
    severity: medium
    points: 5
    pass: 1
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: main
  - id: F4
    category: script-automation
    severity: low
    points: 1
    pass: 2
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: main
  - id: PF-F1
    category: script-automation
    severity: medium
    points: 5
    pass: 1
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: postfix
-->

## Process Gaps

- Process-Review: no CE-blocking systemic gap found.
- Created follow-up #455: Add freshness check before acting on persisted rate-limit deferrals.

Closes #427

## Summary by Sourcery

Introduce a frame validation subsystem and integrate it into the quick-validate pipeline with initial symmetry and predicate parsing checks.

New Features:
- Add a frame validator CLI and core library that validate adapter provides declarations against the frame port catalog and parse applies-when predicates into an AST.
- Expose a dedicated frame-validate script that runs the validator checks and reports aggregate pass/fail status from the command line.

Enhancements:
- Integrate the frame validator as a FrameValidator structural check within quick-validate, including propagating detailed results into the aggregated output.
- Extend the frame architecture design document to describe the shipped symmetry-only and parse-only validator slice, current adapter discovery surfaces, and updated sub-issue plan.

Tests:
- Add unit and integration test suites for the frame predicate parser, frame validator checks, and their aggregation through frame-validate and quick-validate.