### PR TITLE
Fix guidance complexity test asset churn

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.5.3"
+    "version": "2.5.4"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 14 specialized agents and a shared skill library.",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Multi-agent workflow system for Claude Code. Pipeline-based agent orchestration: Issue → Design → Plan → Implement → Review → PR.",
   "author": {
     "name": "Grimblaz"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "Multi-agent workflow system for GitHub Copilot",
-    "version": "2.5.3"
+    "version": "2.5.4"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "Multi-agent workflow system for GitHub Copilot with 14 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.5.3"
+      "version": "2.5.4"
     }
   ]
 }

--- a/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
+++ b/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
@@ -2768,51 +2768,45 @@ exit 0
             if (-not $script:GhAvailable) { Set-ItResult -Skipped -Because 'gh CLI not found'; return }
 
             $workDir = & $script:NewWorkDir
-            $configPath = Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json'
-            $configBackup = Get-Content -Path $configPath -AsByteStream -Raw
-            try {
-                # Write custom config with persistent_threshold=2
-                $customConfig = [ordered]@{
-                    version              = 1
-                    ceilings             = [ordered]@{}
-                    default_ceiling      = [ordered]@{ max_directives = 128 }
-                    persistent_threshold = 2
-                }
-                $customConfig | ConvertTo-Json -Depth 5 | Set-Content -Path $configPath -Encoding UTF8
+            $tempConfigPath = Join-Path $workDir 'guidance-complexity.json'
 
-                $preSeededHistory = [ordered]@{
-                    'TestAgent.agent.md' = [ordered]@{
-                        consecutive_count = 1
-                        first_observed_at = '2026-03-01T00:00:00Z'
-                        last_observed_at  = '2026-03-15T00:00:00Z'
-                        last_pr_number    = 1
-                    }
-                }
-                $calib = [ordered]@{
-                    calibration_version             = 1
-                    entries                         = @()
-                    complexity_over_ceiling_history = $preSeededHistory
-                }
-                $calibPath = Join-Path $workDir 'threshold-calib.json'
-                & $script:WriteCalibrationFile -Path $calibPath -Data $calib
-
-                # This run increments TestAgent to consecutive_count=2 -> meets custom threshold of 2
-                $complexityPath = Join-Path $workDir 'complexity-threshold.json'
-                & $script:WriteComplexityFile -Path $complexityPath -AgentsOverCeiling @('TestAgent.agent.md')
-
-                $result = & $script:InvokeAggregate `
-                    -ExtraArgs @('-CalibrationFile', $calibPath, '-ComplexityJsonPath', $complexityPath)
-
-                $result.ExitCode | Should -Be 0
-                $result.Output | Should -Match 'extraction_agents:' `
-                    -Because 'extraction_agents section must appear in YAML output when an agent meets or exceeds the custom persistent_threshold of 2'
-                $result.Output | Should -Match 'TestAgent\.agent\.md' `
-                    -Because 'the agent meeting the threshold must be listed under extraction_agents'
+            # Write custom config with persistent_threshold=2
+            $customConfig = [ordered]@{
+                version              = 1
+                ceilings             = [ordered]@{}
+                default_ceiling      = [ordered]@{ max_directives = 128 }
+                persistent_threshold = 2
             }
-            finally {
-                # Restore the real config regardless of test outcome
-                Set-Content -Path $configPath -AsByteStream -Value $configBackup
+            $customConfig | ConvertTo-Json -Depth 5 | Set-Content -Path $tempConfigPath -Encoding UTF8
+
+            $preSeededHistory = [ordered]@{
+                'TestAgent.agent.md' = [ordered]@{
+                    consecutive_count = 1
+                    first_observed_at = '2026-03-01T00:00:00Z'
+                    last_observed_at  = '2026-03-15T00:00:00Z'
+                    last_pr_number    = 1
+                }
             }
+            $calib = [ordered]@{
+                calibration_version             = 1
+                entries                         = @()
+                complexity_over_ceiling_history = $preSeededHistory
+            }
+            $calibPath = Join-Path $workDir 'threshold-calib.json'
+            & $script:WriteCalibrationFile -Path $calibPath -Data $calib
+
+            # This run increments TestAgent to consecutive_count=2 -> meets custom threshold of 2
+            $complexityPath = Join-Path $workDir 'complexity-threshold.json'
+            & $script:WriteComplexityFile -Path $complexityPath -AgentsOverCeiling @('TestAgent.agent.md')
+
+            $result = & $script:InvokeAggregate `
+                -ExtraArgs @('-CalibrationFile', $calibPath, '-ComplexityJsonPath', $complexityPath, '-ComplexityCeilingConfigPath', $tempConfigPath)
+
+            $result.ExitCode | Should -Be 0
+            $result.Output | Should -Match 'extraction_agents:' `
+                -Because 'extraction_agents section must appear in YAML output when an agent meets or exceeds the custom persistent_threshold of 2'
+            $result.Output | Should -Match 'TestAgent\.agent\.md' `
+                -Because 'the agent meeting the threshold must be listed under extraction_agents'
         }
 
         It 'skips complexity tracking when -ComplexityJsonPath points to a non-existent file' -Tag 'requires-gh' {

--- a/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
+++ b/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
@@ -2579,6 +2579,81 @@ exit 0
                 -Because 'the omitted-path wrapper invocation must not trip StrictMode on an uninitialized core library directory'
         }
 
+        It 'Process-Review 4.7-style wrapper invocation uses the canonical persistent threshold when config path is omitted' -Tag 'requires-gh' {
+            if (-not $script:GhAvailable) { Set-ItResult -Skipped -Because 'gh CLI not found'; return }
+
+            $workDir = & $script:NewWorkDir
+            $complexityPath = Join-Path $workDir 'process-review-complexity.json'
+            & $script:WriteComplexityFile -Path $complexityPath -AgentsOverCeiling @('TestAgent.agent.md')
+
+            $preSeededHistory = [ordered]@{
+                'TestAgent.agent.md' = [ordered]@{
+                    consecutive_count = 2
+                    first_observed_at = '2026-03-01T00:00:00Z'
+                    last_observed_at  = '2026-03-15T00:00:00Z'
+                    last_pr_number    = 1
+                }
+            }
+            $calibPath = Join-Path $workDir 'process-review-calib.json'
+            & $script:WriteCalibrationFile -Path $calibPath -Data ([ordered]@{
+                    calibration_version             = 1
+                    entries                         = @()
+                    complexity_over_ceiling_history = $preSeededHistory
+                })
+
+            $healthReportPath = Join-Path $workDir 'process-review-health-report.md'
+            $guidanceComplexityAsset = Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json'
+            $startingAssetHash = (Get-FileHash -Path $guidanceComplexityAsset).Hash
+            $ghCliPath = if ($script:FixtureMode) { $script:FixtureGhPath } else { 'gh' }
+            $pwshCommand = Get-Command pwsh -ErrorAction SilentlyContinue
+            if (-not $pwshCommand) { Set-ItResult -Skipped -Because 'pwsh executable not found'; return }
+
+            $arguments = @(
+                '-NoProfile',
+                '-NonInteractive',
+                '-File', $script:ScriptFile,
+                '-CalibrationFile', $calibPath,
+                '-GhCliPath', $ghCliPath,
+                '-ComplexityJsonPath', $complexityPath,
+                '-OutputPath', $healthReportPath
+            )
+            $arguments | Should -Contain '-ComplexityJsonPath' `
+                -Because 'the Process-Review 4.7-style wrapper call must pass the measured complexity JSON path'
+            $arguments | Should -Contain '-OutputPath' `
+                -Because 'the Process-Review 4.7-style wrapper call must pass the health report output path'
+            $arguments | Should -Not -Contain '-ComplexityCeilingConfigPath' `
+                -Because 'Process-Review 4.7 does not pass an explicit complexity ceiling config path'
+
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $pwshCommand.Source
+            $startInfo.WorkingDirectory = $script:RepoRoot
+            $startInfo.UseShellExecute = $false
+            $startInfo.RedirectStandardOutput = $true
+            $startInfo.RedirectStandardError = $true
+            foreach ($argument in $arguments) {
+                [void]$startInfo.ArgumentList.Add($argument)
+            }
+
+            $process = [System.Diagnostics.Process]::Start($startInfo)
+            $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+            $stderrTask = $process.StandardError.ReadToEndAsync()
+            $process.WaitForExit()
+            $stdout = $stdoutTask.GetAwaiter().GetResult()
+            $stderr = $stderrTask.GetAwaiter().GetResult()
+            $endingAssetHash = (Get-FileHash -Path $guidanceComplexityAsset).Hash
+
+            $process.ExitCode | Should -Be 0 `
+                -Because "the wrapper invocation should succeed without -ComplexityCeilingConfigPath; stderr: $stderr"
+            $stdout | Should -Match 'extraction_agents:' `
+                -Because 'pre-seeded consecutive_count 2 plus the current over-ceiling observation should meet the canonical threshold'
+            $stdout | Should -Match 'TestAgent\.agent\.md' `
+                -Because 'the over-ceiling agent should be listed under extraction_agents'
+            $stdout | Should -Match '(?m)^\s*persistent_threshold:\s*3\s*$' `
+                -Because 'omitting -ComplexityCeilingConfigPath must read the committed canonical guidance-complexity.json threshold'
+            $endingAssetHash | Should -Be $startingAssetHash `
+                -Because 'the production-shape wrapper invocation must not mutate the committed guidance-complexity.json asset'
+        }
+
         It 'script references guidance-complexity.json for persistent_threshold' -Tag 'no-gh' {
             $content = Get-Content -Path $script:LibFile -Raw
             $content | Should -Match 'guidance-complexity\.json' `

--- a/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
+++ b/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
@@ -554,6 +554,22 @@ exit 0
         }
 
         # ------------------------------------------------------------------
+        # Helper: write a simple mock gh.ps1 that returns a fixed PR list.
+        # ------------------------------------------------------------------
+        $script:WriteAggregateMockGh = {
+            param([string]$WorkDir, [string]$JsonOutput)
+            $dataFile = Join-Path $WorkDir 'gh-response.json'
+            $mockPath = Join-Path $WorkDir 'gh.ps1'
+            $JsonOutput | Set-Content -Path $dataFile -Encoding UTF8
+            @"
+# Mock gh CLI — outputs pre-defined JSON regardless of arguments
+Get-Content -Raw -Path '$($dataFile -replace "'", "''")'
+exit 0
+"@ | Set-Content -Path $mockPath -Encoding UTF8
+            return $mockPath
+        }
+
+        # ------------------------------------------------------------------
         # Helper: load NonMetricsPrNumbers from fixture (fixture mode) or via
         # live gh CLI (live mode), with @(9901) fallback on gh failure.
         # ------------------------------------------------------------------
@@ -2534,6 +2550,53 @@ exit 0
                 -Because 'a missing explicit complexity ceiling config path should warn without failing aggregation'
             ($result.Warnings -join "`n") | Should -Match ([regex]::Escape($missingConfigPath)) `
                 -Because 'the warning must include the literal missing explicit config path'
+        }
+
+        It 'warns with the missing explicit complexity ceiling config path when the merged PR list is empty' -Tag 'no-gh' {
+            $workDir = & $script:NewWorkDir
+            $mockGhPath = & $script:WriteAggregateMockGh -WorkDir $workDir -JsonOutput '[]'
+            $missingConfigPath = Join-Path $workDir 'missing-guidance-complexity.json'
+
+            $invokeRecords = @(Invoke-AggregateReviewScores `
+                    -GhCliPath $mockGhPath `
+                    -Repo 'test/repo' `
+                    -ComplexityCeilingConfigPath $missingConfigPath `
+                    3>&1)
+            $result = $invokeRecords | Where-Object { $_ -is [hashtable] } | Select-Object -First 1
+            $warnings = @($invokeRecords |
+                    Where-Object { $_ -is [System.Management.Automation.WarningRecord] } |
+                    ForEach-Object { $_.Message })
+
+            $result.ExitCode | Should -Be 0 `
+                -Because 'an empty merged PR list remains a successful insufficient-data run'
+            ($warnings -join "`n") | Should -Match ([regex]::Escape($missingConfigPath)) `
+                -Because 'the explicit missing config-path warning must be emitted before the empty-PR early return'
+        }
+
+        It 'warns with the literal wildcard-like complexity ceiling config path instead of expanding it' -Tag 'no-gh' {
+            $workDir = & $script:NewWorkDir
+            $mockGhPath = & $script:WriteAggregateMockGh -WorkDir $workDir -JsonOutput '[]'
+            $wildcardConfigPath = Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.jso?'
+
+            (Test-Path -Path $wildcardConfigPath) | Should -BeTrue `
+                -Because 'the wildcard-like path must match the canonical JSON if wildcard semantics are used'
+            (Get-Item -LiteralPath $wildcardConfigPath -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty `
+                -Because 'the wildcard-like path must not exist as a literal file'
+
+            $invokeRecords = @(Invoke-AggregateReviewScores `
+                    -GhCliPath $mockGhPath `
+                    -Repo 'test/repo' `
+                    -ComplexityCeilingConfigPath $wildcardConfigPath `
+                    3>&1)
+            $result = $invokeRecords | Where-Object { $_ -is [hashtable] } | Select-Object -First 1
+            $warnings = @($invokeRecords |
+                    Where-Object { $_ -is [System.Management.Automation.WarningRecord] } |
+                    ForEach-Object { $_.Message })
+
+            $result.ExitCode | Should -Be 0 `
+                -Because 'a missing explicit wildcard-like config path should warn without failing aggregation'
+            ($warnings -join "`n") | Should -Match ([regex]::Escape($wildcardConfigPath)) `
+                -Because 'the warning must contain the literal supplied wildcard string rather than reading through wildcard expansion'
         }
 
         It 'omits the complexity ceiling config path in a fresh wrapper runspace without StrictMode failure' -Tag 'requires-gh' {

--- a/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
+++ b/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
@@ -391,17 +391,54 @@ exit 0
         }
 
         # ------------------------------------------------------------------
-        # Parse script AST for parameter introspection tests (no gh needed)
+        # Parse script ASTs for parameter introspection tests (no gh needed)
         # ------------------------------------------------------------------
-        $scriptContent = Get-Content -Path $script:ScriptFile -Raw
-        $parseErrors = $null
-        $script:ScriptAst = [System.Management.Automation.Language.Parser]::ParseInput(
-            $scriptContent, [ref]$null, [ref]$parseErrors
+        $wrapperScriptContent = Get-Content -Path $script:ScriptFile -Raw
+        $wrapperParseErrors = $null
+        $script:WrapperScriptAst = [System.Management.Automation.Language.Parser]::ParseInput(
+            $wrapperScriptContent, [ref]$null, [ref]$wrapperParseErrors
         )
-        $script:AllParams = $script:ScriptAst.FindAll(
+        $script:WrapperAllParams = $script:WrapperScriptAst.FindAll(
             { $args[0] -is [System.Management.Automation.Language.ParameterAst] }, $true
         )
-        $script:ParamNames = $script:AllParams | ForEach-Object { $_.Name.VariablePath.UserPath }
+        $script:WrapperParamNames = $script:WrapperAllParams | ForEach-Object { $_.Name.VariablePath.UserPath }
+        $script:WrapperParamBlockParams = @(
+            if ($script:WrapperScriptAst.ParamBlock) {
+                $script:WrapperScriptAst.ParamBlock.Parameters
+            }
+        )
+        $script:WrapperParamBlockParamNames = $script:WrapperParamBlockParams |
+            ForEach-Object { $_.Name.VariablePath.UserPath }
+
+        $coreScriptContent = Get-Content -Path $script:LibFile -Raw
+        $coreParseErrors = $null
+        $script:CoreScriptAst = [System.Management.Automation.Language.Parser]::ParseInput(
+            $coreScriptContent, [ref]$null, [ref]$coreParseErrors
+        )
+        $script:CoreAllParams = $script:CoreScriptAst.FindAll(
+            { $args[0] -is [System.Management.Automation.Language.ParameterAst] }, $true
+        )
+        $script:CoreParamNames = $script:CoreAllParams | ForEach-Object { $_.Name.VariablePath.UserPath }
+        $script:CoreInvokeAggregateReviewScoresAst = $script:CoreScriptAst.Find(
+            {
+                $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $args[0].Name -eq 'Invoke-AggregateReviewScores'
+            },
+            $true
+        )
+        $script:CoreInvokeAggregateReviewScoresParams = @(
+            if ($script:CoreInvokeAggregateReviewScoresAst -and
+                $script:CoreInvokeAggregateReviewScoresAst.Body.ParamBlock) {
+                $script:CoreInvokeAggregateReviewScoresAst.Body.ParamBlock.Parameters
+            }
+        )
+        $script:CoreInvokeAggregateReviewScoresParamNames = $script:CoreInvokeAggregateReviewScoresParams |
+            ForEach-Object { $_.Name.VariablePath.UserPath }
+
+        # Backward-compatible aliases for existing wrapper-only AST tests.
+        $script:ScriptAst = $script:WrapperScriptAst
+        $script:AllParams = $script:WrapperAllParams
+        $script:ParamNames = $script:WrapperParamNames
 
         # ------------------------------------------------------------------
         # Calibration fixture: one valid local entry for a real merged PR in a repo
@@ -2402,7 +2439,7 @@ exit 0
 
     # ==================================================================
     # Context: complexity_over_ceiling_history
-    # Tests for -ComplexityJsonPath parameter and complexity history
+    # Tests for -ComplexityJsonPath / -ComplexityCeilingConfigPath parameters and complexity history
     # write-back behavior (Phase 2 D7 implementation).
     # AST tests (no-gh): verify parameter declaration and script structure.
     # Execution tests (requires-gh): verify history increment, reset,
@@ -2440,6 +2477,34 @@ exit 0
                 -Because '-ComplexityJsonPath parameter AST node must be found'
             $paramAst.StaticType.Name | Should -Be 'String' `
                 -Because '-ComplexityJsonPath must be declared as [string]'
+        }
+
+        It 'wrapper script declares -ComplexityCeilingConfigPath parameter as [string]' -Tag 'no-gh' {
+            $script:WrapperParamBlockParamNames | Should -Contain 'ComplexityCeilingConfigPath' `
+                -Because 'aggregate-review-scores.ps1 must declare -ComplexityCeilingConfigPath for temp config injection'
+
+            $paramAst = @($script:WrapperParamBlockParams | Where-Object {
+                    $_.Name.VariablePath.UserPath -eq 'ComplexityCeilingConfigPath'
+                })
+            $paramAst.Count | Should -Be 1 `
+                -Because '-ComplexityCeilingConfigPath must be declared exactly once in the wrapper param block'
+            $paramAst[0].StaticType.Name | Should -Be 'String' `
+                -Because '-ComplexityCeilingConfigPath must be declared as [string] in aggregate-review-scores.ps1'
+        }
+
+        It 'core Invoke-AggregateReviewScores declares -ComplexityCeilingConfigPath parameter as [string]' -Tag 'no-gh' {
+            $script:CoreInvokeAggregateReviewScoresAst | Should -Not -BeNullOrEmpty `
+                -Because 'Invoke-AggregateReviewScores must be found before checking its parameters'
+            $script:CoreInvokeAggregateReviewScoresParamNames | Should -Contain 'ComplexityCeilingConfigPath' `
+                -Because 'Invoke-AggregateReviewScores must accept -ComplexityCeilingConfigPath from the wrapper'
+
+            $paramAst = @($script:CoreInvokeAggregateReviewScoresParams | Where-Object {
+                    $_.Name.VariablePath.UserPath -eq 'ComplexityCeilingConfigPath'
+                })
+            $paramAst.Count | Should -Be 1 `
+                -Because '-ComplexityCeilingConfigPath must be declared exactly once on Invoke-AggregateReviewScores'
+            $paramAst[0].StaticType.Name | Should -Be 'String' `
+                -Because '-ComplexityCeilingConfigPath must be declared as [string] on Invoke-AggregateReviewScores'
         }
 
         It 'script references guidance-complexity.json for persistent_threshold' -Tag 'no-gh' {

--- a/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
+++ b/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
@@ -1,4 +1,5 @@
 #Requires -Version 7.0
+# This suite is supported on pwsh 7+; PowerShell 5.1 is out of scope.
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
@@ -57,6 +58,7 @@ Describe 'aggregate-review-scores.ps1 -CalibrationFile' {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         $script:ScriptFile = Join-Path $script:RepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores.ps1'
         $script:LibFile = Join-Path $script:RepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:GuidanceComplexityStartingHash = (Get-FileHash -Path (Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json')).Hash
         . $script:LibFile
 
         # Master temp root — all per-test dirs live under here
@@ -2874,6 +2876,14 @@ exit 0
             $entry['last_observed_at'] | Should -Not -Be $seedTime `
                 -Because 'last_observed_at must be updated to reflect the new observation time'
         }
+    }
+
+    It 'leaves skills/calibration-pipeline/assets/guidance-complexity.json byte-stable across the suite' -Tag 'no-gh' {
+        # Note: this assertion only fires on suite-completion; interrupted runs are caught structurally by D3 (no mutation in the first place) and forward-protected by the AC6 class-invariant at next suite run.
+        $endingHash = (Get-FileHash -Path (Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json')).Hash
+
+        $endingHash | Should -Be $script:GuidanceComplexityStartingHash `
+            -Because 'the committed guidance-complexity.json asset must remain byte-stable across this Pester suite'
     }
 }
 

--- a/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
+++ b/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
@@ -572,7 +572,7 @@ exit 0
         # ------------------------------------------------------------------
         # Helper: invoke Invoke-AggregateReviewScores in-process.
         # $ExtraArgs are parsed from '-Key Value' pairs into a params hashtable.
-        # Returns @{ ExitCode; Output (stdout string); Error (stderr string) }
+        # Returns @{ ExitCode; Output (stdout string); Error (stderr string); Warnings (warning strings) }
         # ------------------------------------------------------------------
         $script:InvokeAggregate = {
             param([string[]]$ExtraArgs = @())
@@ -597,7 +597,12 @@ exit 0
                         $i++
                     }
                 }
-                return Invoke-AggregateReviewScores @params
+                $invokeRecords = @(Invoke-AggregateReviewScores @params 3>&1)
+                $result = $invokeRecords | Where-Object { $_ -is [hashtable] } | Select-Object -First 1
+                $result['Warnings'] = @($invokeRecords |
+                    Where-Object { $_ -is [System.Management.Automation.WarningRecord] } |
+                    ForEach-Object { $_.Message })
+                return $result
             }
             finally {
                 Pop-Location
@@ -2505,6 +2510,71 @@ exit 0
                 -Because '-ComplexityCeilingConfigPath must be declared exactly once on Invoke-AggregateReviewScores'
             $paramAst[0].StaticType.Name | Should -Be 'String' `
                 -Because '-ComplexityCeilingConfigPath must be declared as [string] on Invoke-AggregateReviewScores'
+        }
+
+        It 'warns with the missing explicit complexity ceiling config path and still exits cleanly' -Tag 'requires-gh' {
+            if (-not $script:GhAvailable) { Set-ItResult -Skipped -Because 'gh CLI not found'; return }
+
+            $workDir = & $script:NewWorkDir
+            $calibPath = Join-Path $workDir 'missing-config-calib.json'
+            & $script:WriteCalibrationFile -Path $calibPath -Data ([ordered]@{
+                    calibration_version = 1; entries = @()
+                })
+            $missingConfigPath = 'C:\nonexistent\config.json'
+
+            $result = & $script:InvokeAggregate `
+                -ExtraArgs @(
+                    '-CalibrationFile', $calibPath,
+                    '-ComplexityCeilingConfigPath', $missingConfigPath
+                )
+
+            $result.ExitCode | Should -Be 0 `
+                -Because 'a missing explicit complexity ceiling config path should warn without failing aggregation'
+            ($result.Warnings -join "`n") | Should -Match ([regex]::Escape($missingConfigPath)) `
+                -Because 'the warning must include the literal missing explicit config path'
+        }
+
+        It 'omits the complexity ceiling config path in a fresh wrapper runspace without StrictMode failure' -Tag 'requires-gh' {
+            if (-not $script:GhAvailable) { Set-ItResult -Skipped -Because 'gh CLI not found'; return }
+
+            $workDir = & $script:NewWorkDir
+            $calibPath = Join-Path $workDir 'fresh-runspace-omitted-config-calib.json'
+            & $script:WriteCalibrationFile -Path $calibPath -Data ([ordered]@{
+                    calibration_version = 1; entries = @()
+                })
+
+            $ghCliPath = if ($script:FixtureMode) { $script:FixtureGhPath } else { 'gh' }
+            $pwshCommand = Get-Command pwsh -ErrorAction SilentlyContinue
+            if (-not $pwshCommand) { Set-ItResult -Skipped -Because 'pwsh executable not found'; return }
+
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $pwshCommand.Source
+            $startInfo.WorkingDirectory = $script:RepoRoot
+            $startInfo.UseShellExecute = $false
+            $startInfo.RedirectStandardOutput = $true
+            $startInfo.RedirectStandardError = $true
+            foreach ($argument in @(
+                    '-NoProfile',
+                    '-NonInteractive',
+                    '-File', $script:ScriptFile,
+                    '-CalibrationFile', $calibPath,
+                    '-GhCliPath', $ghCliPath
+                )) {
+                [void]$startInfo.ArgumentList.Add($argument)
+            }
+
+            $process = [System.Diagnostics.Process]::Start($startInfo)
+            $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+            $stderrTask = $process.StandardError.ReadToEndAsync()
+            $process.WaitForExit()
+            $stdout = $stdoutTask.GetAwaiter().GetResult()
+            $stderr = $stderrTask.GetAwaiter().GetResult()
+            $combinedOutput = "$stdout`n$stderr"
+
+            $process.ExitCode | Should -Be 0 `
+                -Because 'omitting -ComplexityCeilingConfigPath should resolve the wrapper default config path in a fresh pwsh process'
+            $combinedOutput | Should -Not -Match 'Set-StrictMode|_ARSCoreLibDir|cannot be retrieved because it has not been set' `
+                -Because 'the omitted-path wrapper invocation must not trip StrictMode on an uninitialized core library directory'
         }
 
         It 'script references guidance-complexity.json for persistent_threshold' -Tag 'no-gh' {

--- a/.github/scripts/Tests/routing-tables.Tests.ps1
+++ b/.github/scripts/Tests/routing-tables.Tests.ps1
@@ -22,9 +22,29 @@ Describe 'routing tables deterministic contract' {
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         $script:RoutingTablesCore = Join-Path $script:RepoRoot 'skills\routing-tables\scripts\routing-tables-core.ps1'
-        $script:RoutingConfigPath = Join-Path $script:RepoRoot 'skills\routing-tables\assets\routing-config.json'
+        $script:RoutingConfigAssetSourcePath = Join-Path $script:RepoRoot 'skills\routing-tables\assets\routing-config.json'
+        $script:RoutingConfigTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
+            "pester-routing-tables-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $script:RoutingConfigTempRoot -Force | Out-Null
+        $script:RoutingConfigTempPath = Join-Path $script:RoutingConfigTempRoot 'routing-config.json'
+        Copy-Item -LiteralPath $script:RoutingConfigAssetSourcePath -Destination $script:RoutingConfigTempPath
 
         . $script:RoutingTablesCore
+
+        function Get-RTConfigPath {
+            return $script:RoutingConfigTempPath
+        }
+    }
+
+    AfterAll {
+        try {
+            if ($script:RoutingConfigTempRoot -and (Test-Path -LiteralPath $script:RoutingConfigTempRoot)) {
+                Remove-Item -Recurse -Force -LiteralPath $script:RoutingConfigTempRoot
+            }
+        }
+        finally {
+            # Suppress removal errors so AfterAll never throws
+        }
     }
 
     It 'routes src/app/foo.tsx to Code-Smith for specialist dispatch' {
@@ -99,30 +119,24 @@ Describe 'routing tables deterministic contract' {
     }
 
     It 're-reads routing-config.json on each invocation so asset edits take effect immediately' {
-        $originalJson = Get-Content -Path $script:RoutingConfigPath -Raw
+        $originalJson = Get-Content -Path $script:RoutingConfigTempPath -Raw
+        $initial = Invoke-RoutingLookup -Table specialist_dispatch -Key FilePattern -Value '*.ps1'
+        $initial | Should -Be 'Code-Smith'
 
-        try {
-            $initial = Invoke-RoutingLookup -Table specialist_dispatch -Key FilePattern -Value '*.ps1'
-            $initial | Should -Be 'Code-Smith'
+        $updatedConfig = $originalJson | ConvertFrom-Json -AsHashtable
+        $ps1Entry = $updatedConfig.specialist_dispatch.entries |
+            Where-Object { @($_.file_patterns) -contains '*.ps1' } |
+            Select-Object -First 1
 
-            $updatedConfig = $originalJson | ConvertFrom-Json -AsHashtable
-            $ps1Entry = $updatedConfig.specialist_dispatch.entries |
-                Where-Object { @($_.file_patterns) -contains '*.ps1' } |
-                Select-Object -First 1
+        $ps1Entry | Should -Not -BeNullOrEmpty -Because 'the routing asset must explicitly carry the *.ps1 mapping for this contract to stay data-driven'
 
-            $ps1Entry | Should -Not -BeNullOrEmpty -Because 'the routing asset must explicitly carry the *.ps1 mapping for this contract to stay data-driven'
+        $ps1Entry.agent = 'Doc-Keeper'
+        $updatedJson = $updatedConfig | ConvertTo-Json -Depth 20
+        [System.IO.File]::WriteAllText($script:RoutingConfigTempPath, $updatedJson, [System.Text.UTF8Encoding]::new($false))
 
-            $ps1Entry.agent = 'Doc-Keeper'
-            $updatedJson = $updatedConfig | ConvertTo-Json -Depth 20
-            [System.IO.File]::WriteAllText($script:RoutingConfigPath, $updatedJson, [System.Text.UTF8Encoding]::new($false))
+        $updated = Invoke-RoutingLookup -Table specialist_dispatch -Key FilePattern -Value '*.ps1'
 
-            $updated = Invoke-RoutingLookup -Table specialist_dispatch -Key FilePattern -Value '*.ps1'
-
-            $updated | Should -Be 'Doc-Keeper' -Because 'Invoke-RoutingLookup must re-read the routing asset instead of using a hardcoded PowerShell override'
-        }
-        finally {
-            [System.IO.File]::WriteAllText($script:RoutingConfigPath, $originalJson, [System.Text.UTF8Encoding]::new($false))
-        }
+        $updated | Should -Be 'Doc-Keeper' -Because 'Invoke-RoutingLookup must re-read the routing asset instead of using a hardcoded PowerShell override'
     }
 
     It 'throws when table name is missing' {
@@ -148,12 +162,12 @@ Describe 'routing tables asset parity contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:RoutingConfigPath = Join-Path $script:RepoRoot 'skills\routing-tables\assets\routing-config.json'
+        $script:RoutingConfigAssetPath = Join-Path $script:RepoRoot 'skills\routing-tables\assets\routing-config.json'
         $script:ScriptSafetyContract = Join-Path $script:RepoRoot '.github\scripts\Tests\script-safety-contract.Tests.ps1'
     }
 
     It 'keeps routing-config category enums aligned with the script safety contract taxonomy' {
-        $routingConfig = Get-Content -Path $script:RoutingConfigPath -Raw | ConvertFrom-Json -AsHashtable
+        $routingConfig = Get-Content -Path $script:RoutingConfigAssetPath -Raw | ConvertFrom-Json -AsHashtable
         $contractContent = Get-Content -Path $script:ScriptSafetyContract -Raw
 
         $mandatedCategoryMatch = [regex]::Match($contractContent, '(?s)\$script:MandatedCategories\s*=\s*@\((.*?)\)')

--- a/.github/scripts/Tests/test-source-mutation-contract.Tests.ps1
+++ b/.github/scripts/Tests/test-source-mutation-contract.Tests.ps1
@@ -1,0 +1,434 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Contract tests preventing Pester sources from mutating committed skill assets.
+
+.DESCRIPTION
+    Locks issue #402 AC6. Pester test sources may create and mutate temporary
+    fixtures, but they must not write committed files under skills/*/assets/.
+    The contract parses test sources hermetically and excludes this file so the
+    write-call literals used by the detector do not self-trigger.
+#>
+
+Describe 'test source mutation contract' -Tag 'no-gh' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:TestsRoot = Join-Path $script:RepoRoot '.github\scripts\Tests'
+        $script:ThisFile = (Resolve-Path $PSCommandPath).Path
+        $script:AssetPathPattern = 'skills[/\\][^/\\]+[/\\]assets[/\\]'
+
+        $script:WriteCommandPathParameters = @{
+            'Set-Content' = @('Path', 'LiteralPath')
+            'Out-File'    = @('FilePath', 'LiteralPath')
+            'Add-Content' = @('Path', 'LiteralPath')
+            'Move-Item'   = @('Path', 'LiteralPath', 'Destination')
+            'Copy-Item'   = @('Path', 'LiteralPath', 'Destination')
+            'Rename-Item' = @('Path', 'LiteralPath', 'NewName')
+        }
+
+        $script:PositionalPathArgumentCounts = @{
+            'Set-Content' = 1
+            'Out-File'    = 1
+            'Add-Content' = 1
+            'Move-Item'   = 2
+            'Copy-Item'   = 2
+            'Rename-Item' = 2
+        }
+
+        $script:SwitchOnlyParameterNames = @(
+            'AsByteStream', 'Confirm', 'Force', 'NoClobber', 'NoNewline',
+            'PassThru', 'Recurse', 'WhatIf'
+        )
+
+        $script:NormalizeVariableName = {
+            param([System.Management.Automation.Language.VariableExpressionAst]$VariableAst)
+
+            if ($null -eq $VariableAst) {
+                return ''
+            }
+
+            return ($VariableAst.VariablePath.UserPath -replace '^(global|local|private|script|using):', '')
+        }
+
+        $script:GetAssetPathMatchesFromAst = {
+            param(
+                [System.Management.Automation.Language.Ast]$Ast,
+                [hashtable]$VariableValues
+            )
+
+            if ($null -eq $Ast) {
+                return @()
+            }
+
+            $candidateValues = [System.Collections.Generic.List[string]]::new()
+            $nodes = @($Ast.FindAll({
+                        param($Node)
+                        $Node -is [System.Management.Automation.Language.StringConstantExpressionAst] -or
+                        $Node -is [System.Management.Automation.Language.ExpandableStringExpressionAst] -or
+                        $Node -is [System.Management.Automation.Language.VariableExpressionAst]
+                    }, $true))
+
+            if ($nodes.Count -eq 0 -and $Ast -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                $nodes = @($Ast)
+            }
+
+            foreach ($node in $nodes) {
+                if ($node -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+                    [void]$candidateValues.Add($node.Value)
+                    [void]$candidateValues.Add($node.Extent.Text)
+                    continue
+                }
+
+                if ($node -is [System.Management.Automation.Language.ExpandableStringExpressionAst]) {
+                    [void]$candidateValues.Add($node.Value)
+                    [void]$candidateValues.Add($node.Extent.Text)
+                    continue
+                }
+
+                if ($node -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                    $name = & $script:NormalizeVariableName -VariableAst $node
+                    if ($VariableValues.ContainsKey($name)) {
+                        [void]$candidateValues.Add($VariableValues[$name])
+                    }
+                }
+            }
+
+            return @(
+                $candidateValues |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                    Where-Object { $_ -match $script:AssetPathPattern } |
+                    Select-Object -Unique
+            )
+        }
+
+        $script:GetVariableAssetPathMap = {
+            param([System.Management.Automation.Language.Ast]$Ast)
+
+            $variableValues = [hashtable]::new([System.StringComparer]::OrdinalIgnoreCase)
+            $assignments = @($Ast.FindAll({
+                        param($Node)
+                        $Node -is [System.Management.Automation.Language.AssignmentStatementAst]
+                    }, $true))
+
+            foreach ($assignment in $assignments) {
+                if ($assignment.Left -isnot [System.Management.Automation.Language.VariableExpressionAst]) {
+                    continue
+                }
+
+                $variableName = & $script:NormalizeVariableName -VariableAst $assignment.Left
+                $assetMatches = & $script:GetAssetPathMatchesFromAst -Ast $assignment.Right -VariableValues $variableValues
+                if ($assetMatches.Count -gt 0) {
+                    $variableValues[$variableName] = $assetMatches[0]
+                }
+            }
+
+            return $variableValues
+        }
+
+        $script:CommandHasForce = {
+            param([System.Management.Automation.Language.CommandAst]$CommandAst)
+
+            foreach ($element in $CommandAst.CommandElements) {
+                if ($element -isnot [System.Management.Automation.Language.CommandParameterAst]) {
+                    continue
+                }
+
+                if ($element.ParameterName -ne 'Force') {
+                    continue
+                }
+
+                if ($element.Argument -is [System.Management.Automation.Language.ConstantExpressionAst] -and
+                    $element.Argument.Value -eq $false) {
+                    continue
+                }
+
+                return $true
+            }
+
+            return $false
+        }
+
+        $script:GetCommandPathArgumentAsts = {
+            param(
+                [System.Management.Automation.Language.CommandAst]$CommandAst,
+                [string]$CommandName
+            )
+
+            $pathParameters = @($script:WriteCommandPathParameters[$CommandName])
+            $positionalLimit = [int]$script:PositionalPathArgumentCounts[$CommandName]
+            $pathArguments = [System.Collections.Generic.List[System.Management.Automation.Language.Ast]]::new()
+            $pendingPathParameter = $false
+            $pendingNonPathParameter = $false
+            $positionalIndex = 0
+
+            for ($index = 1; $index -lt $CommandAst.CommandElements.Count; $index++) {
+                $element = $CommandAst.CommandElements[$index]
+
+                if ($element -is [System.Management.Automation.Language.CommandParameterAst]) {
+                    $parameterName = $element.ParameterName
+                    $pendingPathParameter = $false
+                    $pendingNonPathParameter = $false
+
+                    if ($pathParameters -contains $parameterName) {
+                        if ($null -ne $element.Argument) {
+                            [void]$pathArguments.Add($element.Argument)
+                        }
+                        else {
+                            $pendingPathParameter = $true
+                        }
+
+                        continue
+                    }
+
+                    if (($script:SwitchOnlyParameterNames -notcontains $parameterName) -and $null -eq $element.Argument) {
+                        $pendingNonPathParameter = $true
+                    }
+
+                    continue
+                }
+
+                if ($element -isnot [System.Management.Automation.Language.ExpressionAst]) {
+                    continue
+                }
+
+                if ($pendingPathParameter) {
+                    [void]$pathArguments.Add($element)
+                    $pendingPathParameter = $false
+                    continue
+                }
+
+                if ($pendingNonPathParameter) {
+                    $pendingNonPathParameter = $false
+                    continue
+                }
+
+                $positionalIndex++
+                if ($positionalIndex -le $positionalLimit) {
+                    [void]$pathArguments.Add($element)
+                }
+            }
+
+            return @($pathArguments)
+        }
+
+        $script:NewViolation = {
+            param(
+                [string]$SourcePath,
+                [System.Management.Automation.Language.Ast]$Ast,
+                [string]$Command,
+                [string]$ResolvedPath
+            )
+
+            $relativePath = $SourcePath
+            if (Test-Path -LiteralPath $SourcePath) {
+                $relativePath = [System.IO.Path]::GetRelativePath($script:RepoRoot, (Resolve-Path $SourcePath).Path)
+            }
+            return [pscustomobject]@{
+                File         = ($relativePath -replace '\\', '/')
+                Line         = $Ast.Extent.StartLineNumber
+                Command      = $Command
+                PathArgument = $Ast.Extent.Text
+                ResolvedPath = $ResolvedPath
+            }
+        }
+
+        $script:GetCommandViolations = {
+            param(
+                [System.Management.Automation.Language.Ast]$Ast,
+                [hashtable]$VariableValues,
+                [string]$SourcePath
+            )
+
+            $violations = [System.Collections.Generic.List[object]]::new()
+            $commands = @($Ast.FindAll({
+                        param($Node)
+                        $Node -is [System.Management.Automation.Language.CommandAst]
+                    }, $true))
+
+            foreach ($commandAst in $commands) {
+                $commandName = $commandAst.GetCommandName()
+                if ([string]::IsNullOrWhiteSpace($commandName)) {
+                    continue
+                }
+
+                if (-not $script:WriteCommandPathParameters.ContainsKey($commandName)) {
+                    continue
+                }
+
+                if ($commandName -eq 'Copy-Item' -and -not (& $script:CommandHasForce -CommandAst $commandAst)) {
+                    continue
+                }
+
+                foreach ($argumentAst in (& $script:GetCommandPathArgumentAsts -CommandAst $commandAst -CommandName $commandName)) {
+                    $assetMatches = & $script:GetAssetPathMatchesFromAst -Ast $argumentAst -VariableValues $VariableValues
+                    foreach ($assetMatch in $assetMatches) {
+                        [void]$violations.Add((& $script:NewViolation -SourcePath $SourcePath -Ast $argumentAst -Command $commandName -ResolvedPath $assetMatch))
+                    }
+                }
+            }
+
+            return @($violations)
+        }
+
+        $script:GetStaticFileWriteViolations = {
+            param(
+                [System.Management.Automation.Language.Ast]$Ast,
+                [hashtable]$VariableValues,
+                [string]$SourcePath
+            )
+
+            $violations = [System.Collections.Generic.List[object]]::new()
+            $methodCalls = @($Ast.FindAll({
+                        param($Node)
+                        $Node -is [System.Management.Automation.Language.InvokeMemberExpressionAst]
+                    }, $true))
+
+            foreach ($methodCall in $methodCalls) {
+                if (-not $methodCall.Static) {
+                    continue
+                }
+
+                $targetType = $methodCall.Expression.Extent.Text
+                if ($targetType -notmatch '(?i)^\[(System\.)?IO\.File\]$') {
+                    continue
+                }
+
+                $methodName = $methodCall.Member.Extent.Text.Trim('''"')
+                if ($methodName -notin @('WriteAllText', 'WriteAllBytes')) {
+                    continue
+                }
+
+                $arguments = @($methodCall.Arguments)
+                if ($arguments.Count -eq 0) {
+                    continue
+                }
+
+                $assetMatches = & $script:GetAssetPathMatchesFromAst -Ast $arguments[0] -VariableValues $VariableValues
+                foreach ($assetMatch in $assetMatches) {
+                    [void]$violations.Add((& $script:NewViolation -SourcePath $SourcePath -Ast $arguments[0] -Command "[IO.File]::$methodName" -ResolvedPath $assetMatch))
+                }
+            }
+
+            return @($violations)
+        }
+
+        $script:GetAssetWriteViolationsFromAst = {
+            param(
+                [System.Management.Automation.Language.Ast]$Ast,
+                [string]$SourcePath
+            )
+
+            $variableValues = & $script:GetVariableAssetPathMap -Ast $Ast
+            return @(
+                & $script:GetCommandViolations -Ast $Ast -VariableValues $variableValues -SourcePath $SourcePath
+                & $script:GetStaticFileWriteViolations -Ast $Ast -VariableValues $variableValues -SourcePath $SourcePath
+            )
+        }
+
+        $script:GetAssetWriteViolationsFromContent = {
+            param(
+                [string]$Content,
+                [string]$SourcePath = 'inline-fixture.Tests.ps1'
+            )
+
+            $tokens = $null
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput($Content, [ref]$tokens, [ref]$parseErrors)
+            if ($parseErrors.Count -gt 0) {
+                throw "Failed to parse $SourcePath fixture: $($parseErrors[0].Message)"
+            }
+
+            return & $script:GetAssetWriteViolationsFromAst -Ast $ast -SourcePath $SourcePath
+        }
+
+        $script:GetAssetWriteViolationsFromFile = {
+            param([string]$SourcePath)
+
+            $tokens = $null
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($SourcePath, [ref]$tokens, [ref]$parseErrors)
+            if ($parseErrors.Count -gt 0) {
+                throw "Failed to parse ${SourcePath}: $($parseErrors[0].Message)"
+            }
+
+            return & $script:GetAssetWriteViolationsFromAst -Ast $ast -SourcePath $SourcePath
+        }
+    }
+
+    It 'detects committed skill asset writes through simple variable resolution in inline fixtures' {
+        $fixture = @'
+$configPath = Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json'
+Set-Content -Path $configPath -Value '{}'
+'@
+
+        $violations = & $script:GetAssetWriteViolationsFromContent -Content $fixture
+
+        $violations | Should -HaveCount 1 -Because 'a write through a variable assigned from a skills/*/assets/ Join-Path must be rejected'
+        $violations[0].Command | Should -Be 'Set-Content'
+        $violations[0].ResolvedPath | Should -Match $script:AssetPathPattern
+    }
+
+    It 'allows writes through variables resolved to temporary fixture paths' {
+        $fixture = @'
+$configPath = Join-Path $workDir 'foo.json'
+Set-Content -Path $configPath -Value '{}'
+'@
+
+        $violations = & $script:GetAssetWriteViolationsFromContent -Content $fixture
+
+        $violations | Should -HaveCount 0 -Because 'temporary fixture paths outside skills/*/assets/ remain valid test setup writes'
+    }
+
+    It 'recognizes every prohibited write-call form in inline fixtures' {
+        $fixture = @'
+$assetPath = Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json'
+Set-Content -Path $assetPath -Value '{}'
+'{}' | Out-File -FilePath $assetPath
+Add-Content -Path $assetPath -Value '{}'
+[IO.File]::WriteAllText($assetPath, '{}')
+[IO.File]::WriteAllBytes($assetPath, [byte[]]@())
+Move-Item -Path $assetPath -Destination (Join-Path $workDir 'moved.json')
+Copy-Item -Path (Join-Path $workDir 'source.json') -Destination $assetPath -Force
+Rename-Item -Path $assetPath -NewName 'guidance-complexity-renamed.json'
+'@
+
+        $commands = @(
+            & $script:GetAssetWriteViolationsFromContent -Content $fixture |
+                ForEach-Object { $_.Command } |
+                Sort-Object -Unique
+        )
+
+        $commands | Should -Be @(
+            '[IO.File]::WriteAllBytes',
+            '[IO.File]::WriteAllText',
+            'Add-Content',
+            'Copy-Item',
+            'Move-Item',
+            'Out-File',
+            'Rename-Item',
+            'Set-Content'
+        ) -Because 'the contract must cover the full AC6 write-call set'
+    }
+
+    It 'Pester test sources do not write committed skills assets' -Tag 'no-gh' {
+        $testSources = Get-ChildItem -Path $script:TestsRoot -Recurse -Filter '*.Tests.ps1' -File |
+            Where-Object { (Resolve-Path $_.FullName).Path -ne $script:ThisFile } |
+            Sort-Object -Property FullName
+
+        $violations = @(
+            foreach ($testSource in $testSources) {
+                & $script:GetAssetWriteViolationsFromFile -SourcePath $testSource.FullName
+            }
+        )
+
+        $violationSummary = @(
+            $violations |
+                Sort-Object -Property File, Line, Command |
+                ForEach-Object { "$($_.File):$($_.Line) $($_.Command) targets $($_.PathArgument) resolved as $($_.ResolvedPath)" }
+        )
+
+        $violations | Should -HaveCount 0 -Because "Pester tests must not write committed assets under skills/*/assets/. Use temporary fixtures and explicit config-path injection instead.`n$($violationSummary -join "`n")"
+    }
+}

--- a/.github/scripts/Tests/test-source-mutation-contract.Tests.ps1
+++ b/.github/scripts/Tests/test-source-mutation-contract.Tests.ps1
@@ -17,14 +17,14 @@ Describe 'test source mutation contract' -Tag 'no-gh' {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         $script:TestsRoot = Join-Path $script:RepoRoot '.github\scripts\Tests'
         $script:ThisFile = (Resolve-Path $PSCommandPath).Path
-        $script:AssetPathPattern = 'skills[/\\][^/\\]+[/\\]assets[/\\]'
+        $script:AssetPathPattern = 'skills[/\\][^/\\]+[/\\]assets(?:[/\\]|$)'
 
         $script:WriteCommandPathParameters = @{
             'Set-Content' = @('Path', 'LiteralPath')
             'Out-File'    = @('FilePath', 'LiteralPath')
             'Add-Content' = @('Path', 'LiteralPath')
             'Move-Item'   = @('Path', 'LiteralPath', 'Destination')
-            'Copy-Item'   = @('Path', 'LiteralPath', 'Destination')
+            'Copy-Item'   = @('Destination')
             'Rename-Item' = @('Path', 'LiteralPath', 'NewName')
         }
 
@@ -52,7 +52,75 @@ Describe 'test source mutation contract' -Tag 'no-gh' {
             return ($VariableAst.VariablePath.UserPath -replace '^(global|local|private|script|using):', '')
         }
 
-        $script:GetAssetPathMatchesFromAst = {
+        $script:JoinStaticPath = {
+            param([string]$Parent, [string]$Child)
+
+            if ([string]::IsNullOrWhiteSpace($Parent)) {
+                return $Child
+            }
+            if ([string]::IsNullOrWhiteSpace($Child)) {
+                return $Parent
+            }
+
+            return (($Parent.TrimEnd('/\')) + '/' + ($Child.TrimStart('/\')))
+        }
+
+        $script:GetJoinPathArgumentAsts = {
+            param([System.Management.Automation.Language.CommandAst]$CommandAst)
+
+            $pathParameterNames = @('Path', 'LiteralPath', 'ChildPath', 'AdditionalChildPath')
+            $argumentAsts = [System.Collections.Generic.List[System.Management.Automation.Language.Ast]]::new()
+            $pendingPathParameter = $false
+            $pendingNonPathParameter = $false
+
+            for ($index = 1; $index -lt $CommandAst.CommandElements.Count; $index++) {
+                $element = $CommandAst.CommandElements[$index]
+
+                if ($element -is [System.Management.Automation.Language.CommandParameterAst]) {
+                    $parameterName = $element.ParameterName
+                    $pendingPathParameter = $false
+                    $pendingNonPathParameter = $false
+
+                    if ($pathParameterNames -contains $parameterName) {
+                        if ($null -ne $element.Argument) {
+                            [void]$argumentAsts.Add($element.Argument)
+                        }
+                        else {
+                            $pendingPathParameter = $true
+                        }
+
+                        continue
+                    }
+
+                    if (($script:SwitchOnlyParameterNames -notcontains $parameterName) -and $null -eq $element.Argument) {
+                        $pendingNonPathParameter = $true
+                    }
+
+                    continue
+                }
+
+                if ($element -isnot [System.Management.Automation.Language.ExpressionAst]) {
+                    continue
+                }
+
+                if ($pendingPathParameter) {
+                    [void]$argumentAsts.Add($element)
+                    $pendingPathParameter = $false
+                    continue
+                }
+
+                if ($pendingNonPathParameter) {
+                    $pendingNonPathParameter = $false
+                    continue
+                }
+
+                [void]$argumentAsts.Add($element)
+            }
+
+            return @($argumentAsts)
+        }
+
+        $script:GetStaticPathValuesFromAst = {
             param(
                 [System.Management.Automation.Language.Ast]$Ast,
                 [hashtable]$VariableValues
@@ -63,6 +131,56 @@ Describe 'test source mutation contract' -Tag 'no-gh' {
             }
 
             $candidateValues = [System.Collections.Generic.List[string]]::new()
+
+            if ($Ast -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+                [void]$candidateValues.Add($Ast.Value)
+            }
+
+            if ($Ast -is [System.Management.Automation.Language.ExpandableStringExpressionAst]) {
+                [void]$candidateValues.Add($Ast.Value)
+                [void]$candidateValues.Add($Ast.Extent.Text)
+            }
+
+            if ($Ast -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                $name = & $script:NormalizeVariableName -VariableAst $Ast
+                if ($VariableValues.ContainsKey($name)) {
+                    [void]$candidateValues.Add($VariableValues[$name])
+                }
+            }
+
+            $joinPathCommands = @($Ast.FindAll({
+                        param($Node)
+                        $Node -is [System.Management.Automation.Language.CommandAst] -and
+                        $Node.GetCommandName() -eq 'Join-Path'
+                    }, $true))
+
+            foreach ($joinPathCommand in $joinPathCommands) {
+                $composedValues = @('')
+                $argumentAsts = @(& $script:GetJoinPathArgumentAsts -CommandAst $joinPathCommand)
+
+                foreach ($argumentAst in $argumentAsts) {
+                    $argumentValues = @(
+                        & $script:GetStaticPathValuesFromAst -Ast $argumentAst -VariableValues $VariableValues |
+                            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+                    )
+                    if ($argumentValues.Count -eq 0) {
+                        continue
+                    }
+
+                    $nextValues = [System.Collections.Generic.List[string]]::new()
+                    foreach ($parentValue in $composedValues) {
+                        foreach ($childValue in $argumentValues) {
+                            [void]$nextValues.Add((& $script:JoinStaticPath -Parent $parentValue -Child $childValue))
+                        }
+                    }
+                    $composedValues = @($nextValues)
+                }
+
+                foreach ($composedValue in $composedValues) {
+                    [void]$candidateValues.Add($composedValue)
+                }
+            }
+
             $nodes = @($Ast.FindAll({
                         param($Node)
                         $Node -is [System.Management.Automation.Language.StringConstantExpressionAst] -or
@@ -98,6 +216,18 @@ Describe 'test source mutation contract' -Tag 'no-gh' {
             return @(
                 $candidateValues |
                     Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                    Select-Object -Unique
+            )
+        }
+
+        $script:GetAssetPathMatchesFromAst = {
+            param(
+                [System.Management.Automation.Language.Ast]$Ast,
+                [hashtable]$VariableValues
+            )
+
+            return @(
+                & $script:GetStaticPathValuesFromAst -Ast $Ast -VariableValues $VariableValues |
                     Where-Object { $_ -match $script:AssetPathPattern } |
                     Select-Object -Unique
             )
@@ -118,36 +248,22 @@ Describe 'test source mutation contract' -Tag 'no-gh' {
                 }
 
                 $variableName = & $script:NormalizeVariableName -VariableAst $assignment.Left
-                $assetMatches = & $script:GetAssetPathMatchesFromAst -Ast $assignment.Right -VariableValues $variableValues
+                $pathCandidates = @(& $script:GetStaticPathValuesFromAst -Ast $assignment.Right -VariableValues $variableValues)
+                $assetMatches = @($pathCandidates | Where-Object { $_ -match $script:AssetPathPattern })
                 if ($assetMatches.Count -gt 0) {
                     $variableValues[$variableName] = $assetMatches[0]
+                    continue
+                }
+
+                $pathLikeCandidates = @($pathCandidates |
+                        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                        Where-Object { $_ -ne 'Join-Path' })
+                if ($pathLikeCandidates.Count -gt 0) {
+                    $variableValues[$variableName] = $pathLikeCandidates[0]
                 }
             }
 
             return $variableValues
-        }
-
-        $script:CommandHasForce = {
-            param([System.Management.Automation.Language.CommandAst]$CommandAst)
-
-            foreach ($element in $CommandAst.CommandElements) {
-                if ($element -isnot [System.Management.Automation.Language.CommandParameterAst]) {
-                    continue
-                }
-
-                if ($element.ParameterName -ne 'Force') {
-                    continue
-                }
-
-                if ($element.Argument -is [System.Management.Automation.Language.ConstantExpressionAst] -and
-                    $element.Argument.Value -eq $false) {
-                    continue
-                }
-
-                return $true
-            }
-
-            return $false
         }
 
         $script:GetCommandPathArgumentAsts = {
@@ -160,7 +276,10 @@ Describe 'test source mutation contract' -Tag 'no-gh' {
             $positionalLimit = [int]$script:PositionalPathArgumentCounts[$CommandName]
             $pathArguments = [System.Collections.Generic.List[System.Management.Automation.Language.Ast]]::new()
             $pendingPathParameter = $false
+            $pendingCopyItemSourceParameter = $false
             $pendingNonPathParameter = $false
+            $copyItemNamedSourceBound = $false
+            $copyItemNamedDestinationBound = $false
             $positionalIndex = 0
 
             for ($index = 1; $index -lt $CommandAst.CommandElements.Count; $index++) {
@@ -169,9 +288,23 @@ Describe 'test source mutation contract' -Tag 'no-gh' {
                 if ($element -is [System.Management.Automation.Language.CommandParameterAst]) {
                     $parameterName = $element.ParameterName
                     $pendingPathParameter = $false
+                    $pendingCopyItemSourceParameter = $false
                     $pendingNonPathParameter = $false
 
+                    if ($CommandName -eq 'Copy-Item' -and $parameterName -in @('Path', 'LiteralPath')) {
+                        $copyItemNamedSourceBound = $true
+                        if ($null -eq $element.Argument) {
+                            $pendingCopyItemSourceParameter = $true
+                        }
+
+                        continue
+                    }
+
                     if ($pathParameters -contains $parameterName) {
+                        if ($CommandName -eq 'Copy-Item' -and $parameterName -eq 'Destination') {
+                            $copyItemNamedDestinationBound = $true
+                        }
+
                         if ($null -ne $element.Argument) {
                             [void]$pathArguments.Add($element.Argument)
                         }
@@ -199,12 +332,29 @@ Describe 'test source mutation contract' -Tag 'no-gh' {
                     continue
                 }
 
+                if ($pendingCopyItemSourceParameter) {
+                    $pendingCopyItemSourceParameter = $false
+                    continue
+                }
+
                 if ($pendingNonPathParameter) {
                     $pendingNonPathParameter = $false
                     continue
                 }
 
                 $positionalIndex++
+                if ($CommandName -eq 'Copy-Item') {
+                    if ($copyItemNamedDestinationBound) {
+                        continue
+                    }
+
+                    $destinationPosition = if ($copyItemNamedSourceBound) { 1 } else { 2 }
+                    if ($positionalIndex -eq $destinationPosition) {
+                        [void]$pathArguments.Add($element)
+                    }
+                    continue
+                }
+
                 if ($positionalIndex -le $positionalLimit) {
                     [void]$pathArguments.Add($element)
                 }
@@ -254,10 +404,6 @@ Describe 'test source mutation contract' -Tag 'no-gh' {
                 }
 
                 if (-not $script:WriteCommandPathParameters.ContainsKey($commandName)) {
-                    continue
-                }
-
-                if ($commandName -eq 'Copy-Item' -and -not (& $script:CommandHasForce -CommandAst $commandAst)) {
                     continue
                 }
 
@@ -379,6 +525,88 @@ Set-Content -Path $configPath -Value '{}'
         $violations = & $script:GetAssetWriteViolationsFromContent -Content $fixture
 
         $violations | Should -HaveCount 0 -Because 'temporary fixture paths outside skills/*/assets/ remain valid test setup writes'
+    }
+
+    It 'treats Copy-Item destination as a write target without requiring Force' {
+        $fixture = @'
+$assetPath = Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json'
+$temp = Join-Path $workDir 'source.json'
+Copy-Item -Path $temp -Destination $assetPath
+'@
+
+        $violations = & $script:GetAssetWriteViolationsFromContent -Content $fixture
+
+        $violations | Should -HaveCount 1 -Because 'Copy-Item writes to its destination even when -Force is omitted'
+        $violations[0].Command | Should -Be 'Copy-Item'
+        $violations[0].PathArgument | Should -Be '$assetPath'
+    }
+
+    It 'detects Copy-Item positional destination when source is bound by named Path' {
+        $fixture = @'
+$assetPath = Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json'
+$temp = Join-Path $workDir 'source.json'
+Copy-Item -Path $temp $assetPath
+'@
+
+        $violations = & $script:GetAssetWriteViolationsFromContent -Content $fixture
+
+        $violations | Should -HaveCount 1 -Because 'when Copy-Item source is bound by -Path, the next positional argument is the destination write target'
+        $violations[0].Command | Should -Be 'Copy-Item'
+        $violations[0].PathArgument | Should -Be '$assetPath'
+    }
+
+    It 'detects Copy-Item positional destination when source is bound by named LiteralPath' {
+        $fixture = @'
+$assetPath = Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json'
+$temp = Join-Path $workDir 'source.json'
+Copy-Item -LiteralPath $temp $assetPath
+'@
+
+        $violations = & $script:GetAssetWriteViolationsFromContent -Content $fixture
+
+        $violations | Should -HaveCount 1 -Because 'when Copy-Item source is bound by -LiteralPath, the next positional argument is the destination write target'
+        $violations[0].Command | Should -Be 'Copy-Item'
+        $violations[0].PathArgument | Should -Be '$assetPath'
+    }
+
+    It 'allows Copy-Item to read a committed asset source into a temporary destination' {
+        $fixture = @'
+$assetPath = Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json'
+$temp = Join-Path $workDir 'copied.json'
+Copy-Item -LiteralPath $assetPath -Destination $temp -Force
+'@
+
+        $violations = & $script:GetAssetWriteViolationsFromContent -Content $fixture
+
+        $violations | Should -HaveCount 0 -Because 'Copy-Item source Path/LiteralPath arguments read assets but do not write them'
+    }
+
+    It 'detects committed asset writes assembled through split Join-Path roots' {
+        $fixture = @'
+$skillsRoot = Join-Path $script:RepoRoot 'skills'
+$skillRoot = Join-Path $skillsRoot 'calibration-pipeline'
+$assetPath = Join-Path (Join-Path $skillRoot 'assets') 'guidance-complexity.json'
+Set-Content -Path $assetPath -Value '{}'
+'@
+
+        $violations = & $script:GetAssetWriteViolationsFromContent -Content $fixture
+
+        $violations | Should -HaveCount 1 -Because 'common Join-Path chains must resolve to skills/*/assets/ write targets'
+        $violations[0].ResolvedPath | Should -Match 'skills[/\\]calibration-pipeline[/\\]assets[/\\]guidance-complexity\.json'
+    }
+
+    It 'detects committed asset writes assembled from an asset directory and file name' {
+        $fixture = @'
+$assetDir = Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets'
+$fileName = 'guidance-complexity.json'
+$assetPath = Join-Path $assetDir $fileName
+Set-Content -Path $assetPath -Value '{}'
+'@
+
+        $violations = & $script:GetAssetWriteViolationsFromContent -Content $fixture
+
+        $violations | Should -HaveCount 1 -Because 'assets as a directory plus a filename must still resolve to a committed asset write'
+        $violations[0].ResolvedPath | Should -Match 'skills[/\\]calibration-pipeline[/\\]assets[/\\]guidance-complexity\.json'
     }
 
     It 'recognizes every prohibited write-call form in inline fixtures' {

--- a/Documents/Design/guidance-complexity.md
+++ b/Documents/Design/guidance-complexity.md
@@ -10,16 +10,17 @@ Guardrail additions accumulate asymmetrically — new rules are proposed with no
 
 | # | Decision | Choice | Rationale |
 |---|----------|--------|-----------|
-| D1 | How to detect complexity | **Regex script with calibration override** — `.github/skills/guidance-measurement/scripts/measure-guidance-complexity.ps1` counts directive density per agent (MUST/NEVER/ALWAYS/REQUIRED/MANDATORY keywords + checklist items `- [ ]`/`- [x]`), excluding fenced code block content; soft ceilings in `.github/skills/calibration-pipeline/assets/guidance-complexity.json` (committed, not gitignored); override comments (`<!-- complexity-override: {reason} -->`) for false positives; section count + nesting depth as supplemental signals. Script always exits 0 (advisory). | Automated, Pester-testable, integrates with quick-validate; soft ceilings avoid blocking deployment |
+| D1 | How to detect complexity | **Regex script with calibration override** — `skills/guidance-measurement/scripts/measure-guidance-complexity.ps1` counts directive density per agent (MUST/NEVER/ALWAYS/REQUIRED/MANDATORY keywords + checklist items `- [ ]`/`- [x]`), excluding fenced code block content; soft ceilings in `skills/calibration-pipeline/assets/guidance-complexity.json` (committed, not gitignored); override comments (`<!-- complexity-override: {reason} -->`) for false positives; section count + nesting depth as supplemental signals. Script always exits 0 (advisory). | Automated, Pester-testable, integrates with quick-validate; soft ceilings avoid blocking deployment |
 | D2 | How to trigger compression | **Complexity ceiling trigger** — when an agent exceeds its soft ceiling, guardrail proposals targeting that agent in Process-Review §4.9 are tagged `compression_required: true` with advisory guidance (does NOT block the proposal). Scoped to `agent-prompt` proposals only (instruction/skill/plan-template proposals have no per-agent ceilings). | Creates symmetric pressure: simplify before adding; advisory ensures proposals aren't silently dropped |
 | D3 | What retirement means | **Consolidation + archival** — compress to general principles + examples, move specifics to `Documents/Archive/retired-rules/` with metadata (source agent, section, version range, restoration instructions). | Knowledge preserved; context reduced; rollback easy; compound-signal guard prevents premature retirement |
 | D4 | How to distinguish structural vs. rule-level | **Hybrid** — script defaults `prevention_level: unknown`; Process-Review §4.9 evaluates against upstream catch hierarchy and reclassifies to `structural` or `rule-level`. | Deterministic default where possible; flexible reasoning for novel patterns |
 | D5 | How to measure quality after consolidation | **Consolidation event tracking + regression threshold** — record events in calibration data; sustain rate monitoring with +10pp regression threshold; human review (not auto-rollback). | Uses existing infrastructure; regression detection is meaningful and non-destructive |
 | D6 | How to extract agent sections to skills | **Skill reference stubs** — 2-3 line stub in agent ("what and when"), full procedure in skill ("how"); 4 extraction criteria defined (see [Agent-to-Skill Extraction Criteria](#agent-to-skill-extraction-criteria)); **framework only — no immediate extractions**; §4.8 gets widened trigger + monitoring to collect evidence for future extraction/retirement decision. | Framework-first; candidates emerge from monitoring data; §4.8 needs fair chance before extraction |
-| D7 | Persistent over-ceiling detection | **`complexity_over_ceiling_history` write-back** — `.github/skills/calibration-pipeline/scripts/aggregate-review-scores.ps1` gains `-ComplexityJsonPath` parameter and tracks per-agent over-ceiling history in calibration JSON; `persistent_threshold` in `.github/skills/calibration-pipeline/assets/guidance-complexity.json` controls extraction advisory trigger. | Enables compound-signal retirement and regression detection; requires calibration data maturity (Phase 2) |
+| D7 | Persistent over-ceiling detection | **`complexity_over_ceiling_history` write-back** — `skills/calibration-pipeline/scripts/aggregate-review-scores.ps1` passes `-ComplexityJsonPath` to `Invoke-AggregateReviewScores`, which tracks per-agent over-ceiling history in calibration JSON; `persistent_threshold` in `skills/calibration-pipeline/assets/guidance-complexity.json` controls extraction advisory trigger. Both wrapper and core accept optional `-ComplexityCeilingConfigPath` for explicit threshold-config injection while preserving the canonical default when omitted. | Enables compound-signal retirement and regression detection; requires calibration data maturity (Phase 2) |
 | D8 | Tiered advisory | **Extraction replaces compression** — when an agent's `consecutive_count ≥ persistent_threshold`, §4.9 emits `extraction_recommended: true` instead of compression advisory; D8 fires exclusively (D2 suppressed when D8 fires). | Avoids repeated compression of already-compressed sections; extraction is higher-leverage when compression has been sustained |
 | D9 | Agent creation complexity budget | **Convention + quick-validate gate** — new agents must not exceed 80% of `default_ceiling.max_directives` at creation time; enforced at PR time via the existing `agents_over_ceiling.Count  # should be 0` quick-validate check. | Prevents ceiling violations at agent-creation time without additional infrastructure |
 | D10 | Implementation capacity gate | **CC autonomous decision rule** — when Code-Conductor begins implementing a rule-addition issue (`systemic_fix_type: agent-prompt`), it checks whether the target agent exceeds its soft ceiling (`measure-guidance-complexity.ps1`). If over ceiling, CC autonomously creates a compression prerequisite issue and blocks the rule-addition until the compression issue is closed AND the agent ≤ ceiling. Exempt: issues reducing directive count (compression, extraction, consolidation). Complements the D2/D8 advisory system with implementation-time enforcement. | Preserves D2/D8 advisory semantics; same autonomy pattern as improvement-first (§2a); no infrastructure gate required — CC is self-enforcing |
+| D11 | How to test threshold variants | **Temp config injection; committed assets read-only** — tests that need custom `persistent_threshold` values write a temporary config and pass `-ComplexityCeilingConfigPath`; production callers omit the parameter and use the canonical config. Repo-wide Pester AST coverage rejects test-source writes to committed `skills/*/assets/` paths. | Prevents dirty-tree and trailing-whitespace churn while preserving default Process-Review behavior |
 
 ---
 
@@ -27,13 +28,13 @@ Guardrail additions accumulate asymmetrically — new rules are proposed with no
 
 ### Phase 1 — Data-Independent (Ships With This PR)
 
-- **D1**: `.github/skills/guidance-measurement/scripts/measure-guidance-complexity.ps1` + `.github/skills/calibration-pipeline/assets/guidance-complexity.json` + quick-validate integration
+- **D1**: `skills/guidance-measurement/scripts/measure-guidance-complexity.ps1` + `skills/calibration-pipeline/assets/guidance-complexity.json` + quick-validate integration
 - **D2**: Compression trigger wiring in Process-Review §4.9 (ceiling flag, advisory guidance)
 - **D6**: Extraction criteria documented; Process-Review §4.8 trigger widened to calibration-inclusive mode; invocation monitoring added
 
 ### Phase 2 — Consolidation Monitoring & Tiered Advisory (Ships With This PR)
 
-- **D7**: Persistent over-ceiling detection — `-ComplexityJsonPath` parameter, `complexity_over_ceiling_history` write-back, `consolidation_events[]` (`.github/skills/calibration-pipeline/scripts/aggregate-review-scores.ps1`)
+- **D7**: Persistent over-ceiling detection — `-ComplexityJsonPath` parameter, optional `-ComplexityCeilingConfigPath`, `complexity_over_ceiling_history` write-back, `consolidation_events[]` (`skills/calibration-pipeline/scripts/aggregate-review-scores.ps1` and `skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1`)
 - **D8**: Tiered advisory in Process-Review §4.9 — extraction advisory replaces compression advisory when `consecutive_count >= persistent_threshold`
 - **D9**: Agent Creation Complexity Budget — convention documented, enforced by existing quick-validate gate
 
@@ -89,7 +90,7 @@ When an agent exceeds its directive ceiling, consolidate related rules into gene
 
 ## Complexity Ceiling Configuration
 
-Config file at `.github/skills/calibration-pipeline/assets/guidance-complexity.json`. Schema:
+Config file at `skills/calibration-pipeline/assets/guidance-complexity.json`. Schema:
 
 ```json
 {
@@ -100,6 +101,16 @@ Config file at `.github/skills/calibration-pipeline/assets/guidance-complexity.j
   "default_ceiling": { "max_directives": N }
 }
 ```
+
+### Config Path Injection and Test Fixtures
+
+`skills/calibration-pipeline/scripts/aggregate-review-scores.ps1` and `Invoke-AggregateReviewScores` in `skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1` accept optional `[string]$ComplexityCeilingConfigPath = ''`.
+
+When the parameter is omitted, the core reads the canonical `skills/calibration-pipeline/assets/guidance-complexity.json` file. If that default file is absent or unreadable, the aggregate path silently uses the fallback persistent threshold of `3` so production and Process-Review invocations remain backward compatible.
+
+When the parameter is supplied, the path is treated literally. A missing explicit path emits a warning containing the supplied path and continues with the fallback persistent threshold of `3`.
+
+Pester tests that need custom `persistent_threshold` values must write a temporary fixture config outside `skills/*/assets/` and pass `-ComplexityCeilingConfigPath`. Tests must not mutate committed skill assets to exercise threshold variants. `.github/scripts/Tests/test-source-mutation-contract.Tests.ps1` enforces this with a repo-wide AST scan for write operations targeting committed `skills/*/assets/` paths.
 
 **Initial ceiling values** are set above current agent directive counts so no agents trigger on day one (advisory, zero false triggers at deployment). Ceilings are tunable as the system is used.
 
@@ -125,16 +136,18 @@ When those conditions are met, reduce the ceiling by 10 directives and reassess 
 
 | Artifact | Change | Phase |
 |---|---|---|
-| `.github/skills/guidance-measurement/scripts/measure-guidance-complexity.ps1` | New — directive density counting script | 1 |
-| `.github/skills/calibration-pipeline/assets/guidance-complexity.json` | New — soft ceilings config per agent (committed) | 1 |
+| `skills/guidance-measurement/scripts/measure-guidance-complexity.ps1` | New — directive density counting script | 1 |
+| `skills/calibration-pipeline/assets/guidance-complexity.json` | New — soft ceilings config per agent (committed) | 1 |
 | `copilot-instructions.md` (Quick-validate) | Modified — add D1 script to pre-merge check list | 1 |
 | `Process-Review.agent.md` §4.7 | Modified — invoke `measure-guidance-complexity.ps1` in run-scripts phase | 1 |
 | `Process-Review.agent.md` §4.8 | Modified — widen trigger to calibration-inclusive mode + monitoring note | 1 |
 | `Process-Review.agent.md` §4.9 | Modified — `compression_required` flag when ceiling exceeded | 1 |
-| `.github/skills/calibration-pipeline/scripts/aggregate-review-scores.ps1` | Modified — `-ComplexityJsonPath` parameter, `complexity_over_ceiling_history` write-back, `extraction_agents:` output, `consolidation_events[]` | 2 |
+| `skills/calibration-pipeline/scripts/aggregate-review-scores.ps1` | Modified — wrapper parameters for `-ComplexityJsonPath` and `-ComplexityCeilingConfigPath` | 2 |
+| `skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1` | Modified — persistent-threshold config loading, explicit-path warning, `complexity_over_ceiling_history` write-back, `extraction_agents:` output, `consolidation_events[]` | 2 |
+| `.github/scripts/Tests/test-source-mutation-contract.Tests.ps1` | New — Pester AST contract preventing test-source writes to committed `skills/*/assets/` files | 2 |
 | `Documents/Archive/retired-rules/` | New convention — archive for retired rules with restoration metadata | 2 |
 
-**Net-new artifacts capped**: 1 script + 1 config (Phase 1). Phase 2 modifies existing files only (plus archive convention).
+**Net-new runtime artifacts capped**: 1 script + 1 config (Phase 1). Phase 2 modifies existing runtime files only (plus archive convention); test contracts may be added to protect those invariants.
 
 ---
 
@@ -146,7 +159,7 @@ Implements the data-dependent mechanisms from D7–D9 that require calibration h
 
 ### D7 — Persistent Over-Ceiling Detection
 
-`.github/skills/calibration-pipeline/scripts/aggregate-review-scores.ps1` gains a `-ComplexityJsonPath` parameter (type `[string]`, optional) that receives the path to the JSON output from `.github/skills/guidance-measurement/scripts/measure-guidance-complexity.ps1`. When provided, the script tracks per-agent over-ceiling history in the calibration JSON under `complexity_over_ceiling_history`.
+`skills/calibration-pipeline/scripts/aggregate-review-scores.ps1` exposes a `-ComplexityJsonPath` parameter (type `[string]`, optional) and splats it to `Invoke-AggregateReviewScores` in `skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1`. The parameter receives the path to the JSON output from `skills/guidance-measurement/scripts/measure-guidance-complexity.ps1`. When provided, the core tracks per-agent over-ceiling history in the calibration JSON under `complexity_over_ceiling_history`.
 
 **History entry schema** (per agent filename):
 
@@ -163,7 +176,7 @@ Implements the data-dependent mechanisms from D7–D9 that require calibration h
 
 **Idempotency**: The `last_pr_number` field prevents re-incrementing `consecutive_count` when the aggregate script is run multiple times with the same calibration state (e.g., on model switch resume). Increment is skipped when `last_pr_number == $maxMergedPrNumber`.
 
-**`persistent_threshold`** (authoritative source: `.github/skills/calibration-pipeline/assets/guidance-complexity.json`): The consecutive-run count at which the extraction advisory fires. Default value: `3`. Read by `.github/skills/calibration-pipeline/scripts/aggregate-review-scores.ps1` directly from the config file (not from the complexity JSON temp file) to keep the config as the single source of truth.
+**`persistent_threshold`** (authoritative source: `skills/calibration-pipeline/assets/guidance-complexity.json`): The consecutive-run count at which the extraction advisory fires. Default value: `3`. Read by `Invoke-AggregateReviewScores` from the config file (not from the complexity JSON temp file) to keep the config as the single source of truth. The optional `-ComplexityCeilingConfigPath` parameter exists for tests and controlled runs; omitted calls use the canonical asset path and silently fall back to `3` if the default file is absent or unreadable.
 
 **`extraction_agents:` YAML output**: After processing, the aggregate script emits an `extraction_agents:` block listing every agent whose `consecutive_count >= persistent_threshold`:
 
@@ -194,12 +207,12 @@ This block is consumed by §4.9 Step 1b during the same Process-Review calibrati
 
 New agents should be designed to fit within the soft ceiling from the outset. This is a convention, not an automated check; the quick-validate gate (`agents_over_ceiling.Count  # should be 0`) enforces it at PR time.
 
-**Convention**: When creating a new agent, its initial directive density should not exceed 80% of the `default_ceiling.max_directives` value in `.github/skills/calibration-pipeline/assets/guidance-complexity.json` (currently **102 directives** with the default ceiling of 128). This leaves headroom for guardrail additions over the agent's lifecycle before compression becomes necessary.
+**Convention**: When creating a new agent, its initial directive density should not exceed 80% of the `default_ceiling.max_directives` value in `skills/calibration-pipeline/assets/guidance-complexity.json` (currently **102 directives** with the default ceiling of 128). This leaves headroom for guardrail additions over the agent's lifecycle before compression becomes necessary.
 
 **Verification workflow**: After any agent addition or modification, run:
 
 ```powershell
-(pwsh -NoProfile -NonInteractive -File .github/skills/guidance-measurement/scripts/measure-guidance-complexity.ps1 | ConvertFrom-Json).agents_over_ceiling.Count  # should be 0
+(pwsh -NoProfile -NonInteractive -File skills/guidance-measurement/scripts/measure-guidance-complexity.ps1 | ConvertFrom-Json).agents_over_ceiling.Count  # should be 0
 ```
 
 This is already part of the Quick-validate suite in `.github/copilot-instructions.md`.
@@ -253,11 +266,12 @@ Consolidation events provide evidence for D5 monitoring (quality regression thre
 The data flow for D7/D8 in a Process-Review calibration run (§4.7):
 
 ```text
-.github/skills/guidance-measurement/scripts/measure-guidance-complexity.ps1
+skills/guidance-measurement/scripts/measure-guidance-complexity.ps1
    → $complexityOutput (in-memory PSCustomObject)
    → $complexityTempFile (temp JSON in $env:TEMP)
-.github/skills/calibration-pipeline/scripts/aggregate-review-scores.ps1 -ComplexityJsonPath $complexityTempFile
-   → reads agents_over_ceiling from temp file
+skills/calibration-pipeline/scripts/aggregate-review-scores.ps1 -ComplexityJsonPath $complexityTempFile
+  → reads agents_over_ceiling from temp file
+  → reads persistent_threshold from canonical config unless -ComplexityCeilingConfigPath is supplied
    → updates complexity_over_ceiling_history in calibration JSON (atomic write-back)
    → emits extraction_agents: block in YAML output
 §4.9 Step 1b reads extraction_agents: from aggregate YAML output
@@ -265,9 +279,9 @@ The data flow for D7/D8 in a Process-Review calibration run (§4.7):
 Temp file cleanup: Remove-Item $complexityTempFile
 ```
 
-**Error handling**: If `.github/skills/guidance-measurement/scripts/measure-guidance-complexity.ps1` fails or produces non-JSON output, `$complexityTempFile = $null` and the aggregate script runs without `-ComplexityJsonPath` (backward compatible — no complexity history tracking for that run).
+**Error handling**: If `skills/guidance-measurement/scripts/measure-guidance-complexity.ps1` fails or produces non-JSON output, `$complexityTempFile = $null` and the aggregate script runs without `-ComplexityJsonPath` (backward compatible — no complexity history tracking for that run).
 
-**`persistent_threshold` authority**: The value lives in `.github/skills/calibration-pipeline/assets/guidance-complexity.json` (key: `persistent_threshold`). The aggregate script reads it from the sibling `../assets/guidance-complexity.json` path. §4.9 reads the value from the `extraction_agents:` YAML block produced by the aggregate script — §4.9 never reads the config file directly.
+**`persistent_threshold` authority**: The value lives in `skills/calibration-pipeline/assets/guidance-complexity.json` (key: `persistent_threshold`). The aggregate core reads it from the sibling `../assets/guidance-complexity.json` path unless `-ComplexityCeilingConfigPath` supplies an explicit config file. §4.9 reads the value from the `extraction_agents:` YAML block produced by the aggregate script — §4.9 never reads the config file directly.
 
 ### Archive Convention
 
@@ -278,10 +292,10 @@ When a rule section is retired as part of D3 (compound-signal retirement), move 
 ````markdown
 # {Rule Section Name} — Archived
 
-**Source**: `.github/agents/{AgentName}.agent.md`, section "{Section heading}"
+**Source**: `agents/{AgentName}.agent.md`, section "{Section heading}"
 **Archived at**: PR #{N} (merged {date})
 **Version range**: Committed at PR #{first-pr} — retired at PR #{N}
-**Replacement**: Compressed into `{principle name}` in `.github/agents/{AgentName}.agent.md`
+**Replacement**: Compressed into `{principle name}` in `agents/{AgentName}.agent.md`
 **Restoration**: Revert to git tag `{tag}` or cherry-pick from commit `{sha}` to restore the original section
 
 ## Original Content
@@ -309,6 +323,7 @@ When a rule section is retired as part of D3 (compound-signal retirement), move 
 | Complex weighted scoring for density | Over-engineered; simple directive + checklist counting with section depth supplementals provides sufficient signal |
 | Blocking proposal when ceiling exceeded | Proposals might be important and urgent; advisory approach preserves human judgment; `compression_required` flag is sufficient signal |
 | Compression check on non-agent targets | instruction/skill/plan-template proposals don't have per-agent ceilings; scoping to `agent-prompt` only avoids false positives |
+| In-place Pester mutation of committed `guidance-complexity.json` | Interrupted or concurrent runs can leave phantom whitespace diffs; temp fixture config via `-ComplexityCeilingConfigPath` exercises custom thresholds without touching the committed asset |
 
 ---
 
@@ -317,7 +332,7 @@ When a rule section is retired as part of D3 (compound-signal retirement), move 
 **Phase 1 (this PR):**
 
 - `measure-guidance-complexity.ps1` exists and counts directive density per agent, excluding fenced code block content, with Pester test coverage
-- `.github/skills/calibration-pipeline/assets/guidance-complexity.json` defines soft ceilings per agent file (committed to repo, not gitignored)
+- `skills/calibration-pipeline/assets/guidance-complexity.json` defines soft ceilings per agent file (committed to repo, not gitignored)
 - Quick-validate includes complexity check using `(..).agents_over_ceiling.Count  # should be 0` pattern
 - Process-Review §4.9 references complexity ceiling and flags `compression_required: true` when ceiling exceeded (advisory only, scoped to `agent-prompt` proposals)
 - Process-Review §4.8 trigger widened to run in calibration-only mode, with invocation monitoring note
@@ -328,6 +343,8 @@ When a rule section is retired as part of D3 (compound-signal retirement), move 
 **Phase 2 (this PR):**
 
 - `-ComplexityJsonPath` parameter in `aggregate-review-scores.ps1`; per-agent `complexity_over_ceiling_history` write-back to calibration JSON (D7)
+- Optional `-ComplexityCeilingConfigPath` in the wrapper and core preserves canonical default behavior when omitted, warns on missing explicit paths, and supports temp fixture config for tests
+- `.github/scripts/Tests/test-source-mutation-contract.Tests.ps1` prevents Pester test sources from writing committed `skills/*/assets/` files
 - Tiered advisory in Process-Review §4.9 — extraction advisory replaces compression advisory at `persistent_threshold` (D8)
 - Agent Creation Complexity Budget convention documented; quick-validate gate enforces it (D9)
 - `consolidation_events[]` logged when an agent drops from over-ceiling tracking
@@ -354,7 +371,7 @@ Issue #212 applies this framework to reduce existing instruction bloat. All work
 
 ### W2 — Process-Review Skill Extraction
 
-Extracted "Common Scenarios" section (5 workflows) from `Process-Review.agent.md` to `.github/skills/process-troubleshooting/SKILL.md`. Process-Review retains an ~11-line stub with symptom-keyword triggers. Skill count: 14 → 15.
+Extracted "Common Scenarios" section (5 workflows) from `Process-Review.agent.md` to `skills/process-troubleshooting/SKILL.md`. Process-Review retains an ~11-line stub with symptom-keyword triggers. Skill count: 14 → 15.
 
 ### W3 — Structural Prevention
 

--- a/Documents/Design/guidance-complexity.md
+++ b/Documents/Design/guidance-complexity.md
@@ -106,7 +106,7 @@ Config file at `skills/calibration-pipeline/assets/guidance-complexity.json`. Sc
 
 `skills/calibration-pipeline/scripts/aggregate-review-scores.ps1` and `Invoke-AggregateReviewScores` in `skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1` accept optional `[string]$ComplexityCeilingConfigPath = ''`.
 
-When the parameter is omitted, the core reads the canonical `skills/calibration-pipeline/assets/guidance-complexity.json` file. If that default file is absent or unreadable, the aggregate path silently uses the fallback persistent threshold of `3` so production and Process-Review invocations remain backward compatible.
+When the parameter is omitted, the core resolves the canonical `skills/calibration-pipeline/assets/guidance-complexity.json` file. If that default file is missing, the aggregate path silently uses the fallback persistent threshold of `3` so production and Process-Review invocations remain backward compatible. If the resolved default file exists but cannot be read or parsed, the aggregate path emits a warning and falls back to `3`.
 
 When the parameter is supplied, the path is treated literally. A missing explicit path emits a warning containing the supplied path and continues with the fallback persistent threshold of `3`.
 
@@ -176,7 +176,7 @@ Implements the data-dependent mechanisms from D7–D9 that require calibration h
 
 **Idempotency**: The `last_pr_number` field prevents re-incrementing `consecutive_count` when the aggregate script is run multiple times with the same calibration state (e.g., on model switch resume). Increment is skipped when `last_pr_number == $maxMergedPrNumber`.
 
-**`persistent_threshold`** (authoritative source: `skills/calibration-pipeline/assets/guidance-complexity.json`): The consecutive-run count at which the extraction advisory fires. Default value: `3`. Read by `Invoke-AggregateReviewScores` from the config file (not from the complexity JSON temp file) to keep the config as the single source of truth. The optional `-ComplexityCeilingConfigPath` parameter exists for tests and controlled runs; omitted calls use the canonical asset path and silently fall back to `3` if the default file is absent or unreadable.
+**`persistent_threshold`** (authoritative source: `skills/calibration-pipeline/assets/guidance-complexity.json`): The consecutive-run count at which the extraction advisory fires. Default value: `3`. Read by `Invoke-AggregateReviewScores` from the config file (not from the complexity JSON temp file) to keep the config as the single source of truth. The optional `-ComplexityCeilingConfigPath` parameter exists for tests and controlled runs; omitted calls resolve the canonical asset path. A missing default file silently falls back to `3`; an existing default file that cannot be read or parsed emits a warning before falling back to `3`. Explicit supplied paths are literal; missing explicit paths warn and fall back to `3`.
 
 **`extraction_agents:` YAML output**: After processing, the aggregate script emits an `extraction_agents:` block listing every agent whose `consecutive_count >= persistent_threshold`:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Orchestra
 
-[![Version](https://img.shields.io/badge/version-v2.5.3-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v2.5.4-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development across specialized agents in GitHub Copilot and Claude Code.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "Multi-agent workflow system for GitHub Copilot. Pipeline-based agent orchestration: Issue → Design → Plan → Implement → Review → PR.",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "author": {
     "name": "Grimblaz"
   },

--- a/skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1
+++ b/skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1
@@ -501,7 +501,20 @@ function Invoke-AggregateReviewScores {
     $consolidationEvents = @()
     $complexityHistoryChanged = $false
 
+    # Resolve guidance-complexity config path and persistent_threshold default (Phase 2 D7)
+    $persistentThreshold = 3  # default when config is absent or unreadable
+    $hasExplicitComplexityConfigPath = -not [string]::IsNullOrWhiteSpace($ComplexityCeilingConfigPath)
+    $complexityConfigPath = if ($hasExplicitComplexityConfigPath) {
+        $ComplexityCeilingConfigPath
+    }
+    else {
+        Join-Path $script:_ARSCoreLibDir '../assets/guidance-complexity.json'
+    }
+
     if ($null -eq $mergedPRs -or $mergedPRs.Count -eq 0) {
+        if ($hasExplicitComplexityConfigPath -and -not (Test-Path -LiteralPath $complexityConfigPath)) {
+            Write-Warning "Complexity ceiling config path '$ComplexityCeilingConfigPath' was not found; using default persistent_threshold $persistentThreshold"
+        }
         [void]$out.AppendLine("data_source: $dataSource")
         [void]$out.AppendLine("insufficient_data: true")
         [void]$out.AppendLine("effective_sample_size: 0")
@@ -575,18 +588,9 @@ function Invoke-AggregateReviewScores {
         }
     }
 
-    # Read persistent_threshold from guidance-complexity config (Phase 2 D7)
-    $persistentThreshold = 3  # default when config is absent or unreadable
-    $hasExplicitComplexityConfigPath = -not [string]::IsNullOrWhiteSpace($ComplexityCeilingConfigPath)
-    $complexityConfigPath = if ($hasExplicitComplexityConfigPath) {
-        $ComplexityCeilingConfigPath
-    }
-    else {
-        Join-Path $script:_ARSCoreLibDir '../assets/guidance-complexity.json'
-    }
-    if (Test-Path $complexityConfigPath) {
+    if (Test-Path -LiteralPath $complexityConfigPath) {
         try {
-            $complexityCfg = Get-Content $complexityConfigPath -Raw | ConvertFrom-Json
+            $complexityCfg = Get-Content -LiteralPath $complexityConfigPath -Raw | ConvertFrom-Json
             if ($null -ne $complexityCfg.persistent_threshold -and [int]$complexityCfg.persistent_threshold -gt 0) {
                 $persistentThreshold = [int]$complexityCfg.persistent_threshold
             }

--- a/skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1
+++ b/skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1
@@ -432,6 +432,7 @@ function Invoke-AggregateReviewScores {
         [string]$Repo = '',
         [string]$CalibrationFile = '.copilot-tracking/calibration/review-data.json',
         [string]$ComplexityJsonPath = '',
+        [string]$ComplexityCeilingConfigPath = '',
         [string]$GhCliPath = 'gh',
         [switch]$HealthReport
     )

--- a/skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1
+++ b/skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1
@@ -577,7 +577,13 @@ function Invoke-AggregateReviewScores {
 
     # Read persistent_threshold from guidance-complexity config (Phase 2 D7)
     $persistentThreshold = 3  # default when config is absent or unreadable
-    $complexityConfigPath = Join-Path $script:_ARSCoreLibDir '../assets/guidance-complexity.json'
+    $hasExplicitComplexityConfigPath = -not [string]::IsNullOrWhiteSpace($ComplexityCeilingConfigPath)
+    $complexityConfigPath = if ($hasExplicitComplexityConfigPath) {
+        $ComplexityCeilingConfigPath
+    }
+    else {
+        Join-Path $script:_ARSCoreLibDir '../assets/guidance-complexity.json'
+    }
     if (Test-Path $complexityConfigPath) {
         try {
             $complexityCfg = Get-Content $complexityConfigPath -Raw | ConvertFrom-Json
@@ -591,6 +597,9 @@ function Invoke-AggregateReviewScores {
         catch {
             Write-Warning "Could not read persistent_threshold from guidance-complexity config: $_ — defaulting to $persistentThreshold"
         }
+    }
+    elseif ($hasExplicitComplexityConfigPath) {
+        Write-Warning "Complexity ceiling config path '$ComplexityCeilingConfigPath' was not found; using default persistent_threshold $persistentThreshold"
     }
 
     # ---------------------------------------------------------------------------

--- a/skills/calibration-pipeline/scripts/aggregate-review-scores.ps1
+++ b/skills/calibration-pipeline/scripts/aggregate-review-scores.ps1
@@ -57,6 +57,7 @@ param(
     [string]$Repo = '',
     [string]$CalibrationFile = '.copilot-tracking/calibration/review-data.json',
     [string]$ComplexityJsonPath = '',
+    [string]$ComplexityCeilingConfigPath = '',
     [string]$GhCliPath = 'gh',
     [switch]$HealthReport,
     [string]$OutputPath = ''

--- a/skills/calibration-pipeline/scripts/aggregate-review-scores.ps1
+++ b/skills/calibration-pipeline/scripts/aggregate-review-scores.ps1
@@ -37,6 +37,13 @@
     Path to a measure-guidance-complexity.ps1 JSON output file. When provided,
     increments consecutive_count for over-ceiling agents and logs consolidation events.
 
+.PARAMETER ComplexityCeilingConfigPath
+    Optional path to a guidance-complexity config JSON file that overrides the
+    committed canonical default used for persistent_threshold. When omitted, the
+    script reads skills/calibration-pipeline/assets/guidance-complexity.json.
+    When an explicit path is supplied but not found, the script emits a warning
+    and uses the default persistent_threshold.
+
 .PARAMETER GhCliPath
     Path to the gh CLI executable. Defaults to 'gh'. Override for testing.
 


### PR DESCRIPTION
## Summary

- Adds `-ComplexityCeilingConfigPath` to the aggregate-review-scores wrapper and core so tests can inject a temp guidance-complexity config without touching the committed asset.
- Rewrites the persistent-threshold aggregate test and routing-table reread test to mutate temp fixtures only, then adds a repo-wide AST contract that blocks Pester tests from writing committed `skills/*/assets/` files.
- Adds byte-stability coverage for `guidance-complexity.json`, updates the guidance-complexity design doc, and bumps the plugin cache key from 2.5.3 to 2.5.4.

## Changed Files

- `skills/calibration-pipeline/scripts/aggregate-review-scores.ps1`
- `skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1`
- `.github/scripts/Tests/aggregate-review-scores.Tests.ps1`
- `.github/scripts/Tests/routing-tables.Tests.ps1`
- `.github/scripts/Tests/test-source-mutation-contract.Tests.ps1`
- `Documents/Design/guidance-complexity.md`
- Plugin version files: `plugin.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.github/plugin/marketplace.json`, `README.md`

## Validation Evidence

| Check | Result |
| --- | --- |
| Full Pester suite: `Invoke-Pester .github/scripts/Tests/ -Output None -PassThru` | 683 total, 682 passed, 0 failed, 1 skipped |
| Structural validation: `pwsh -NoProfile -NonInteractive -File .github/scripts/quick-validate.ps1` | 12/12 checks passed |
| Review Completion Gate | `complete` |
| Formatting gate | `markdownlint-cli2 --fix` on changed Markdown: 0 errors; whitespace normalizer ran on allowlisted changed config files |
| Version lockstep | `bump-version.ps1 -Version 2.5.4 -DryRun` confirmed 7 occurrences across 5 files at 2.5.4 |
| Targeted asset status | `skills/calibration-pipeline/assets/guidance-complexity.json` and `skills/routing-tables/assets/routing-config.json` clean |
| Scope check | Branch diff limited to issue #402 implementation, tests, design doc, and required plugin version files |

Migration scan: N/A, this is not a migration-type issue.

Cleanup note: Contributors with prior dirty `guidance-complexity.json` state can run `git restore skills/calibration-pipeline/assets/guidance-complexity.json` and drop any related stash entries (e.g., `issue-382-guidance-complexity-whitespace`) once this fix lands.

## Review Mode

Full review.

## CE Gate Result

| ID | Type | Class | Result | Evidence | Source |
| --- | --- | --- | --- | --- | --- |
| S1 | Manual | Functional | PASS | Scoped suite passed and `guidance-complexity.json` hash stayed stable | Experience-Owner CE evidence |
| S2 | Manual | Functional/Structural | PASS | Tests now use temp config injection; AC6 AST contract blocks committed skill-asset writes | Experience-Owner CE evidence |
| S3 | Manual | Functional/Structural | PASS | Targeted asset status remained clean; no branch-carried phantom diff source remains | Experience-Owner CE evidence |
| S4 | Manual | Intent | PASS | Representative suite left no asset diff; working-tree confidence restored for this asset class | Experience-Owner CE evidence |

✅ CE Gate passed — intent match: strong

## Adversarial Review Scores

| Stage | Prosecutor | Defense | Judge rulings | Outcome |
| --- | ---: | ---: | ---: | --- |
| Code Review | 12 pts, 4 findings | 0 pts | 4 sustained | All accepted findings fixed |
| Post-fix Review | 11 pts, 2 findings | 0 pts | 2 sustained | All accepted findings fixed |
| CE Review | 0 pts, 0 findings | 0 pts | 0 rulings | Strong intent match |

## Prosecution Depth Summary

All categories ran at full depth. No light/skip categories, no override, and no prosecution-depth reactivation events were recorded.

## Process / Retrospective Evidence

- D1-D6 design fidelity: faithful. The implementation followed the design: wrapper/core `-ComplexityCeilingConfigPath`, explicit-path warning/default fallback semantics, temp-config aggregate tests, removal of committed-asset backup/restore mutation, byte-stability coverage, and repo-wide AST protection against Pester writes to committed `skills/*/assets/` files.
- Acceptance criteria softening: none. AC5 remains intentionally forensic for normal suite completion only, with AC6 carrying interrupted-run prevention; AC6 was strengthened after review to cover Copy-Item binding cases and assembled `Join-Path` asset paths.
- Propagation to #461: no sustained review finding remains unresolved. #461 should inherit only the broader attribution lesson that whitespace-drift metrics must distinguish test-induced dirty-tree churn from hook/formatter cleanup.
- Baseline attribution: keep hook-installed and hook-uninstalled contributors as separate populations. Issue #402 evidence should be attributed to source-mutation removal plus byte-stability/AST guards, not pre-commit hook cleanup.
- Cross-tool resume: same-session memory helped execution, but future resume should rely on durable issue/PR artifacts; pre-PR review-state memory is not durable cross-tool evidence.

## Process Gaps Found

None requiring follow-up from this implementation. The broader whitespace attribution posture remains owned by #461.

## Pipeline Metrics

<!-- pipeline-metrics
metrics_version: 3
review_mode: full
stages_run:
  prosecution: true
  defense: true
  judgment: true
prosecution_findings: 4
pass_1_findings: 2
pass_2_findings: 1
pass_3_findings: 1
defense_disproved: 0
judge_accepted: 4
judge_rejected: 0
judge_deferred: 0
ce_gate_result: passed
ce_gate_intent: strong
ce_gate_defects_found: 0
rework_cycles: 1
postfix_triggered: true
postfix_prosecution_findings: 2
postfix_judge_accepted: 2
postfix_judge_rejected: 0
postfix_judge_deferred: 0
postfix_defense_disproved: 0
postfix_rework_cycles: 1
express_lane_count: 0
postfix_passes: 2
batch_dispatch_calls: 2
batch_dispatch_findings: 6
rate_limit_retries: 0
rate_limit_deferred: false
prosecution_depth_light: []
prosecution_depth_skip: []
prosecution_depth_override: false
prosecution_depth_reactivations: 0
findings:
  - id: M-F1
    category: test-safety
    severity: medium
    points: 4
    pass: 1
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: main
  - id: M-F2
    category: test-safety
    severity: medium
    points: 4
    pass: 1
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: main
  - id: M-F3
    category: error-handling
    severity: medium
    points: 3
    pass: 2
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: main
  - id: M-F4
    category: documentation-audit
    severity: low
    points: 1
    pass: 3
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: main
  - id: PF-F1
    category: test-safety
    severity: high
    points: 7
    pass: 1
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: postfix
  - id: PF-F2
    category: path-handling
    severity: medium
    points: 4
    pass: 2
    defense_verdict: conceded
    judge_ruling: finding-sustained
    judge_confidence: high
    systemic_fix_type: none
    review_stage: postfix
-->

Closes #402
