### PR TITLE
test: CE Gate S2 release-hygiene credit verification (99.99.1) — issue #441

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.8.1"
+    "version": "99.99.1"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 14 specialized agents and a shared skill library.",
-      "version": "2.8.1",
+      "version": "99.99.1",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.8.1",
+  "version": "99.99.1",
   "description": "Multi-agent workflow system for Claude Code. Pipeline-based agent orchestration: Issue → Design → Plan → Implement → Review → PR.",
   "author": {
     "name": "Grimblaz"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "Multi-agent workflow system for GitHub Copilot",
-    "version": "2.8.1"
+    "version": "99.99.1"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "Multi-agent workflow system for GitHub Copilot with 14 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.8.1"
+      "version": "99.99.1"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Orchestra
 
-[![Version](https://img.shields.io/badge/version-v2.8.1-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v99.99.1-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development across specialized agents in GitHub Copilot and Claude Code.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "Multi-agent workflow system for GitHub Copilot. Pipeline-based agent orchestration: Issue → Design → Plan → Implement → Review → PR.",
-  "version": "2.8.1",
+  "version": "99.99.1",
   "author": {
     "name": "Grimblaz"
   },


### PR DESCRIPTION
## Summary

CE Gate S2 test PR — contrived version bump to 99.99.1 for issue #441 release-hygiene credit verification. **Do not merge — close when CE Gate verification is complete.**

⚠️ `99.99.x` is a reserved test namespace. This version is never shipped.

<!-- pipeline-metrics
metrics_version: 4
frame_version: 1
credits:
  - port: release-hygiene
    adapter: symmetric-bump
    status: passed
    run_index: 1
    evidence: "all manifests at 99.99.1"
    version-bump:
      from: "2.8.1"
      to: "99.99.1"
    symmetric-bump-verification:
      status: passed
      files-checked: ["plugin.json", ".claude-plugin/plugin.json", ".claude-plugin/marketplace.json", ".github/plugin/marketplace.json", "README.md"]
-->

## Summary by Sourcery

Bump the project version to 99.99.1 across manifests and documentation for release-hygiene credit verification in the CE Gate S2 pipeline.

Enhancements:
- Update all plugin manifest files to use the test version 99.99.1 instead of 2.8.1.
- Refresh the README version badge to reflect the 99.99.1 test release.