### PR TITLE
feat(#524): add terminal-stall guardrails for multiline prompts and diagnostic wrappers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.12.0"
+    "version": "2.12.1"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 14 specialized agents and a shared skill library.",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "Multi-agent workflow system for GitHub Copilot",
-    "version": "2.12.0"
+    "version": "2.12.1"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "Multi-agent workflow system for GitHub Copilot with 14 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.12.0"
+      "version": "2.12.1"
     }
   ]
 }

--- a/.github/scripts/Tests/terminal-hygiene-guardrails.Tests.ps1
+++ b/.github/scripts/Tests/terminal-hygiene-guardrails.Tests.ps1
@@ -6,8 +6,7 @@
     Contract tests for terminal-hygiene guardrails introduced by issue #524.
 
 .DESCRIPTION
-    RED coverage for issue #524 until the two new sections are written into
-    skills/terminal-hygiene/SKILL.md. Tests use section-scoped extraction so
+    Non-regression contract for the two terminal-hygiene H2 sections added by issue #524 (`## Multiline Continuation-Prompt Hazard`, `## Non-Fatal Diagnostic Wrapper Pattern`) in skills/terminal-hygiene/SKILL.md. Tests use section-scoped extraction so
     that tokens already present in the existing '## Terminal Retry Hygiene'
     section (kill_terminal, fresh terminal) cannot false-GREEN assertions
     intended to target the new '## Multiline Continuation-Prompt Hazard' section.

--- a/.github/scripts/Tests/terminal-hygiene-guardrails.Tests.ps1
+++ b/.github/scripts/Tests/terminal-hygiene-guardrails.Tests.ps1
@@ -1,0 +1,166 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Contract tests for terminal-hygiene guardrails introduced by issue #524.
+
+.DESCRIPTION
+    RED coverage for issue #524 until the two new sections are written into
+    skills/terminal-hygiene/SKILL.md. Tests use section-scoped extraction so
+    that tokens already present in the existing '## Terminal Retry Hygiene'
+    section (kill_terminal, fresh terminal) cannot false-GREEN assertions
+    intended to target the new '## Multiline Continuation-Prompt Hazard' section.
+
+    Assertion coverage (ac-refs: AC1, AC2, AC3, AC4, AC5, AC6, AC7):
+        (a) Both new H2 headings exist in SKILL.md
+        (b) Each new section body is non-empty
+        (c) Non-Fatal Diagnostic Wrapper Pattern section contains required tokens
+        (d) Multiline Continuation-Prompt Hazard section describes kill/fresh-terminal recovery
+        (e) Code-Conductor.agent.md references both new section names verbatim
+        (f) Gotchas section contains the two new operator-vocabulary rows
+        (g) All pre-existing H2 sections remain present
+        (h) terminal-test-hygiene.md has a D12 entry referencing both new sections
+#>
+
+Describe 'terminal hygiene guardrails contract' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:SkillPath     = Join-Path $script:RepoRoot 'skills\terminal-hygiene\SKILL.md'
+        $script:ConductorPath = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
+        $script:DesignDocPath = Join-Path $script:RepoRoot 'Documents\Design\terminal-test-hygiene.md'
+
+        $script:MultilineHeading = '## Multiline Continuation-Prompt Hazard'
+        $script:WrapperHeading   = '## Non-Fatal Diagnostic Wrapper Pattern'
+
+        # Load file content normalized to LF line endings
+        $script:GetContent = {
+            param([string]$Path)
+            (Get-Content -Path $Path -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
+        }
+
+        # Extract the body of a named H2 section.
+        # Returns content from the line after the heading up to the next '## ' heading or EOF.
+        # Uses section-scoped extraction to avoid cross-section false-GREENs.
+        $script:GetH2Section = {
+            param([string]$Content, [string]$Heading)
+            $escaped = [regex]::Escape($Heading)
+            # Match heading line (heading + anything on same line + newline), then capture body
+            $pattern = "(?ms)^$escaped[^\n]*\n(?<body>.*?)(?=^## |\z)"
+            $m = [regex]::Match($Content, $pattern)
+            if (-not $m.Success) { return '' }
+            return $m.Groups['body'].Value
+        }
+
+        # Extract the body of a named ### section from the design doc.
+        # Returns content from the line after the heading up to the next '### ', '## ', or EOF.
+        $script:GetH3Section = {
+            param([string]$Content, [string]$HeadingPrefix)
+            $escaped = [regex]::Escape($HeadingPrefix)
+            $pattern = "(?ms)^$escaped[^\n]*\n(?<body>.*?)(?=^### |^## |\z)"
+            $m = [regex]::Match($Content, $pattern)
+            if (-not $m.Success) { return '' }
+            return $m.Groups['body'].Value
+        }
+
+        # Load all target files
+        $script:SkillContent     = if (Test-Path $script:SkillPath)     { & $script:GetContent -Path $script:SkillPath }     else { '' }
+        $script:ConductorContent = if (Test-Path $script:ConductorPath) { & $script:GetContent -Path $script:ConductorPath } else { '' }
+        $script:DesignContent    = if (Test-Path $script:DesignDocPath)  { & $script:GetContent -Path $script:DesignDocPath }  else { '' }
+    }
+
+    # (a) Both new H2 headings exist in SKILL.md
+    It 'requires both new H2 headings to be present in terminal-hygiene SKILL.md' {
+        $script:SkillContent | Should -Match '(?m)^## Multiline Continuation-Prompt Hazard\s*$' `
+            -Because 'AC1: Multiline Continuation-Prompt Hazard section must be added to SKILL.md'
+        $script:SkillContent | Should -Match '(?m)^## Non-Fatal Diagnostic Wrapper Pattern\s*$' `
+            -Because 'AC2: Non-Fatal Diagnostic Wrapper Pattern section must be added to SKILL.md'
+    }
+
+    # (b) Each new section body is non-empty
+    It 'requires each new section to have a non-empty body' {
+        $multilineBody = & $script:GetH2Section -Content $script:SkillContent -Heading $script:MultilineHeading
+        $wrapperBody   = & $script:GetH2Section -Content $script:SkillContent -Heading $script:WrapperHeading
+
+        $multilineBody.Trim() | Should -Not -BeNullOrEmpty `
+            -Because 'AC1: Multiline Continuation-Prompt Hazard section must contain guidance'
+        $wrapperBody.Trim() | Should -Not -BeNullOrEmpty `
+            -Because 'AC2: Non-Fatal Diagnostic Wrapper Pattern section must contain guidance'
+    }
+
+    # (c) Non-Fatal Diagnostic Wrapper Pattern section contains VALIDATION_STATUS tokens (section-scoped)
+    It 'requires the Non-Fatal Diagnostic Wrapper Pattern section to document VALIDATION_STATUS tokens' {
+        $wrapperBody = & $script:GetH2Section -Content $script:SkillContent -Heading $script:WrapperHeading
+
+        $wrapperBody | Should -Match 'VALIDATION_STATUS=pass' `
+            -Because 'AC3: wrapper pattern must document the VALIDATION_STATUS=pass token'
+        $wrapperBody | Should -Match 'VALIDATION_STATUS=fail' `
+            -Because 'AC3: wrapper pattern must document the VALIDATION_STATUS=fail token'
+        $wrapperBody | Should -Match 'exit 0' `
+            -Because 'AC3: wrapper pattern must specify exit 0 so orchestration continues'
+        $wrapperBody | Should -Match '(?i)non-?zero|retain.*exit' `
+            -Because 'AC3: wrapper pattern must clarify that real validation gates retain non-zero exits'
+    }
+
+    # (d) Multiline Continuation-Prompt Hazard section describes kill/fresh-terminal recovery (section-scoped).
+    # IMPORTANT: kill_terminal and fresh terminal already appear in '## Terminal Retry Hygiene'
+    # (lines 70 and 73 of the current SKILL.md). A flat-file regex would pass RED before s2 runs.
+    # This assertion is scoped to the extracted section body to prevent that false-GREEN.
+    It 'requires the Multiline Continuation-Prompt Hazard section to describe kill_terminal or fresh terminal recovery' {
+        $multilineBody = & $script:GetH2Section -Content $script:SkillContent -Heading $script:MultilineHeading
+
+        $multilineBody | Should -Match '(?i)kill_terminal|fresh terminal|reissue' `
+            -Because 'AC4: multiline hazard section must describe recovery (section-scoped to prevent false-GREEN from existing Terminal Retry Hygiene section)'
+    }
+
+    # (e) Code-Conductor.agent.md references both new section names verbatim
+    It 'requires Code-Conductor.agent.md to reference both new section names' {
+        $script:ConductorContent | Should -Match ([regex]::Escape('Multiline Continuation-Prompt Hazard')) `
+            -Because 'AC5: Code-Conductor must pointer-reference the Multiline Continuation-Prompt Hazard section'
+        $script:ConductorContent | Should -Match ([regex]::Escape('Non-Fatal Diagnostic Wrapper Pattern')) `
+            -Because 'AC5: Code-Conductor must pointer-reference the Non-Fatal Diagnostic Wrapper Pattern section'
+    }
+
+    # (f) Gotchas table contains the two new operator-vocabulary rows (section-scoped)
+    It 'requires the Gotchas section to include both new operator-vocabulary rows' {
+        $gotchasBody = & $script:GetH2Section -Content $script:SkillContent -Heading '## Gotchas'
+
+        $gotchasBody | Should -Match '(?i)silently.{0,60}multi-?line|multi-?line.{0,60}silent' `
+            -Because 'AC6: Gotchas must include a row for the terminal sitting silently after a multi-line command'
+        $gotchasBody | Should -Match '(?i)diagnostic.{0,80}halt|halt.{0,80}diagnostic|causes orchestration to halt' `
+            -Because 'AC6: Gotchas must include a row for a diagnostic check causing orchestration to halt unexpectedly'
+    }
+
+    # (g) All pre-existing H2 sections remain present (non-regression)
+    It 'requires all pre-existing terminal-hygiene H2 sections to remain intact' {
+        $preExistingHeadings = @(
+            '(?m)^## Pester Scope\s*$',
+            '(?m)^## `isBackground` Default\s*$',
+            '(?m)^## No Terminal/Subagent Batching\s*$',
+            '(?m)^## Terminal Cleanup\s*$',
+            '(?m)^## Terminal Retry Hygiene\s*$',
+            '(?m)^## Gotchas\s*$'
+        )
+
+        foreach ($pattern in $preExistingHeadings) {
+            $script:SkillContent | Should -Match $pattern `
+                -Because "non-regression: pre-existing heading matching '$pattern' must remain in SKILL.md"
+        }
+    }
+
+    # (h) terminal-test-hygiene.md contains a D12 entry with non-empty body referencing both new sections
+    It 'requires terminal-test-hygiene.md to record a D12 design entry referencing both new sections' {
+        $script:DesignContent | Should -Match '(?m)^### D12' `
+            -Because 'AC7: design doc must include a D12 entry recording the issue #524 decisions'
+
+        $d12Body = & $script:GetH3Section -Content $script:DesignContent -HeadingPrefix '### D12'
+
+        $d12Body.Trim() | Should -Not -BeNullOrEmpty `
+            -Because 'AC7: D12 entry must have content'
+        $d12Body | Should -Match ([regex]::Escape('Multiline Continuation-Prompt Hazard')) `
+            -Because 'AC7: D12 must reference the Multiline Continuation-Prompt Hazard section by name'
+        $d12Body | Should -Match ([regex]::Escape('Non-Fatal Diagnostic Wrapper Pattern')) `
+            -Because 'AC7: D12 must reference the Non-Fatal Diagnostic Wrapper Pattern section by name'
+    }
+}

--- a/Documents/Design/terminal-test-hygiene.md
+++ b/Documents/Design/terminal-test-hygiene.md
@@ -28,6 +28,9 @@ addressing the within-step retry gap that the Terminal Lifecycle Protocol does n
 | `.github/skills/terminal-hygiene/scripts/check-port-core.ps1` | Port-availability check library — `Invoke-CheckPort` (TD7) |
 | `.github/skills/terminal-hygiene/scripts/check-port.ps1` | Port-check CLI wrapper (TD7) |
 | `.github/scripts/Tests/check-port.Tests.ps1` | Pester tests for check-port (TD7) |
+| `skills/terminal-hygiene/SKILL.md` | `## Multiline Continuation-Prompt Hazard` and `## Non-Fatal Diagnostic Wrapper Pattern` sections (D12) |
+| `agents/Code-Conductor.agent.md` | Pointer extension naming both new sections (D12) |
+| `.github/scripts/Tests/terminal-hygiene-guardrails.Tests.ps1` | Contract tests for both new sections (D12) |
 
 ## Design Decisions
 
@@ -183,6 +186,24 @@ from "not currently in the VS Code deferred tools inventory" to "is a deferred t
 `tool_search_tool_regex`". Forward-compatible: agents try to load the tool and degrade to
 preserve-all when unavailable (version regression or restricted tool surface). The degradation
 behavior specification is preserved.
+
+### D12 — Multiline continuation-prompt hazard and non-fatal diagnostic wrapper (issue #524)
+
+**Status**: working hypothesis — both failure modes are observed in practice but the root-cause list is not exhaustive. Revisit if new stall patterns emerge after rollout.
+
+**Implementation approach**: docs-only. No helper script was added (compare D10's `check-port.ps1` library). Rationale: the continuation-prompt failure occurs inside a blocked shell where a script cannot be invoked anyway; recovery requires a terminal-level operation (`kill_terminal`), not a library call. For the diagnostic-wrapper pattern, docs-only prevents future agents from using `exit 1` by reading the skill — no runtime enforcement is needed because the pattern author is an agent following skill guidance, not an untrusted caller. Adding a `Wrap-Diagnostic.ps1` library would add maintenance overhead and a Script Library Convention surface without providing enforcement benefit.
+
+**`VALIDATION_STATUS` token rationale**: the token is kept despite having no automated consumer. It serves the operator reading the terminal buffer (structured evidence at a glance) and is future-greppable as `^VALIDATION_STATUS=` for an automated parser. Alternatives considered: JSON envelope (too verbose for a one-line status signal), exit-code mirroring (defeats the wrapper's non-zero-exit-suppression purpose), prefixed marker like `[PASS]`/`[FAIL]` (less greppable and harder to parse programmatically).
+
+**`^C` working hypothesis** (per design challenge Cluster C / R6 disposition): sending `^C` as literal text from the agent side in VS Code persistent shells appends to the buffered input rather than interrupting the shell — the interrupt signal cannot be injected directly. This was observed during design investigation but not exhaustively verified across every shell variant. The skill body states this unconditionally; this note records the open uncertainty.
+
+Issue #524 extends `skills/terminal-hygiene/SKILL.md` with two new sections that cover failure modes observed during subagent orchestration.
+
+The **Multiline Continuation-Prompt Hazard** section addresses the case where an agent sends a syntactically incomplete command — unclosed here-strings, parentheses, braces, or backtick continuations in PowerShell; unclosed heredocs, quotes, or backslash continuations in bash — causing the shell to enter a continuation prompt (`>>` in PowerShell, `>` in bash). The terminal appears frozen but is waiting for more input. Recovery requires identifying the unclosed construct (input-shape detection) and, when the buffer is inspectable, confirming the `>>` or `>` marker before using `kill_terminal` on the stalled terminal ID and opening a fresh terminal. Sending `^C` as literal text is not effective from the agent side (see `^C` working hypothesis above). This extends the existing kill-before-retry pattern from `## Terminal Retry Hygiene` to cover the continuation-prompt scenario specifically.
+
+The **Non-Fatal Diagnostic Wrapper Pattern** section addresses the case where a subagent diagnostic check (linting, structural validation, schema inspection) exits non-zero and causes the orchestrator to halt unexpectedly. The pattern requires the wrapper script to emit `VALIDATION_STATUS=pass` or `VALIDATION_STATUS=fail` as any readable line in stdout (last line recommended for unambiguous parsing) and always exit 0, so the orchestrator continues regardless of findings. Real validation gates (Pester, PSScriptAnalyzer, markdownlint) retain their non-zero exits — the pattern is scoped to diagnostic wrappers only.
+
+Both sections are accompanied by new rows in the `## Gotchas` table in the skill file, and `agents/Code-Conductor.agent.md` was updated to reference both section names explicitly. A contract Pester test was added at `.github/scripts/Tests/terminal-hygiene-guardrails.Tests.ps1`.
 
 ## Rejected Alternatives
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Orchestra
 
-[![Version](https://img.shields.io/badge/version-v2.12.0-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v2.12.1-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development across specialized agents in GitHub Copilot and Claude Code.

--- a/agents/Code-Conductor.agent.md
+++ b/agents/Code-Conductor.agent.md
@@ -125,7 +125,7 @@ Quick checklist before declaring mode for a step:
 
 When this user-invocable agent receives a request referencing an existing GitHub issue, load `skills/upstream-onboarding/SKILL.md` and follow its protocol.
 
-For terminal and validation execution guardrails, load `skills/terminal-hygiene/SKILL.md`.
+For terminal and validation execution guardrails, load `skills/terminal-hygiene/SKILL.md` — especially the **Multiline Continuation-Prompt Hazard** and **Non-Fatal Diagnostic Wrapper Pattern** sections when dispatching subagent diagnostics.
 
 ## Core Workflow
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "Multi-agent workflow system for GitHub Copilot. Pipeline-based agent orchestration: Issue → Design → Plan → Implement → Review → PR.",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "author": {
     "name": "Grimblaz"
   },

--- a/skills/terminal-hygiene/SKILL.md
+++ b/skills/terminal-hygiene/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: terminal-hygiene
-description: "Terminal and test execution guardrails for Agent Orchestra workflows. Use when choosing sync versus async terminal mode, scoping Pester runs, retrying background commands, or avoiding terminal and subagent batching mistakes. DO NOT USE FOR: application-level debugging root-cause analysis (use systematic-debugging) or post-merge archival workflow steps (use post-pr-review)."
+description: "Terminal and test execution guardrails for Agent Orchestra workflows. Use when choosing sync versus async terminal mode, scoping Pester runs, retrying background commands, detecting or recovering from multiline-prompt continuation stalls, wrapping subagent diagnostics to avoid non-zero-exit halts, or avoiding terminal and subagent batching mistakes. DO NOT USE FOR: application-level debugging root-cause analysis (use systematic-debugging) or post-merge archival workflow steps (use post-pr-review)."
 ---
 
 # Terminal Hygiene
@@ -79,6 +79,60 @@ Scope notes:
 - Kill-before-retry and Terminal Cleanup are complementary, not substitutes. If both target the same terminal ID, the first successful kill wins and later attempts are harmless no-ops.
 - Both `kill_terminal` failures and `check-port.ps1` errors are non-blocking. Degrade gracefully to retry-without-kill when necessary.
 
+## Multiline Continuation-Prompt Hazard
+
+PowerShell enters a continuation prompt (`>>`) and bash enters a `>` prompt when a command is syntactically incomplete: unclosed here-strings (`@'`/`@"`), parentheses, braces, or backtick line continuations in PowerShell; unclosed heredocs, quotes, or backslash continuations in bash.
+
+**Symptom**: the terminal appears to hang — no output, no PS prompt. The buffer tail shows `>>` or `>` rather than a prompt.
+
+**Agent-side detection**: if the prior command contained an unclosed multiline construct (a here-string, unclosed parenthesis, or continuation backslash) and the terminal returns no new output, presume a continuation prompt rather than a frozen process. When the terminal buffer is inspectable, a trailing `>>` or `>` line with no surrounding command output confirms this.
+
+**Recovery**: do not attempt `^C` — from the agent side, sending literal `"^C"` adds more input to the here-string rather than interrupting the shell. Use `kill_terminal` on the stalled terminal ID, then open a fresh terminal. This extends the existing kill-before-retry pattern from `## Terminal Retry Hygiene`.
+
+**Prevention**: prefer one-line commands. When a multiline construct is genuinely required, write it to a temporary `.ps1` or `.sh` file and invoke the file, rather than passing the block inline to the terminal.
+
+## Non-Fatal Diagnostic Wrapper Pattern
+
+When a subagent needs to run a diagnostic check (linting, structural validation, schema inspection) without risking an orchestration halt on a non-zero exit code, the wrapper script should emit a structured status line as its final stdout output and always exit 0.
+
+**Shape**:
+
+- Readable line: `VALIDATION_STATUS=pass` or `VALIDATION_STATUS=fail` as any line in stdout; emit it last for unambiguous parsing
+- Optional preceding lines: evidence such as diff output, line counts, or error messages
+- Exit code: always `exit 0` so the orchestrator continues regardless of findings
+
+**Worked examples**:
+
+PowerShell:
+
+```powershell
+if ($findings.Count -eq 0) {
+    Write-Output 'VALIDATION_STATUS=pass'
+} else {
+    $findings | ForEach-Object { Write-Output $_ }
+    Write-Output 'VALIDATION_STATUS=fail'
+}
+exit 0
+```
+
+Bash:
+
+```bash
+if [ "$finding_count" -eq 0 ]; then
+  echo 'VALIDATION_STATUS=pass'
+else
+  echo "$error_details"
+  echo 'VALIDATION_STATUS=fail'
+fi
+exit 0
+```
+
+**Scope**: this pattern applies to diagnostic wrappers only. Real validation gates (Pester, PSScriptAnalyzer, markdownlint) retain their non-zero exits — do not apply `exit 0` to gates that must halt on failure. Criterion: if the orchestrator should stop when this tool reports failure, it is a gate; if it should continue and log findings, it is a diagnostic.
+
+**Residual non-zero sources**: existing third-party tools (e.g., `grep -q`) exit non-zero on no-match by design. Wrap calls to such tools explicitly if their exit codes would be misread as failures.
+
+**Consumer**: the `VALIDATION_STATUS` token is readable by the operator in the terminal buffer and future-greppable as `^VALIDATION_STATUS=` in stdout. No automated consumer exists today — the value is operator-facing structured evidence at a glance.
+
 ## Gotchas
 
 | Trigger                                               | Gotcha                                                                          | Fix                                                                            |
@@ -88,3 +142,11 @@ Scope notes:
 | Trigger                                                         | Gotcha                                                             | Fix                                                                                                |
 | --------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
 | Retrying a failed async server without killing the old terminal | The old shell or port can stay alive and make the retry look flaky | Kill the prior terminal ID first, check the port for dev servers, then restart in a fresh terminal |
+
+| Trigger                                                          | Gotcha                                                                                        | Fix                                                                                                            |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Terminal sits silently after a multi-line command                | The shell entered a continuation prompt (`>>` or `>`); the terminal is not frozen             | Intervene immediately — the shell waits indefinitely; use `kill_terminal` and open a fresh terminal — do not send `^C` |
+
+| Trigger                                                          | Gotcha                                                                                        | Fix                                                                                                            |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Subagent diagnostic check causes orchestration to halt unexpectedly | The diagnostic script exited non-zero and the orchestrator treated it as a blocking failure | Wrap the diagnostic in the Non-Fatal Diagnostic Wrapper Pattern: emit `VALIDATION_STATUS=pass/fail`, exit 0    |

--- a/skills/terminal-hygiene/SKILL.md
+++ b/skills/terminal-hygiene/SKILL.md
@@ -145,7 +145,7 @@ exit 0
 
 | Trigger                                                          | Gotcha                                                                                        | Fix                                                                                                            |
 | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| Terminal sits silently after a multi-line command                | The shell entered a continuation prompt (`>>` or `>`); the terminal is not frozen             | Intervene immediately — the shell waits indefinitely; use `kill_terminal` and open a fresh terminal — do not send `^C` |
+| Terminal sits silently after a multiline command                | The shell entered a continuation prompt (`>>` or `>`); the terminal is not frozen             | Intervene immediately — the shell waits indefinitely; use `kill_terminal` and open a fresh terminal — do not send `^C` |
 
 | Trigger                                                          | Gotcha                                                                                        | Fix                                                                                                            |
 | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

- Adds `## Multiline Continuation-Prompt Hazard` section to `skills/terminal-hygiene/SKILL.md` with input-shape detection, `kill_terminal` + fresh-terminal recovery (not `^C`), and temp-file prevention rule
- Adds `## Non-Fatal Diagnostic Wrapper Pattern` section with `VALIDATION_STATUS=pass/fail` + `exit 0` shape, PowerShell + bash worked examples, and a gate-vs-diagnostic criterion
- Extends `agents/Code-Conductor.agent.md` pointer to name both new sections
- Adds contract Pester test (8 section-scoped assertions, AC1–AC7) as `terminal-hygiene-guardrails.Tests.ps1`
- Appends `### D12` to `Documents/Design/terminal-test-hygiene.md` with working-hypothesis status, docs-only rationale, VALIDATION_STATUS token rationale, and Cluster C cross-reference
- Bumps plugin version `2.12.0` → `2.12.1` across all 5 manifest files

## Test plan

- [x] Targeted Pester: `Invoke-Pester '.github/scripts/Tests/terminal-hygiene-guardrails.Tests.ps1' -Output Minimal` → 8/8 pass
- [x] Full suite: 1682 passed, 4 failed (all pre-existing: customer-experience composite line-cap, conductor-body-size, session-startup-wording, aggregate-review-scores fixture staleness), 1 skipped
- [x] Version bump verified: `bump-version.ps1` ran atomically; all 5 manifest files at `2.12.1`
- [x] Adversarial review: 3 prosecution passes → defense → judge; verdict SHIP (confidence HIGH); 19/20 findings defense-sustained, 1 split (M5 `kill_terminal` vocabulary — non-blocking, follow-up recommended)

Closes #524

<!-- pipeline-metrics
issue: 524
pr: 530
head: d37bf620153030c3a1264d9bd4bc2e70cf82afce
branch: feature/issue-524-terminal-stall-guardrails
credits:
  - port: experience
    adapter: work-adapter
    evidence: "issue #524; experience-owner-complete-524 marker posted"
  - port: design
    adapter: work-adapter
    evidence: "issue #524; design-phase-complete-524 marker posted"
  - port: plan
    adapter: work-adapter
    evidence: "issue #524; plan-issue-524 marker posted"
  - port: implement-test
    adapter: work-adapter
    evidence: "issue #524 s1: terminal-hygiene-guardrails.Tests.ps1 authored RED then GREEN"
  - port: implement-docs
    adapter: work-adapter
    cycle: 1
    evidence: "issue #524 s2: skills/terminal-hygiene/SKILL.md + agents/Code-Conductor.agent.md"
  - port: implement-docs
    adapter: work-adapter
    cycle: 2
    terminal: true
    evidence: "issue #524 s3: Documents/Design/terminal-test-hygiene.md D12 entry"
  - port: release-hygiene
    adapter: work-adapter
    evidence: "issue #524 s2: plugin version bumped 2.12.0->2.12.1 via bump-version.ps1"
  - port: review
    adapter: work-adapter
    evidence: "issue #524 s4: 3-pass prosecution → defense → judge; SHIP HIGH confidence"
  - port: implement-code
    adapter: auto-na-adapter
    evidence: "docs-only change; no production code added"
  - port: implement-refactor
    adapter: auto-na-adapter
    evidence: "docs-only change; no refactoring"
  - port: ce-gate-api
    adapter: auto-na-adapter
    evidence: "ce_gate: false; internal methodology docs only"
  - port: ce-gate-browser
    adapter: auto-na-adapter
    evidence: "ce_gate: false; internal methodology docs only"
  - port: ce-gate-canvas
    adapter: auto-na-adapter
    evidence: "ce_gate: false; internal methodology docs only"
  - port: ce-gate-cli
    adapter: auto-na-adapter
    evidence: "ce_gate: false; internal methodology docs only"
  - port: process-review
    adapter: auto-na-adapter
    evidence: "ce_gate: false; no CE Gate defects; process-review trigger not met"
  - port: post-pr
    adapter: auto-na-adapter
    evidence: "post-pr deferred until after merge"
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)