### PR TITLE
feat(#574): cognitive-surrender-prevention v0 — solution-authoring skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.15.0"
+    "version": "2.16.0"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-      "version": "2.15.0",
+      "version": "2.16.0",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "Multi-agent workflow system for GitHub Copilot",
-    "version": "2.15.0"
+    "version": "2.16.0"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "Multi-agent workflow system for GitHub Copilot with 16 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.15.0"
+      "version": "2.16.0"
     }
   ]
 }

--- a/.github/scripts/Tests/solution-authoring.Tests.ps1
+++ b/.github/scripts/Tests/solution-authoring.Tests.ps1
@@ -1,0 +1,235 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#!
+.SYNOPSIS
+    Contract tests for the solution-authoring skill body and structural assertions.
+
+.DESCRIPTION
+    Locks issue #574: the solution-authoring skill body codifies the 7 D-X decisions
+    with the correct shape (5 rule + 5 template sections, no provides:, decision-brief
+    terminology, forward-compat note preserving teaching_paragraph_excerpt, and
+    recommendation-shift token present).
+#>
+
+Describe 'solution-authoring SKILL body' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:SkillPath = Join-Path $script:RepoRoot 'skills\solution-authoring\SKILL.md'
+        $script:Content = (Get-Content -Path $script:SkillPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
+    }
+
+    It 'AC11.a — file exists' {
+        $script:SkillPath | Should -Exist
+    }
+
+    It 'AC11.a — frontmatter present (file starts with YAML front matter block)' {
+        $script:Content | Should -Match '(?s)^---\n'
+    }
+
+    It 'AC11.a — does not declare provides:' {
+        $script:Content | Should -Not -Match '(?m)^provides:'
+    }
+
+    It 'AC11.a — body is at or under 200 lines' {
+        $lineCount = ($script:Content -split "`n").Count
+        $lineCount | Should -BeLessOrEqual 200 -Because 'body must stay under the 200-line cap'
+    }
+
+    It 'AC11.a — contains exactly 5 ### Rule: sections' {
+        $ruleMatches = [regex]::Matches($script:Content, '(?m)^### Rule:')
+        $ruleMatches.Count | Should -Be 5 -Because 'body must have exactly 5 rule sections'
+    }
+
+    It 'AC11.a — contains exactly 5 ### Template: sections' {
+        $templateMatches = [regex]::Matches($script:Content, '(?m)^### Template:')
+        $templateMatches.Count | Should -Be 5 -Because 'body must have exactly 5 template sections'
+    }
+
+    It 'AC11.a — each Template section contains an exemplar marker' {
+        $templateSections = $script:Content -split '(?m)^### Template:' | Select-Object -Skip 1
+        $templateSections.Count | Should -Be 5 -Because 'there must be 5 template sections to check'
+        foreach ($section in $templateSections) {
+            $section | Should -Match '\*\*Exemplar\*\*' -Because 'each template section must contain an **Exemplar** marker'
+        }
+    }
+
+    It 'AC11.e — literal **Recommendation shift** token present in body' {
+        $script:Content | Should -Match '\*\*Recommendation shift\*\*' -Because 'recommendation-shift template must contain the literal token'
+    }
+
+    It 'AC11.e — v0 do-not-apply comment present on same-decision-resume skip rule' {
+        $script:Content | Should -Match '<!-- v0: do not apply; see #575 for marker-driven activation -->' -Because 'same-decision-resume must be gated with v0 comment'
+    }
+
+    It 'AC11.g — no bare "teaching paragraph" (case-insensitive) outside forward-compat allowlist' {
+        # Allowlist: forward-compat glossary line referencing teaching_paragraph_excerpt, and Exemplar blocks.
+        # Split by the allowlist anchor and check that "teaching paragraph" does not appear in non-allowlist content.
+        $allowlistAnchor = 'teaching_paragraph_excerpt'
+        $lines = $script:Content -split "`n"
+        $violations = $lines | Where-Object {
+            $_ -imatch 'teaching paragraph' -and $_ -notmatch [regex]::Escape($allowlistAnchor)
+        }
+        $violations | Should -BeNullOrEmpty -Because 'teaching paragraph terminology must be limited to the forward-compat glossary allowlist; prose must use decision brief instead'
+    }
+}
+
+Describe 'solution-authoring platforms parity' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:ClaudePath  = Join-Path $script:RepoRoot 'skills\solution-authoring\platforms\claude.md'
+        $script:CopilotPath = Join-Path $script:RepoRoot 'skills\solution-authoring\platforms\copilot.md'
+
+        $script:GetH2Headings = {
+            param([string]$Content)
+            [regex]::Matches($Content, '(?m)^## (.+)$') | ForEach-Object { $_.Groups[1].Value.Trim() }
+        }
+
+        $script:ClaudeContent  = (Get-Content -Path $script:ClaudePath  -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
+        $script:CopilotContent = (Get-Content -Path $script:CopilotPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
+    }
+
+    It 'AC11.b — claude.md exists' {
+        $script:ClaudePath | Should -Exist
+    }
+
+    It 'AC11.b — copilot.md exists' {
+        $script:CopilotPath | Should -Exist
+    }
+
+    It 'AC11.b — both platform files have identical H2 section names' {
+        $claudeH2s  = & $script:GetH2Headings -Content $script:ClaudeContent
+        $copilotH2s = & $script:GetH2Headings -Content $script:CopilotContent
+        $claudeH2s  | Should -Not -BeNullOrEmpty -Because 'claude.md must have at least one H2 section'
+        $copilotH2s | Should -Not -BeNullOrEmpty -Because 'copilot.md must have at least one H2 section'
+        $diff = Compare-Object $claudeH2s $copilotH2s
+        $diff | Should -BeNullOrEmpty -Because 'both platform files must have identical H2 section names (parity requirement AC9)'
+    }
+}
+
+Describe '4-body load directive' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+
+        $script:AgentFiles = @(
+            'agents\Experience-Owner.agent.md',
+            'agents\Solution-Designer.agent.md',
+            'agents\Issue-Planner.agent.md',
+            'agents\Code-Conductor.agent.md'
+        ) | ForEach-Object {
+            $fullPath = Join-Path $script:RepoRoot $_
+            $content = (Get-Content -Path $fullPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
+            [pscustomobject]@{
+                Name    = $_
+                Content = $content
+                Lines   = $content -split "`n"
+            }
+        }
+
+        $script:NewDirectiveSubstring = 'Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question'
+        $script:OldFormPrefix = 'When this user-invocable agent receives a request referencing an existing GitHub issue, load `skills/upstream-onboarding/SKILL.md`'
+    }
+
+    It 'AC11.c — new directive substring present exactly once per body' {
+        foreach ($body in $script:AgentFiles) {
+            $count = [regex]::Matches($body.Content, [regex]::Escape($script:NewDirectiveSubstring)).Count
+            $count | Should -Be 1 -Because "$($body.Name) must contain the new directive substring exactly once"
+        }
+    }
+
+    It 'AC11.c — old standalone upstream-onboarding load line absent from all 4 bodies' {
+        foreach ($body in $script:AgentFiles) {
+            $body.Content | Should -Not -Match ([regex]::Escape($script:OldFormPrefix)) -Because "$($body.Name) must not retain the old-form standalone load line"
+        }
+    }
+
+    It 'AC11.c — new directive line-index precedes any subsequent skill-load reference in each body' {
+        foreach ($body in $script:AgentFiles) {
+            $lines = $body.Lines
+            $directiveIdx = -1
+
+            for ($i = 0; $i -lt $lines.Count; $i++) {
+                if ($lines[$i] -match [regex]::Escape($script:NewDirectiveSubstring)) {
+                    $directiveIdx = $i
+                    break
+                }
+            }
+
+            $directiveIdx | Should -BeGreaterOrEqual 0 -Because "$($body.Name) must contain the new directive"
+
+            $nextSkillLoadIdx = [int]::MaxValue
+            for ($i = $directiveIdx + 1; $i -lt $lines.Count; $i++) {
+                if ($lines[$i] -imatch 'load.*`skills/') {
+                    $nextSkillLoadIdx = $i
+                    break
+                }
+            }
+
+            if ($nextSkillLoadIdx -ne [int]::MaxValue) {
+                $directiveIdx | Should -BeLessThan $nextSkillLoadIdx -Because "$($body.Name): new directive (line $directiveIdx) must precede next skill-load reference (line $nextSkillLoadIdx)"
+            }
+        }
+    }
+
+    It 'AC11.c — Code-Conductor body explicitly enumerates scope-classification and D9-checkpoint touchpoints' {
+        $cc = $script:AgentFiles | Where-Object { $_.Name -like '*Code-Conductor*' }
+        $cc.Content | Should -Match 'scope-classification' -Because 'Code-Conductor must enumerate scope-classification as a content-authoring touchpoint near the directive'
+        $cc.Content | Should -Match 'D9-checkpoint' -Because 'Code-Conductor must enumerate D9-checkpoint as a content-authoring touchpoint near the directive'
+    }
+}
+
+Describe 'upstream-onboarding sweep' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:UOPath    = Join-Path $script:RepoRoot 'skills\upstream-onboarding\SKILL.md'
+        $script:UOContent = (Get-Content -Path $script:UOPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
+    }
+
+    It 'AC11.d — anchor d-load-order-resolution-anchor present' {
+        $script:UOContent | Should -Match '<!-- d-load-order-resolution-anchor -->' -Because 'anchor must be placed near ## When to Use per AC10'
+    }
+
+    It 'AC11.d — frontmatter description field does not contain first load-order claim' {
+        $frontmatter = [regex]::Match($script:UOContent, '(?s)^---\n(.+?)\n---').Groups[1].Value
+        $frontmatter | Should -Not -Match '\bfirst\b' -Because 'description field must not claim load-first ordering'
+    }
+
+    It 'AC11.d — ## When to Use section does not contain first load-order claim' {
+        $section = [regex]::Match($script:UOContent, '(?s)## When to Use\n(.+?)(?=\n## )').Groups[1].Value
+        $section | Should -Not -Match '\bfirst\b' -Because '## When to Use must not claim load-first ordering'
+    }
+
+    It 'AC11.d — ### Sequencing subsection does not contain first load-order claim' {
+        $section = [regex]::Match($script:UOContent, '(?s)### Sequencing\n(.+?)(?=\n### |\n## )').Groups[1].Value
+        $section | Should -Not -Match '\bfirst\b' -Because '### Sequencing must not claim runs-first ordering'
+    }
+
+    It 'AC11.d — removal-step completeness: any remaining first is in the Gotchas allowlist' {
+        $violations = ($script:UOContent -split "`n") | Where-Object {
+            $_ -imatch '\bfirst\b' -and $_ -notmatch 'completion marker first'
+        }
+        $violations | Should -BeNullOrEmpty -Because 'any remaining "first" outside the Gotchas allowlist is a violation'
+    }
+}
+
+Describe 'frame-architecture stacking note' {
+
+    BeforeAll {
+        $script:RepoRoot  = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:FAPath    = Join-Path $script:RepoRoot 'Documents\Design\frame-architecture.md'
+        $script:FAContent = (Get-Content -Path $script:FAPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
+    }
+
+    It 'AC11.f — stacking-precedent paragraph present in frame-architecture.md Adapter Model section' {
+        $script:FAContent | Should -Match "Two ``provides:``-less supporting methodologies can stack" -Because 'Adapter Model section must document the solution-authoring + upstream-onboarding stacking precedent'
+    }
+
+    It 'AC11.f — stacking paragraph names both solution-authoring and upstream-onboarding' {
+        $script:FAContent | Should -Match 'solution-authoring' -Because 'stacking paragraph must name solution-authoring'
+        $script:FAContent | Should -Match 'upstream-onboarding' -Because 'stacking paragraph must name upstream-onboarding'
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to agent-orchestra will be documented in this file.
+
+## [2.16.0] — 2026-05-19
+
+### Added
+
+- **`skills/solution-authoring/SKILL.md`** — new cognitive-surrender-prevention v0 engagement skill. Codifies the D-classification-test (3-leg gate with artifact-citation falsifier), decision brief structure, override semantics, skip rules (including engineer-declined-engagement and same-decision-resume stub for #575), thin-articulation criterion with forward-compatible YAML schema, and 5 template sections each with a canonical exemplar from the #571 R1+R2 transcript. Declares no `provides:` field — supporting methodology, not a frame port adapter.
+- **`skills/solution-authoring/platforms/claude.md`** and **`skills/solution-authoring/platforms/copilot.md`** — platform-specific AskUserQuestion / vscode/askQuestions invocation notes.
+- **`Documents/Design/frame-architecture.md`** — stacking-precedent paragraph in the Adapter Model / Declaration asymmetry section documenting that `solution-authoring` and `upstream-onboarding` can stack as `provides:`-less supporting methodologies with load-order declared in the agent body dispatcher.
+- **`.github/scripts/Tests/solution-authoring.Tests.ps1`** — structural Pester contract covering AC11.a–AC11.g: body shape (5 rule + 5 template sections), platforms parity, 4-body directive (new present, old absent, line-index ordering, CC touchpoint enumeration), upstream-onboarding sweep (no "first" in 3 anchors + allowlist gate), recommendation-shift token, v0 gate comment, terminology drift guard.
+
+### Changed
+
+- **`agents/Experience-Owner.agent.md`**, **`agents/Solution-Designer.agent.md`**, **`agents/Issue-Planner.agent.md`**, **`agents/Code-Conductor.agent.md`** — `## Process` section standalone upstream-onboarding load line replaced with two-sentence solution-authoring-first directive plus cross-session disclaimer (tracked in #575). Code-Conductor additionally enumerates `scope-classification` and `D9-checkpoint` as content-authoring touchpoints.
+- **`skills/upstream-onboarding/SKILL.md`** — removed "first" load-order claim at three section-anchors (frontmatter description, ## When to Use opener, ### Sequencing bullet). Added `<!-- d-load-order-resolution-anchor -->` near ## When to Use. The skill no longer asserts it must be loaded first; that ordering is declared in each agent body dispatcher.

--- a/Documents/Design/frame-architecture.md
+++ b/Documents/Design/frame-architecture.md
@@ -250,6 +250,8 @@ The first shipped validator slice is intentionally symmetry-only plus predicate 
 
 Port-filling skills and agents declare `provides:`. Supporting skills loaded only as methodology do not. Use the credit-author/output test: if the skill or agent produces the terminal output that becomes the credit for a port, it declares `provides:`; if it only supplies reusable guidance to another adapter, such as `session-memory-contract`, `routing-tables`, or `subagent-env-handshake`, it stays declaration-free.
 
+Two `provides:`-less supporting methodologies can stack when their load-order relationship is non-trivial. `solution-authoring` and `upstream-onboarding` are the canonical example: both are declaration-free, but their load order is explicit — `solution-authoring` fires first to classify decisions before `upstream-onboarding` surfaces inherited context. That ordering is declared in the agent body dispatcher, not in either skill, preserving skill independence while keeping the stacking contract auditable.
+
 ### Three adapter types per port
 
 | Type | Count per port | Purpose |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Orchestra
 
-[![Version](https://img.shields.io/badge/version-v2.15.0-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v2.16.0-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development across specialized agents in GitHub Copilot and Claude Code.

--- a/agents/Code-Conductor.agent.md
+++ b/agents/Code-Conductor.agent.md
@@ -123,7 +123,9 @@ Quick checklist before declaring mode for a step:
 
 ## Process
 
-When this user-invocable agent receives a request referencing an existing GitHub issue, load `skills/upstream-onboarding/SKILL.md` and follow its protocol.
+Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575.)
+
+Content-authoring touchpoints where the solution-authoring classification gate applies in this agent: scope-classification and D9-checkpoint.
 
 For terminal and validation execution guardrails, load `skills/terminal-hygiene/SKILL.md` — especially the **Multiline Continuation-Prompt Hazard** and **Non-Fatal Diagnostic Wrapper Pattern** sections when dispatching subagent diagnostics.
 

--- a/agents/Code-Conductor.agent.md
+++ b/agents/Code-Conductor.agent.md
@@ -123,9 +123,9 @@ Quick checklist before declaring mode for a step:
 
 ## Process
 
-Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575.)
+Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575. The classification gate applies only once a target artifact is established — on greenfield invocations, defer until an issue is created.)
 
-Content-authoring touchpoints where the solution-authoring classification gate applies in this agent: scope-classification and D9-checkpoint.
+Content-authoring touchpoints where the solution-authoring classification gate applies in this agent: scope-classification and D9-checkpoint. These qualify under the gate-scope ambiguity tiebreaker ("When the boundary is ambiguous, default to intercepting") because scope-classification shapes the plan-issue scope section content and D9-checkpoint shapes the checkpoint marker payload — both produce durable, authored artifacts. The articulation prompt for these touchpoints fires at D9-checkpoint completion, when the agent hands off to implementation.
 
 For terminal and validation execution guardrails, load `skills/terminal-hygiene/SKILL.md` — especially the **Multiline Continuation-Prompt Hazard** and **Non-Fatal Diagnostic Wrapper Pattern** sections when dispatching subagent diagnostics.
 

--- a/agents/Experience-Owner.agent.md
+++ b/agents/Experience-Owner.agent.md
@@ -64,7 +64,7 @@ Customer experience bookend — upstream framing before technical design begins,
 
 ## Process
 
-Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575.)
+Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575. The classification gate applies only once a target artifact is established — on greenfield invocations, defer until an issue is created.)
 
 ## GitHub Setup
 

--- a/agents/Experience-Owner.agent.md
+++ b/agents/Experience-Owner.agent.md
@@ -64,7 +64,7 @@ Customer experience bookend — upstream framing before technical design begins,
 
 ## Process
 
-When this user-invocable agent receives a request referencing an existing GitHub issue, load `skills/upstream-onboarding/SKILL.md` and follow its protocol.
+Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575.)
 
 ## GitHub Setup
 

--- a/agents/Issue-Planner.agent.md
+++ b/agents/Issue-Planner.agent.md
@@ -47,7 +47,7 @@ You are a meticulous strategist who leaves nothing to chance. Every step in your
 
 ## Process
 
-Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575.)
+Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575. The classification gate applies only once a target artifact is established — on greenfield invocations, defer until an issue is created.)
 
 Cycle through the phases below iteratively based on user input.
 

--- a/agents/Issue-Planner.agent.md
+++ b/agents/Issue-Planner.agent.md
@@ -47,7 +47,7 @@ You are a meticulous strategist who leaves nothing to chance. Every step in your
 
 ## Process
 
-When this user-invocable agent receives a request referencing an existing GitHub issue, load `skills/upstream-onboarding/SKILL.md` and follow its protocol.
+Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575.)
 
 Cycle through the phases below iteratively based on user input.
 

--- a/agents/Solution-Designer.agent.md
+++ b/agents/Solution-Designer.agent.md
@@ -61,7 +61,7 @@ High-level design thinking — "what are we building and why?" Operates at conce
 
 ## Process
 
-Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575.)
+Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575. The classification gate applies only once a target artifact is established — on greenfield invocations, defer until an issue is created.)
 
 ## Stage 1: GitHub Setup
 

--- a/agents/Solution-Designer.agent.md
+++ b/agents/Solution-Designer.agent.md
@@ -61,7 +61,7 @@ High-level design thinking — "what are we building and why?" Operates at conce
 
 ## Process
 
-When this user-invocable agent receives a request referencing an existing GitHub issue, load `skills/upstream-onboarding/SKILL.md` and follow its protocol.
+Load `skills/solution-authoring/SKILL.md` first and follow its protocol before any subsequent skill fires a structured question. Then load `skills/upstream-onboarding/SKILL.md` and follow its protocol. (Note: cross-session resume preserves no engagement state in this release; structured questions on settled decisions may re-fire when resuming in a new session — tracked in #575.)
 
 ## Stage 1: GitHub Setup
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "Multi-agent workflow system for GitHub Copilot. Pipeline-based agent orchestration: Issue → Design → Plan → Implement → Review → PR.",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "author": {
     "name": "Grimblaz"
   },

--- a/skills/solution-authoring/SKILL.md
+++ b/skills/solution-authoring/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: solution-authoring
+description: "Reusable engagement-gate methodology for content-authoring structured questions in upstream phases. Use when classifying a decision as load-bearing or routine, authoring a decision brief, handling an override or decline, capturing articulation, or evaluating skip rules. DO NOT USE FOR: GitHub setup, completion-marker ownership, or adversarial review pipeline orchestration."
+---
+
+<!-- markdownlint-disable-file MD041 MD003 -->
+
+# Solution Authoring
+
+Reusable methodology for preventing cognitive surrender during upstream phases. Fires before any content-authoring structured question to classify the decision, render a decision brief when warranted, handle overrides, and capture articulation at phase exit.
+
+## When to Use
+
+- When a structured question's answer shapes content the agent will author into a durable artifact (issue body, plan comment, AC slice, marker payload, source/test/config file)
+- When classifying a decision as load-bearing or routine before firing a structured question
+- When rendering a decision brief and teaching before asking
+- When handling an engineer override or decline without argument
+- When capturing articulation at phase exit
+
+## When Not to Use (D-gate-scope)
+
+The classification gate does NOT intercept structured questions that approve or reject an operation the agent is about to take (dedup approval, branch creation, file deletion), clarify factual state, or dispatch agent-to-agent prosecution or research. When the boundary is ambiguous, **default to intercepting** — false positives add audit_rationale text; false negatives miss load-bearing engagement.
+
+### Rule: Classification gate
+
+A decision is load-bearing iff ALL THREE legs pass:
+
+1. **Reversibility** — if wrong, requires rework to a published artifact.
+2. **Non-inheritance with artifact-citation falsifier** — the agent MUST attempt to cite a specific inherited artifact (umbrella comment, prior phase marker, named-decision row, settled methodology rule) that would have answered the decision. The citation is recorded verbatim in `audit_rationale`. If a plausible citation exists, the leg **fails** and the decision is routine. Only documented inability to cite — after a genuine attempt — establishes non-inheritable status.
+3. **Audit-plausibility** — the agent can write a substantive `audit_rationale` sentence.
+
+Failing any one leg collapses to routine. For load-bearing decisions, render the `audit_rationale` as **one sentence immediately above the decision brief** so the engineer can challenge the classification in-band.
+
+### Rule: Decision brief structure
+
+A decision brief has three sentences: (1) **Concrete element** — names the specific artifact, section, or mechanism where the decision lands; (2) **Decision setup** — frames the choice in outcome terms, not implementation jargon; (3) **Conditional misconception** — names the plausible wrong path and its failure mode. The brief precedes the structured question. Teach before asking.
+
+### Rule: Override semantics
+
+Every structured question on a load-bearing decision includes a `Decline engagement — proceed without classification` option (literally so labeled). The engineer's selection of that option (or a free-text response starting with `decline:`) terminates engagement without argument. If the engineer selects a non-recommended option, the agent acknowledges and proceeds without re-asking, persuading, or qualifying.
+
+### Rule: Skip rules
+
+- **gate-fails**: The classification gate returns routine. No structured question fires. Skip is automatic.
+- **engineer-declined-engagement**: The engineer selects `Decline engagement — proceed without classification` or writes `decline:` free-text. Skip immediately; capture decline verbatim.
+- **same-decision-resume**: <!-- v0: do not apply; see #575 for marker-driven activation --> When the engagement-record marker contract ships (#575), this rule suppresses re-firing on a decision already locked in a prior session.
+
+### Rule: Thin-articulation criterion
+
+Articulation is substantive iff it contains: (1) the choice the engineer made, (2) what would have been wrong about a leading alternative, (3) the reasoning bridge between them. The agent renders the prompt and captures raw text; the agent does NOT grade articulation quality against the criterion in-flight (D-falsifiability protected). CE Gate evaluators apply the criterion independently.
+
+Forward-compatible capture format:
+
+```yaml
+articulation_captures:
+  - decision_id: <id>
+    articulation_text: |
+      <verbatim engineer text>
+    capture_phase: experience | design | plan
+    capture_session: manual-ce-gate-v0
+```
+
+**Glossary and forward-compat note**: The YAML field `teaching_paragraph_excerpt` is preserved from the locked #571 engagement-record marker payload (`<!-- engagement-record-design-571 -->`). This skill uses "decision brief" in prose; #575 owns harmonizing the YAML field name. Until #575 ships, `teaching_paragraph_excerpt` and "decision brief" refer to the same concept and both remain valid.
+
+### Template: Decision brief
+
+Render as a block-quoted paragraph immediately after the `audit_rationale` sentence:
+
+> **Decision brief — {decision_id}**: {Concrete element sentence.} {Decision setup sentence in outcome terms.} {Conditional misconception sentence naming the plausible wrong path and its failure mode.}
+
+**Exemplar** (D-load-directive, from #571 R1+R2):
+
+*Audit rationale: The load-order direction for solution-authoring vs upstream-onboarding is not settled in any prior phase comment or umbrella decision — no named-decision row pins this ordering, so the non-inheritance leg holds.*
+
+> **Decision brief — D-load-directive**: The `## Process` section of each agent body is where load-order instructions land. The decision is whether solution-authoring fires before upstream-onboarding or after — this determines whether the engagement gate runs before the brief surfaces inherited decisions. If upstream-onboarding fired first, the gate would intercept questions about content the engineer just read from someone else's output — manufacturing load-bearing signal on settled content.
+
+### Template: AskUserQuestion shape
+
+Present options with strong examples for ALL options — not just the recommended one. Option presentation asymmetry is itself a form of cognitive surrender (the engineer cannot compare without examples).
+
+Include `Decline engagement — proceed without classification` as the last option on every load-bearing question.
+
+**Exemplar** (D-load-directive, from #571 R1+R2):
+
+- **Option 1 (Recommended)** — solution-authoring first: Classification runs before the brief surfaces prior decisions. Example: during `/design`, the inheritance audit evaluates the decision before any prior-phase context is rendered, so the falsifier operates on genuinely unanchored decisions only.
+- **Option 2** — upstream-onboarding first: The brief surfaces inherited decisions first, then solution-authoring fires. Example: the engineer sees inherited answers before being asked to classify them — but the gate would then intercept settled content and produce false load-bearing signal.
+- **Decline engagement — proceed without classification**
+
+### Template: Free-text option treatment
+
+When the engineer overrides via free-text or selects a non-recommended option: (1) accept without argument or re-asking; (2) if the choice materially differs from the recommended option, emit a `**Recommendation shift**` line; (3) proceed with the chosen direction.
+
+**Exemplar** (S1-negative correction, from #571 R1+R2 — engineer pushes back on mis-classification):
+
+Engineer: "Gap-visibility was already answered in the umbrella."
+Agent re-audits, finds citation in #571 D-customer section, reclassifies, and emits:
+
+`**Recommendation shift** — D-gap-visibility: previously load-bearing (non-inheritance claimed); now routine (citation found in #571 D-customer); trigger: classification-re-audit; reason: the decision was answerable from inherited content and the artifact-citation falsifier applies.`
+
+### Template: Recommendation shift
+
+Emit immediately before the revised recommendation:
+
+> `**Recommendation shift** — {decision_id}: previously {old_recommendation}; now {new_recommendation}; trigger: {engineer-pushback | new-evidence | classification-re-audit}; reason: {one-sentence reason}.`
+
+**Exemplar** (D-gap-visibility, from #571 R1+R2 — inline token, then phase-exit YAML aggregate):
+
+`**Recommendation shift** — D-gap-visibility: previously load-bearing; now routine; trigger: classification-re-audit; reason: the decision was answerable from inherited content.`
+
+At phase exit, emit a YAML aggregate of all in-phase shifts:
+
+```yaml
+recommendation_shifts:
+  - decision_id: <id>
+    previous: <old_recommendation>
+    revised: <new_recommendation>
+    trigger: engineer-pushback | new-evidence | classification-re-audit
+    reason: <one-sentence>
+    capture_phase: experience | design | plan
+```
+
+### Template: Articulation prompt
+
+Render at phase exit after all load-bearing decisions are locked:
+
+> For each locked load-bearing decision, describe in 2–4 sentences: the choice you made, what would have been wrong about a leading alternative, and why the bridge between them held for this case. Raw text is captured in manual CE Gate evidence; evaluators apply the three-part criterion independently.
+
+**Exemplar** (D-load-directive, from #571 R1+R2):
+
+> "I chose solution-authoring first because upstream-onboarding surfaces prior decisions that have already been answered — if the engagement gate ran after, it would fire on settled content. If upstream-onboarding had run first, the gate would have intercepted the brief's inherited decisions and manufactured false load-bearing signal. The order had to put classification before context so the falsifier could operate on genuinely unanchored decisions only."
+
+## Related Guidance
+
+- Load `upstream-onboarding` after this skill per the D-load-directive declared in each agent body dispatcher.
+- Load `bdd-scenarios` when scenario IDs and G/W/T formatting are needed for CE Gate scenarios.
+
+## Frame Ports Filled By This Skill
+
+This skill is **supporting methodology** — it declares no `provides:` field and fills no frame port. Classification per `Documents/Design/frame-architecture.md` Adapter Model: the credit-author test confirms this skill adds no frame credit row.

--- a/skills/solution-authoring/SKILL.md
+++ b/skills/solution-authoring/SKILL.md
@@ -26,7 +26,7 @@ The classification gate does NOT intercept structured questions that approve or 
 A decision is load-bearing iff ALL THREE legs pass:
 
 1. **Reversibility** — if wrong, requires rework to a published artifact.
-2. **Non-inheritance with artifact-citation falsifier** — the agent MUST attempt to cite a specific inherited artifact (umbrella comment, prior phase marker, named-decision row, settled methodology rule) that would have answered the decision. The citation is recorded verbatim in `audit_rationale`. If a plausible citation exists, the leg **fails** and the decision is routine. Only documented inability to cite — after a genuine attempt — establishes non-inheritable status.
+2. **Non-inheritance with artifact-citation falsifier** — the agent MUST attempt to cite a specific inherited artifact (umbrella comment, prior phase marker, named-decision row, settled methodology rule) that would have answered the decision. The citation is recorded verbatim in `audit_rationale`. If a plausible citation exists, the leg **fails** and the decision is routine. Only documented inability to cite — after a genuine attempt — establishes non-inheritable status. A plausible citation is one a reasonable reader would accept as topical for the decision at hand — it need not be exact; the four enumerated artifact types are exhaustive for v0. **Re-audit trigger**: if an engineer challenges a load-bearing classification with a citation claim after initial classification, the agent MUST re-attempt Leg 2 against that claim; if a plausible citation is found, emit a `**Recommendation shift**` with `trigger: engineer-pushback` (see Template: Free-text option treatment for the output shape).
 3. **Audit-plausibility** — the agent can write a substantive `audit_rationale` sentence.
 
 Failing any one leg collapses to routine. For load-bearing decisions, render the `audit_rationale` as **one sentence immediately above the decision brief** so the engineer can challenge the classification in-band.
@@ -53,6 +53,7 @@ Forward-compatible capture format:
 
 ```yaml
 articulation_captures:
+  schema_version: 1
   - decision_id: <id>
     articulation_text: |
       <verbatim engineer text>
@@ -111,6 +112,7 @@ At phase exit, emit a YAML aggregate of all in-phase shifts:
 
 ```yaml
 recommendation_shifts:
+  schema_version: 1
   - decision_id: <id>
     previous: <old_recommendation>
     revised: <new_recommendation>

--- a/skills/solution-authoring/SKILL.md
+++ b/skills/solution-authoring/SKILL.md
@@ -26,7 +26,7 @@ The classification gate does NOT intercept structured questions that approve or 
 A decision is load-bearing iff ALL THREE legs pass:
 
 1. **Reversibility** — if wrong, requires rework to a published artifact.
-2. **Non-inheritance with artifact-citation falsifier** — the agent MUST attempt to cite a specific inherited artifact (umbrella comment, prior phase marker, named-decision row, settled methodology rule) that would have answered the decision. The citation is recorded verbatim in `audit_rationale`. If a plausible citation exists, the leg **fails** and the decision is routine. Only documented inability to cite — after a genuine attempt — establishes non-inheritable status. A plausible citation is one a reasonable reader would accept as topical for the decision at hand — it need not be exact; the four enumerated artifact types are exhaustive for v0. **Re-audit trigger**: if an engineer challenges a load-bearing classification with a citation claim after initial classification, the agent MUST re-attempt Leg 2 against that claim; if a plausible citation is found, emit a `**Recommendation shift**` with `trigger: engineer-pushback` (see Template: Free-text option treatment for the output shape).
+2. **Non-inheritance with artifact-citation falsifier** — the agent MUST attempt to cite a specific inherited artifact (umbrella comment, prior phase marker, named-decision row, settled methodology rule) that would have answered the decision. The citation is recorded verbatim in `audit_rationale`. If a plausible citation exists, the leg **fails** and the decision is routine. Only documented inability to cite — after a genuine attempt — establishes non-inheritable status. A plausible citation is one a reasonable reader would accept as topical for the decision at hand — it need not be exact; the four enumerated artifact types are exhaustive for v0. **Re-audit trigger**: if an engineer challenges a load-bearing classification with a citation claim after initial classification, the agent MUST re-attempt Leg 2 against that claim; if a plausible citation is found, emit a `**Recommendation shift**` with `trigger: classification-re-audit` (see Template: Free-text option treatment for the output shape).
 3. **Audit-plausibility** — the agent can write a substantive `audit_rationale` sentence.
 
 Failing any one leg collapses to routine. For load-bearing decisions, render the `audit_rationale` as **one sentence immediately above the decision brief** so the engineer can challenge the classification in-band.
@@ -54,11 +54,12 @@ Forward-compatible capture format:
 ```yaml
 articulation_captures:
   schema_version: 1
-  - decision_id: <id>
-    articulation_text: |
-      <verbatim engineer text>
-    capture_phase: experience | design | plan
-    capture_session: manual-ce-gate-v0
+  entries:
+    - decision_id: <id>
+      articulation_text: |
+        <verbatim engineer text>
+      capture_phase: experience | design | plan
+      capture_session: manual-ce-gate-v0
 ```
 
 **Glossary and forward-compat note**: The YAML field `teaching_paragraph_excerpt` is preserved from the locked #571 engagement-record marker payload (`<!-- engagement-record-design-571 -->`). This skill uses "decision brief" in prose; #575 owns harmonizing the YAML field name. Until #575 ships, `teaching_paragraph_excerpt` and "decision brief" refer to the same concept and both remain valid.
@@ -113,12 +114,13 @@ At phase exit, emit a YAML aggregate of all in-phase shifts:
 ```yaml
 recommendation_shifts:
   schema_version: 1
-  - decision_id: <id>
-    previous: <old_recommendation>
-    revised: <new_recommendation>
-    trigger: engineer-pushback | new-evidence | classification-re-audit
-    reason: <one-sentence>
-    capture_phase: experience | design | plan
+  entries:
+    - decision_id: <id>
+      previous: <old_recommendation>
+      revised: <new_recommendation>
+      trigger: engineer-pushback | new-evidence | classification-re-audit
+      reason: <one-sentence>
+      capture_phase: experience | design | plan
 ```
 
 ### Template: Articulation prompt

--- a/skills/solution-authoring/platforms/claude.md
+++ b/skills/solution-authoring/platforms/claude.md
@@ -1,0 +1,13 @@
+# Platform — Claude Code
+
+> Auto-mode boundary: see [CLAUDE.md § Auto-mode boundary](/CLAUDE.md#auto-mode-boundary). Auto-mode does not suppress `AskUserQuestion`.
+
+This skill's methodology is tool-agnostic. Platform-specific detail: Claude Code agents invoke the `AskUserQuestion` tool to fire structured questions on load-bearing decisions.
+
+## Structured question invocation
+
+Use `AskUserQuestion` with the decision brief as the question body. Include the `audit_rationale` sentence immediately before the question body in the conversation text (not inside the tool call). Include a `Decline engagement — proceed without classification` option as the last choice.
+
+## Skip rule invocation
+
+When `gate-fails` or `engineer-declined-engagement` applies, proceed without calling `AskUserQuestion`. Capture the decline verbatim in the conversation text.

--- a/skills/solution-authoring/platforms/copilot.md
+++ b/skills/solution-authoring/platforms/copilot.md
@@ -1,0 +1,11 @@
+# Platform — Copilot
+
+This skill's methodology is tool-agnostic. Platform-specific detail: Copilot agents invoke the `vscode/askQuestions` tool to fire structured questions on load-bearing decisions.
+
+## Structured question invocation
+
+Use `vscode/askQuestions` with the decision brief as the question body. Include the `audit_rationale` sentence immediately before the question body in the conversation text (not inside the tool call). Include a `Decline engagement — proceed without classification` option as the last choice.
+
+## Skip rule invocation
+
+When `gate-fails` or `engineer-declined-engagement` applies, proceed without calling `vscode/askQuestions`. Capture the decline verbatim in the conversation text.

--- a/skills/upstream-onboarding/SKILL.md
+++ b/skills/upstream-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: upstream-onboarding
-description: "Shared opening-phase protocol for upstream agents (Experience-Owner, Solution-Designer, Issue-Planner) and Code-Conductor when invoked on an existing GitHub issue. Renders a scaled context brief and runs a standards check on inherited work at each phase boundary. Use when a user-invocable agent receives a request referencing an existing GitHub issue and must load the first opening-phase skill. DO NOT USE FOR: subagent dispatches (which already operate within an assessed session context); post-merge review (use post-pr-review); research or non-tree subagents."
+description: "Shared opening-phase protocol for upstream agents (Experience-Owner, Solution-Designer, Issue-Planner) and Code-Conductor when invoked on an existing GitHub issue. Renders a scaled context brief and runs a standards check on inherited work at each phase boundary. Use when a user-invocable agent receives a request referencing an existing GitHub issue and must load solution-authoring and upstream-onboarding at the opening phase. DO NOT USE FOR: subagent dispatches (which already operate within an assessed session context); post-merge review (use post-pr-review); research or non-tree subagents."
 ---
 
 <!-- markdownlint-disable-file MD041 MD003 -->
@@ -11,7 +11,8 @@ Shared opening-phase protocol for the three upstream agents in the Agent Orchest
 
 ## When to Use
 
-Load this skill as the first opening-phase action when a user-invocable upstream agent (Experience-Owner, Solution-Designer, Issue-Planner) or Code-Conductor receives a request referencing an existing GitHub issue, or when the developer is describing a brand-new idea (Greenfield Mode below). Structured-question contracts are platform-mode-independent — see your platform guide for any auto-mode boundary.
+<!-- d-load-order-resolution-anchor -->
+Load this skill as an opening-phase action when a user-invocable upstream agent (Experience-Owner, Solution-Designer, Issue-Planner) or Code-Conductor receives a request referencing an existing GitHub issue, or when the developer is describing a brand-new idea (Greenfield Mode below). Structured-question contracts are platform-mode-independent — see your platform guide for any auto-mode boundary.
 
 ## When to Skip
 
@@ -42,7 +43,7 @@ The standards check fires only when the active agent is picking up work complete
 
 ### Sequencing
 
-- Runs **first** when a user-invocable agent picks up an issue-referencing request (after the session-startup hook + drift check, which are platform-level concerns).
+- Runs at the opening phase when a user-invocable agent picks up an issue-referencing request (after the session-startup hook + drift check, which are platform-level concerns).
 - Runs **before** the agent loads its role-specific skills (design-exploration, plan-authoring, etc.) or takes any phase action.
 
 ### Subagent Self-Skip


### PR DESCRIPTION
## Summary

- Adds `skills/solution-authoring/SKILL.md` (v0 engagement-gate methodology): 3-leg D-classification-test with artifact-citation falsifier, decision brief structure, override/decline semantics, skip rules, thin-articulation criterion, and recommendation-shift template
- Adds `skills/solution-authoring/platforms/claude.md` and `copilot.md` with structured-question and skip-rule invocation sections
- Edits all four agent bodies (`Experience-Owner`, `Solution-Designer`, `Issue-Planner`, `Code-Conductor`) with the D-load-directive: solution-authoring fires before upstream-onboarding; Code-Conductor enumerates content-authoring touchpoints (scope-classification, D9-checkpoint) with ambiguity-tiebreaker justification and articulation timing anchor
- Sweeps `skills/upstream-onboarding/SKILL.md` at 3 anchors to remove conflicting "first" load-order claims; adds `<!-- d-load-order-resolution-anchor -->`
- Adds stacking-precedent paragraph to `Documents/Design/frame-architecture.md` Adapter Model section
- Ships `CHANGELOG.md` and version bump 2.15.0 → 2.16.0
- Creates synthetic CE Gate fixture issue #583 on GitHub
- Ships `solution-authoring.Tests.ps1` (24 Pester assertions, AC11.a–g)

Post-adversarial-review incorporated: 6 sustained findings (M1, M2+M12, M7, M18, M20) — greenfield precondition clause, re-audit trigger formalized, schema_version:1 on YAML templates, CC touchpoints justified.

## Test plan

- [x] 24/24 Pester assertions pass (`solution-authoring.Tests.ps1`)
- [ ] S1: load-bearing decision fires decision brief + structured question against fixture #583 (CE Gate, manual)
- [ ] S1-neg: engineer pushes back with citation claim; agent re-audits and emits `**Recommendation shift**` (CE Gate, manual)
- [ ] S3: engineer selects `Decline engagement` override; agent acknowledges and proceeds without re-asking (CE Gate, manual)
- [ ] S4-partial: cross-session resume fires re-engagement on settled decision; parenthetical note visible in output (CE Gate, exploratory)

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new solution-authoring engagement-gate skill and wire it into upstream agents ahead of upstream-onboarding, while documenting the stacking contract and adding regression tests and release metadata.

New Features:
- Add the solution-authoring skill and platform-specific guides for Claude Code and Copilot to govern how load-bearing structured questions are classified and presented.
- Document the stacking precedent between solution-authoring and upstream-onboarding in the frame architecture adapter model, clarifying their declaration-free load-order contract.
- Introduce a project changelog and bump the documented version from 2.15.0 to 2.16.0.

Enhancements:
- Update upstream-onboarding skill copy to remove hard-coded first-load claims and add a load-order resolution anchor so agents can control sequencing externally.
- Adjust Experience-Owner, Solution-Designer, Issue-Planner, and Code-Conductor agent processes so solution-authoring runs before upstream-onboarding, with Code-Conductor explicitly naming applicable content-authoring touchpoints.

Tests:
- Add Pester contract tests for the solution-authoring skill, platform parity, agent load directives, upstream-onboarding sweep, and frame-architecture stacking note.