### PR TITLE
fix(#548): handle sub-feature-merge topology in commit absorption

### DIFF
--- a/.github/scripts/Tests/test-orphan-branch-commits-absorbed.Tests.ps1
+++ b/.github/scripts/Tests/test-orphan-branch-commits-absorbed.Tests.ps1
@@ -202,6 +202,43 @@ else { exit 1 }
         }
     }
 
+    Context 'sub-feature-merge topology (--no-merges fix)' {
+        It 'feature branch that merged in a sub-feature with spike-only commits returns $true' {
+            $repo = & $script:NewTestRepo
+            & git -C $repo checkout -b 'feature/issue-548-parent' 2>&1 | Out-Null
+            # First spike commit directly on the parent feature branch
+            & $script:CommitFile -RepoPath $repo -RelPath '.tmp/issue-548/parent.md' -Content 'parent spike' -Message 'parent spike'
+            # Sub-feature branch with its own spike commits (second-parent ancestors after merge)
+            & git -C $repo checkout -b 'feature/issue-548-subfeature' 2>&1 | Out-Null
+            & $script:CommitFile -RepoPath $repo -RelPath '.tmp/issue-548/sub1.md' -Content 'sub spike 1' -Message 'sub spike 1'
+            & $script:CommitFile -RepoPath $repo -RelPath '.tmp/issue-548/sub2.md' -Content 'sub spike 2' -Message 'sub spike 2'
+            # Merge sub-feature back into parent — creates a merge commit with two parents
+            & git -C $repo checkout 'feature/issue-548-parent' 2>&1 | Out-Null
+            & git -C $repo -c user.email='t@t.com' -c user.name='T' merge --no-ff 'feature/issue-548-subfeature' -m 'merge sub-feature' 2>&1 | Out-Null
+            # All commits (parent + both sub) are spike-only confined to .tmp/issue-548/.
+            # Under --first-parent (the old behavior), the sub-feature commits would land in
+            # $residualSHAs without paths and hit the empty-path guard — returning $false.
+            # Under --no-merges (the new behavior), they appear in both $residualSHAs and $commitPaths
+            # with their real paths and are correctly classified as spike-only.
+            $result = & $script:Invoke -RepoPath $repo -Branch 'feature/issue-548-parent'
+            $result | Should -BeTrue
+        }
+
+        It 'feature branch that merged in a sub-feature with non-spike commits returns $false' {
+            $repo = & $script:NewTestRepo
+            & git -C $repo checkout -b 'feature/issue-548-parent-bad' 2>&1 | Out-Null
+            & $script:CommitFile -RepoPath $repo -RelPath '.tmp/issue-548/parent.md' -Content 'parent spike' -Message 'parent spike'
+            # Sub-feature branch with a non-spike commit (touches src/ outside .tmp/issue-548/)
+            & git -C $repo checkout -b 'feature/issue-548-subfeature-bad' 2>&1 | Out-Null
+            & $script:CommitFile -RepoPath $repo -RelPath 'src/leaked.ps1' -Content 'leaked' -Message 'leaked work on sub'
+            & git -C $repo checkout 'feature/issue-548-parent-bad' 2>&1 | Out-Null
+            & git -C $repo -c user.email='t@t.com' -c user.name='T' merge --no-ff 'feature/issue-548-subfeature-bad' -m 'merge sub with leak' 2>&1 | Out-Null
+            # The sub-feature's non-spike commit should now be visible and correctly fail spike-only
+            $result = & $script:Invoke -RepoPath $repo -Branch 'feature/issue-548-parent-bad'
+            $result | Should -BeFalse
+        }
+    }
+
     Context 'fail-open on git errors' {
         It 'branch that does not exist returns $null' {
             $repo = & $script:NewTestRepo

--- a/skills/session-startup/scripts/session-startup-git-helpers.ps1
+++ b/skills/session-startup/scripts/session-startup-git-helpers.ps1
@@ -251,23 +251,24 @@ function Test-OrphanBranchCommitsAbsorbed {
         }
     }
 
-    # --- Batched git invocation 2: rev-list — residual commits not reachable from default ---
-    $revListOutput = Invoke-SCDNativeCommand { git rev-list $Branch --not $remoteDefault 2>$null }
+    # --- Batched git invocation 2: rev-list --no-merges — residual non-merge commits not reachable from default ---
+    # --no-merges excludes merge commits (which have no meaningful patch on their own — their
+    # constituent commits, walked through all parents by default, carry the actual file changes).
+    # Pairs with the --no-merges flag on git log below so $residualSHAs and $commitPaths cover
+    # the same commit set, including second-parent ancestors of sub-feature merges.
+    $revListOutput = Invoke-SCDNativeCommand { git rev-list $Branch --not $remoteDefault --no-merges 2>$null }
     if ($LASTEXITCODE -ne 0) { return $null }
     $residualSHAs = @($revListOutput | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_.Trim() })
 
     # No residual commits: branch is fully absorbed
     if ($residualSHAs.Count -eq 0) { return $true }
 
-    # --- Batched git invocation 3: log --first-parent --name-status — per-commit path lists ---
-    # NOTE: --first-parent skips non-first-parent ancestors of merge commits.
-    # If the feature branch ever merged a sub-feature branch in (not just pulling main),
-    # those second-parent SHAs will appear in $residualSHAs (from rev-list, which walks all parents)
-    # but not in $commitPaths (populated from --first-parent log). They hit the empty-path guard
-    # at line 330 and return $false, so auto-resolve is conservatively declined. This is
-    # fail-safe (branch retained, not deleted), but reduces recall for sub-feature-merge topologies.
-    # A future fix could drop --first-parent and explicitly skip merge commits via --no-merges.
-    $logOutput = Invoke-SCDNativeCommand { git log --first-parent --name-status "$remoteDefault..$Branch" 2>$null }
+    # --- Batched git invocation 3: log --no-merges --name-status — per-commit path lists ---
+    # Mirrors the --no-merges flag on rev-list above. Dropping --first-parent (was previously here)
+    # means second-parent ancestors of intra-branch merge commits now appear in $commitPaths with
+    # their actual file paths, so the spike-only / tree-at-HEAD sub-cases can evaluate them
+    # instead of falling through to the empty-path guard and conservatively declining auto-resolve.
+    $logOutput = Invoke-SCDNativeCommand { git log --no-merges --name-status "$remoteDefault..$Branch" 2>$null }
     if ($LASTEXITCODE -ne 0) { return $null }
 
     # Parse per-commit path lists from log output

--- a/skills/session-startup/scripts/session-startup-git-helpers.ps1
+++ b/skills/session-startup/scripts/session-startup-git-helpers.ps1
@@ -256,6 +256,20 @@ function Test-OrphanBranchCommitsAbsorbed {
     # constituent commits, walked through all parents by default, carry the actual file changes).
     # Pairs with the --no-merges flag on git log below so $residualSHAs and $commitPaths cover
     # the same commit set, including second-parent ancestors of sub-feature merges.
+    #
+    # SAFETY ASSUMPTION (workflow-dependent): a merge commit on the branch may carry conflict-
+    # resolution content unique to that commit — content absent from both of its parents — at
+    # a path not touched by any non-merge residual commit. Such paths are not inspected by this
+    # function. Safety relies on the calling orchestrator (Test-OrphanBranchAutoResolveEligible):
+    # under the project's squash-merge-only PR convention, Test-OrphanBranchGitHubSignalsShipped
+    # first requires headRefOid == git rev-parse $Branch (a merged PR's recorded head must equal
+    # the current branch tip SHA). A squash-merge captures the full branch-tip-vs-base diff,
+    # so any merge-commit-unique content is independently propagated to main's tree at those
+    # paths. If the project's merge convention ever broadens to rebase-merge or true merge-commit
+    # as the dominant PR strategy, this function should be hardened: add a fourth batched call
+    # 'git rev-list $Branch --not $remoteDefault --merges' and evaluate each residual merge
+    # commit's paths via 'git diff-tree -m -r --name-status <sha>' through the same spike-only /
+    # tree-at-HEAD sub-cases, conservatively returning $false when paths cannot be determined.
     $revListOutput = Invoke-SCDNativeCommand { git rev-list $Branch --not $remoteDefault --no-merges 2>$null }
     if ($LASTEXITCODE -ne 0) { return $null }
     $residualSHAs = @($revListOutput | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_.Trim() })


### PR DESCRIPTION
## Summary

- Replaces `git log --first-parent` with `git log --no-merges` and adds `--no-merges` to `git rev-list` in `Test-OrphanBranchCommitsAbsorbed`
- Closes the recall gap where feature branches that merged in a sub-feature (second-parent merge, not just pulling main) hit the empty-path guard and conservatively declined auto-resolve
- Adds two regression tests for sub-feature-merge topology

## Background

PR #595 review (Sourcery top-level comment, C595-F8) flagged that `Test-OrphanBranchCommitsAbsorbed` relied on the empty-path guard as an implicit safety net for sub-feature-merge topologies. The behavior was conservatively fail-safe (branch retained, not deleted), but reduced recall and the safety was coincidental rather than explicit.

The original `NOTE:` comment in `session-startup-git-helpers.ps1` documented the limitation and proposed the fix shape (`--no-merges`). This PR implements it.

## What changed

**`skills/session-startup/scripts/session-startup-git-helpers.ps1`**:
- `git rev-list \$Branch --not \$remoteDefault` → `git rev-list \$Branch --not \$remoteDefault --no-merges`
- `git log --first-parent --name-status \"\$remoteDefault..\$Branch\"` → `git log --no-merges --name-status \"\$remoteDefault..\$Branch\"`
- Replaced the limitation `NOTE:` with explanatory comments describing the new pairing

After the change, `\$residualSHAs` and `\$commitPaths` cover the same commit set, including second-parent ancestors of sub-feature merges. The empty-path guard now fires only for genuine `--allow-empty` commits (the original design intent).

**`.github/scripts/Tests/test-orphan-branch-commits-absorbed.Tests.ps1`**:
- New `Context 'sub-feature-merge topology (--no-merges fix)'` with two tests:
  - Parent branch merging a spike-only sub-feature → \$true (correctly absorbed)
  - Parent branch merging a sub-feature that touches `src/` → \$false (correctly declined)

## Verification

Full test suite for `Test-OrphanBranchCommitsAbsorbed` and related cleanup tests pass:
- `test-orphan-branch-commits-absorbed.Tests.ps1`: 16/16 pass (14 existing + 2 new)
- `post-merge-cleanup-squash-merge.Tests.ps1`: pass
- `test-orphan-branch-auto-resolve-eligible.Tests.ps1`: pass
- `test-orphan-branch-github-signals.Tests.ps1`: pass
- `orphan-issue-regex-contract.Tests.ps1`: pass
- `script-wording-contract.Tests.ps1`: pass

48/48 total pass.

## Stacked on

This PR targets `fix/issue-548-polish-nits` (PR #596), which itself targets `feature/issue-548-squash-merge-orphan-autodelete` (PR #595).

Merge order: #595 → #596 → this PR.

## Test plan

- [x] All existing `Test-OrphanBranchCommitsAbsorbed` tests still pass (14 pre-existing tests covering spike-only, patch-equivalent, ancestor, tree-at-HEAD, allow-empty rejection, perf, and master-default-branch)
- [x] New test: spike-only sub-feature merge returns \$true
- [x] New test: non-spike sub-feature merge returns \$false
- [x] Related test suites (post-merge-cleanup, auto-resolve-eligible, github-signals, regex/wording contracts) all pass

## Summary by Sourcery

Adjust orphan-branch absorption logic to ignore merge commits consistently and add regression coverage for sub-feature merge topologies.

Bug Fixes:
- Ensure sub-feature merge commits are correctly classified as spike-only or non-spike by aligning residual commit and path collection to the same non-merge commit set, preventing conservative false negatives in auto-resolve.

Enhancements:
- Document the use of --no-merges in git rev-list and git log to clarify handling of sub-feature merge histories.

Tests:
- Add regression tests covering feature branches that merge spike-only and non-spike sub-features to validate correct absorption decisions under sub-feature-merge topologies.