### PR TITLE
chore(release): 2.17.0 — squash-merge orphan auto-resolve (#548)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.16.0"
+    "version": "2.17.0"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-      "version": "2.16.0",
+      "version": "2.17.0",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "Multi-agent workflow system for GitHub Copilot",
-    "version": "2.16.0"
+    "version": "2.17.0"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "Multi-agent workflow system for GitHub Copilot with 16 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.16.0"
+      "version": "2.17.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to agent-orchestra will be documented in this file.
 
+## [2.17.0] — 2026-05-20
+
+### Added
+
+- **Squash-merge orphan auto-resolve** (#548 / PR #595) — session-startup cleanup now auto-deletes `feature/issue-N-*` branches that have been squash-merged into main. Adds a three-layer verification chain in `skills/session-startup/scripts/session-startup-git-helpers.ps1`: ancestor reachability → patch-equivalent (`git cherry`) → spike-only / tree-at-HEAD per-residual-commit classification. Authorization requires the parent issue to be CLOSED **and** a merged PR with `headRefOid == git rev-parse $Branch` (the local branch tip SHA), so the auto-delete path only fires for branches whose exact tip was the merged head. New Pester suites: `test-orphan-branch-commits-absorbed.Tests.ps1`, `test-orphan-branch-auto-resolve-eligible.Tests.ps1`, `test-orphan-branch-github-signals.Tests.ps1`, `script-wording-contract.Tests.ps1`.
+- **Composite sibling + orphan cleanup invocation** (#548) — the session-startup skill now passes sibling worktree paths and orphan branch names as parameters to a single `post-merge-cleanup.ps1 -SiblingWorktrees @(...) -OrphanBranches @(...)` invocation, so confirming the full cleanup batch triggers one permission prompt instead of one per branch.
+
+### Changed
+
+- **`skills/session-startup/scripts/session-startup-git-helpers.ps1`** (#598) — `Test-OrphanBranchCommitsAbsorbed` switched from `git log --first-parent` to `git rev-list ... --no-merges` + `git log --no-merges --name-status`. Closes a recall gap where sub-feature-merge topologies (feature branches that absorbed a sub-feature via `git merge --no-ff`) hit the empty-path guard and conservatively declined auto-resolve. Second-parent ancestors now appear in both `$residualSHAs` and `$commitPaths` with their actual file paths. Added a `# SAFETY ASSUMPTION (workflow-dependent):` inline comment documenting the squash-merge + headRefOid coupling and the escalation path (issue #599) if the project's merge convention ever broadens.
+- **`skills/session-startup/SKILL.md`** (#596) — race-condition wording updated from `'became unmerged between re-check and force-delete'` to `'branch not reachable from default (merged-state re-check returned false)'` for accuracy.
+
+### Fixed
+
+- **Polish nits from PR #595 adversarial review** (#596) — minor wording fixes (M10/M11/M16/M17), shim call-log assertion for `--base master` in the master-default-branch test, and Pester `-Because` text alignment with the new race-condition wording.
+
 ## [2.16.0] — 2026-05-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Orchestra
 
-[![Version](https://img.shields.io/badge/version-v2.16.0-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v2.17.0-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development across specialized agents in GitHub Copilot and Claude Code.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "Multi-agent workflow system for GitHub Copilot. Pipeline-based agent orchestration: Issue → Design → Plan → Implement → Review → PR.",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "author": {
     "name": "Grimblaz"
   },


### PR DESCRIPTION
## Summary

Bumps the plugin version to **2.17.0** across all 7 version-bearing occurrences (5 files) to invalidate Claude Code's plugin cache so new sessions pick up the squash-merge orphan auto-resolve feature shipped via PRs #595/#596/#598.

## Why minor (not patch)

PR #595 introduced new user-visible cleanup behavior: session-startup now auto-deletes `feature/issue-N-*` branches that have been squash-merged into main, gated by parent-issue CLOSED + matched `headRefOid`. That is a new surface, so per `skills/plugin-release-hygiene/SKILL.md` it warrants a minor bump.

## Changelog entry

Added a `## [2.17.0] — 2026-05-20` section covering:

- **Added**: squash-merge orphan auto-resolve (#595) — three-layer verification chain (ancestor → patch-equivalent → spike-only / tree-at-HEAD); composite sibling + orphan cleanup invocation
- **Changed**: sub-feature-merge topology fix in `Test-OrphanBranchCommitsAbsorbed` (#598) — `--first-parent` → `--no-merges` with documented workflow-dependent safety assumption; race-condition wording correction (#596)
- **Fixed**: polish nits from PR #595 adversarial review (#596)

## Files touched

- `plugin.json` — version
- `.claude-plugin/plugin.json` — version
- `.claude-plugin/marketplace.json` — 2 version occurrences
- `.github/plugin/marketplace.json` — 2 version occurrences
- `README.md` — version
- `CHANGELOG.md` — new release entry

## Test plan

- [x] `bump-version.ps1` reports all 7 occurrences updated, no drift
- [ ] After merge: `claude plugin update agent-orchestra@agent-orchestra` in a new session pulls 2.17.0
- [ ] First session-startup with a `feature/issue-N-*` orphan + CLOSED issue + matching merged-PR head triggers the auto-resolve cleanup path (no more manual `git branch -D`)

## Summary by Sourcery

Release agent-orchestra version 2.17.0 and document the squash-merge orphan auto-resolve feature and related cleanup improvements.

New Features:
- Document the squash-merge orphan auto-resolve behavior and composite sibling + orphan cleanup invocation introduced in prior changes.

Enhancements:
- Clarify session-startup safety assumptions and wording around race conditions in the session-startup skill documentation.

Documentation:
- Add a 2.17.0 changelog entry describing squash-merge orphan auto-resolve, composite cleanup invocation, and recent behavior changes.
- Update the README version badge to 2.17.0.

Chores:
- Bump all plugin and marketplace metadata files to version 2.17.0 to publish the new release.