### PR TITLE
feat(#664): cross-platform Join-Path hygiene — sweep backslash literals + gate + convention (v2.25.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.24.0"
+    "version": "2.25.1"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-      "version": "2.24.0",
+      "version": "2.25.1",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/architecture-rules.md
+++ b/.github/architecture-rules.md
@@ -106,3 +106,26 @@ pwsh -NoProfile -NonInteractive -File .github/scripts/quick-validate.ps1
 ```
 
 This consolidates all structural checks (deleted-agent references, skill frontmatter, guidance complexity, PSScriptAnalyzer, and more).
+
+### Join-Path child-path separator rule
+
+All `Join-Path` calls in tracked `.ps1` files must use forward slashes (`/`) as
+path separators in child-path arguments:
+
+```powershell
+# Correct (cross-platform)
+Join-Path $root 'skills/session-startup/scripts/session-cleanup-detector.ps1'
+
+# Wrong (Linux-breaking)
+Join-Path $root 'skills\session-startup\scripts\session-cleanup-detector.ps1'
+```
+
+PowerShell's `Join-Path` does not normalize embedded backslashes on Linux;
+`Get-Content -LiteralPath` and file-existence checks against such paths fail silently.
+Forward slashes are portable across Windows, Linux, and macOS.
+
+**Exceptions**: Windows-only paths inside an `if ($IsWindows)` block may retain
+backslashes. Mark these with `# host-path-ok` on the same line to suppress the gate.
+
+**Enforcement**: `path-migration-sweep-gate.Tests.ps1` `Describe 'Issue #664...'` block
+(added in issue #664) — run with `Invoke-Pester .github/scripts/Tests/path-migration-sweep-gate.Tests.ps1`.

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot",
-    "version": "2.24.0"
+    "version": "2.25.1"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot with 16 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.24.0"
+      "version": "2.25.1"
     }
   ]
 }

--- a/.github/scripts/Tests/Ensure-ScratchGitignore.Tests.ps1
+++ b/.github/scripts/Tests/Ensure-ScratchGitignore.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Ensure-ScratchGitignore.ps1' {
 
     BeforeAll {
         $script:RepoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ScriptFile = Join-Path $script:RepoRoot 'skills\session-startup\scripts\Ensure-ScratchGitignore.ps1'
+        $script:ScriptFile = Join-Path $script:RepoRoot 'skills/session-startup/scripts/Ensure-ScratchGitignore.ps1'
 
         # Canonical patterns expected to be present after the script runs.
         # /*[Tt]emp* intentionally absent (RF4): over-matched template.md/attempt.js;

--- a/.github/scripts/Tests/Issue-Planner-spine-emission.Tests.ps1
+++ b/.github/scripts/Tests/Issue-Planner-spine-emission.Tests.ps1
@@ -18,8 +18,8 @@ Describe 'Issue-Planner frame spine emission contract' -Tag 'contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:IssuePlanner = Join-Path $script:RepoRoot 'agents\Issue-Planner.agent.md'
-        $script:PlanAuthoring = Join-Path $script:RepoRoot 'skills\plan-authoring\SKILL.md'
+        $script:IssuePlanner = Join-Path $script:RepoRoot 'agents/Issue-Planner.agent.md'
+        $script:PlanAuthoring = Join-Path $script:RepoRoot 'skills/plan-authoring/SKILL.md'
         $script:Content = Get-Content -Path $script:IssuePlanner -Raw
         $script:PlanAuthoringContent = Get-Content -Path $script:PlanAuthoring -Raw
 

--- a/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
+++ b/.github/scripts/Tests/aggregate-review-scores.Tests.ps1
@@ -56,8 +56,8 @@ Describe 'aggregate-review-scores.ps1 -CalibrationFile' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ScriptFile = Join-Path $script:RepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores.ps1'
-        $script:LibFile = Join-Path $script:RepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:ScriptFile = Join-Path $script:RepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
         $script:GuidanceComplexityStartingHash = (Get-FileHash -Path (Join-Path $script:RepoRoot 'skills/calibration-pipeline/assets/guidance-complexity.json')).Hash
         . $script:LibFile
 
@@ -3035,8 +3035,8 @@ Describe 'aggregate-review-scores -HealthReport parameter and return shape contr
 
     BeforeAll {
         $script:HRRepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:HRScriptFile = Join-Path $script:HRRepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores.ps1'
-        $script:HRLibFile = Join-Path $script:HRRepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:HRScriptFile = Join-Path $script:HRRepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores.ps1'
+        $script:HRLibFile = Join-Path $script:HRRepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
         . $script:HRLibFile
 
         # Isolated temp root for mock-gh artifacts
@@ -3179,7 +3179,7 @@ exit 0
 
         It 'return hashtable does NOT include HealthReport key when gh CLI is not found (ExitCode=1)' -Tag 'no-gh' {
             # ARRANGE: GhCliPath points to a path that does not exist → early ExitCode=1 exit
-            $nonExistentGh = Join-Path $script:HRTempRoot 'no-such-subdir\gh.exe'
+            $nonExistentGh = Join-Path $script:HRTempRoot 'no-such-subdir/gh.exe'
 
             # ACT
             $result = Invoke-AggregateReviewScores `
@@ -3204,7 +3204,7 @@ Describe 'Format-HealthReport core content' {
 
     BeforeAll {
         $script:FHRRepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:FHRLibFile = Join-Path $script:FHRRepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:FHRLibFile = Join-Path $script:FHRRepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
         . $script:FHRLibFile
 
         # ---------------------------------------------------------------
@@ -3506,7 +3506,7 @@ Describe 'Directional indicators via temporal split' {
 
     BeforeAll {
         $script:TSSRepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:TSSLibFile = Join-Path $script:TSSRepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:TSSLibFile = Join-Path $script:TSSRepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
         . $script:TSSLibFile
         $script:TSSTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
             "pester-tss-$([System.Guid]::NewGuid().ToString('N'))"
@@ -3756,7 +3756,7 @@ Describe 'Fix Effectiveness: per-category contribution enrichment' {
 
     BeforeAll {
         $script:FERepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:FELibFile = Join-Path $script:FERepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:FELibFile = Join-Path $script:FERepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
         . $script:FELibFile
         $script:FETempRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
             "pester-fe-$([System.Guid]::NewGuid().ToString('N'))"
@@ -4124,7 +4124,7 @@ Describe 'Fix Effectiveness: Measure-FixEffectiveness' {
 
     BeforeAll {
         $script:CFERepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CFELibFile = Join-Path $script:CFERepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:CFELibFile = Join-Path $script:CFERepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
         . $script:CFELibFile
 
         # Helper: build a PrContribution entry
@@ -4571,7 +4571,7 @@ Describe 'Fix Effectiveness: merge-date discovery' {
 
     BeforeAll {
         $script:MDRepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:MDLibFile = Join-Path $script:MDRepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:MDLibFile = Join-Path $script:MDRepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
         . $script:MDLibFile
         $script:MDTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
             "pester-md-$([System.Guid]::NewGuid().ToString('N'))"
@@ -5028,7 +5028,7 @@ Describe 'Read-only mode and insufficient data handling' {
 
     BeforeAll {
         $script:RORepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ROLibFile = Join-Path $script:RORepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:ROLibFile = Join-Path $script:RORepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
         . $script:ROLibFile
         $script:ROTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
             "pester-ro-$([System.Guid]::NewGuid().ToString('N'))"
@@ -5226,7 +5226,7 @@ Describe 'Fix Effectiveness: Format-HealthReport section rendering' {
 
     BeforeAll {
         $script:FHRFERepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:FHRFELibFile = Join-Path $script:FHRFERepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:FHRFELibFile = Join-Path $script:FHRFERepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
         . $script:FHRFELibFile
 
         # ---------------------------------------------------------------
@@ -5538,7 +5538,7 @@ Describe 'Fix Effectiveness: integration tests' {
 
     BeforeAll {
         $script:FEIRepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:FEILibFile = Join-Path $script:FEIRepoRoot 'skills\calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:FEILibFile = Join-Path $script:FEIRepoRoot 'skills/calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
         . $script:FEILibFile
         $script:FEITempRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
             "pester-fei-$([System.Guid]::NewGuid().ToString('N'))"

--- a/.github/scripts/Tests/atomic-adversarial-pipeline.Tests.ps1
+++ b/.github/scripts/Tests/atomic-adversarial-pipeline.Tests.ps1
@@ -5,7 +5,7 @@
 BeforeAll {
     Import-Module powershell-yaml -MinimumVersion 0.4.0
 
-    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
     $script:DispatcherPath = 'skills/adversarial-review/platforms/claude.md'
     $script:DispatcherMarker = '<!-- adversarial-pipeline-atomic-{ISSUE_ID} -->'
     $script:PauseReasons = @('artifact-missing', 'runtime-output-required', 'user-input-required-by-decision-class')

--- a/.github/scripts/Tests/backfill-calibration.Tests.ps1
+++ b/.github/scripts/Tests/backfill-calibration.Tests.ps1
@@ -35,8 +35,8 @@ Describe 'backfill-calibration.ps1' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ScriptFile = Join-Path $script:RepoRoot 'skills\calibration-pipeline\scripts\backfill-calibration.ps1'
-        $script:LibFile = Join-Path $script:RepoRoot 'skills\calibration-pipeline\scripts\backfill-calibration-core.ps1'
+        $script:ScriptFile = Join-Path $script:RepoRoot 'skills/calibration-pipeline/scripts/backfill-calibration.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot 'skills/calibration-pipeline/scripts/backfill-calibration-core.ps1'
         . $script:LibFile
 
         # ---------------------------------------------------------------------------

--- a/.github/scripts/Tests/bdd-scenario-contract.Tests.ps1
+++ b/.github/scripts/Tests/bdd-scenario-contract.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'Experience-Owner BDD scenario contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ExperienceOwner = Join-Path $script:RepoRoot 'agents\Experience-Owner.agent.md'
+        $script:ExperienceOwner = Join-Path $script:RepoRoot 'agents/Experience-Owner.agent.md'
         $script:Content = Get-Content -Path $script:ExperienceOwner -Raw
 
         $script:GwtConditionalPattern = '(?is)(## BDD Framework).{0,300}(G/W/T|Given.{0,10}When.{0,10}Then|structured scenario).{0,300}(natural.{0,30}language|fallback)'
@@ -78,7 +78,7 @@ Describe 'Issue-Planner BDD classification contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:IssuePlanner = Join-Path $script:RepoRoot 'agents\Issue-Planner.agent.md'
+        $script:IssuePlanner = Join-Path $script:RepoRoot 'agents/Issue-Planner.agent.md'
         $script:IPContent = Get-Content -Path $script:IssuePlanner -Raw
     }
 
@@ -103,7 +103,7 @@ Describe 'Code-Conductor BDD CE Gate pre-flight contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CodeConductor = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
+        $script:CodeConductor = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
         $script:CCContent = Get-Content -Path $script:CodeConductor -Raw
     }
 
@@ -136,7 +136,7 @@ Describe 'Code-Critic BDD CE prosecution contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CodeCritic = Join-Path $script:RepoRoot 'agents\Code-Critic.agent.md'
+        $script:CodeCritic = Join-Path $script:RepoRoot 'agents/Code-Critic.agent.md'
         $script:CriticContent = Get-Content -Path $script:CodeCritic -Raw
     }
 
@@ -161,7 +161,7 @@ Describe 'bdd-scenarios SKILL.md Phase 2 contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:SkillFile = Join-Path $script:RepoRoot 'skills\bdd-scenarios\SKILL.md'
+        $script:SkillFile = Join-Path $script:RepoRoot 'skills/bdd-scenarios/SKILL.md'
         $script:SkillContent = Get-Content -Path $script:SkillFile -Raw
     }
 
@@ -190,7 +190,7 @@ Describe 'Test-Writer BDD Phase 2 Gherkin generation contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:TestWriter = Join-Path $script:RepoRoot 'agents\Test-Writer.agent.md'
+        $script:TestWriter = Join-Path $script:RepoRoot 'agents/Test-Writer.agent.md'
         $script:TWContent = Get-Content -Path $script:TestWriter -Raw
     }
 
@@ -215,7 +215,7 @@ Describe 'Code-Conductor BDD Phase 2 runner dispatch contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CodeConductor = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
+        $script:CodeConductor = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
         $script:CCContent = Get-Content -Path $script:CodeConductor -Raw
     }
 
@@ -244,7 +244,7 @@ Describe 'Code-Critic BDD Phase 2 runner evidence evaluation contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CodeCritic = Join-Path $script:RepoRoot 'agents\Code-Critic.agent.md'
+        $script:CodeCritic = Join-Path $script:RepoRoot 'agents/Code-Critic.agent.md'
         $script:CriticContent = Get-Content -Path $script:CodeCritic -Raw
     }
 

--- a/.github/scripts/Tests/branch-authority-gate-contract.Tests.ps1
+++ b/.github/scripts/Tests/branch-authority-gate-contract.Tests.ps1
@@ -22,8 +22,8 @@ Describe 'branch authority gate contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CodeConductor = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
-        $script:HubModeUx = Join-Path $script:RepoRoot 'Documents\Design\hub-mode-ux.md'
+        $script:CodeConductor = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
+        $script:HubModeUx = Join-Path $script:RepoRoot 'Documents/Design/hub-mode-ux.md'
 
         $script:ReadContent = {
             param([string]$Path)

--- a/.github/scripts/Tests/branch-authority-gate.Tests.ps1
+++ b/.github/scripts/Tests/branch-authority-gate.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'branch-authority-gate.ps1' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:HelperPath = Join-Path $script:RepoRoot '.github\scripts\lib\branch-authority-gate.ps1'
+        $script:HelperPath = Join-Path $script:RepoRoot '.github/scripts/lib/branch-authority-gate.ps1'
         $script:SavedPath = $env:PATH
 
         $script:LoadSubject = {

--- a/.github/scripts/Tests/ce-gate-multi-path-coverage-contract.Tests.ps1
+++ b/.github/scripts/Tests/ce-gate-multi-path-coverage-contract.Tests.ps1
@@ -24,8 +24,8 @@ Describe 'ce gate multi-path output coverage contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:IssuePlanner = Join-Path $script:RepoRoot 'agents\Issue-Planner.agent.md'
-        $script:CodeReviewDesign = Join-Path $script:RepoRoot 'Documents\Design\code-review.md'
+        $script:IssuePlanner = Join-Path $script:RepoRoot 'agents/Issue-Planner.agent.md'
+        $script:CodeReviewDesign = Join-Path $script:RepoRoot 'Documents/Design/code-review.md'
 
         $script:ReadContent = {
             param([string]$Path)

--- a/.github/scripts/Tests/code-conductor-inline-commands.Tests.ps1
+++ b/.github/scripts/Tests/code-conductor-inline-commands.Tests.ps1
@@ -21,9 +21,9 @@ Describe 'Code-Conductor inline commands contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CodeConductorCommandPath = Join-Path $script:RepoRoot 'commands\code-conductor.md'
-        $script:ReviewGithubCommandPath = Join-Path $script:RepoRoot 'commands\review-github.md'
-        $script:CodeConductorAgentPath = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
+        $script:CodeConductorCommandPath = Join-Path $script:RepoRoot 'commands/code-conductor.md'
+        $script:ReviewGithubCommandPath = Join-Path $script:RepoRoot 'commands/review-github.md'
+        $script:CodeConductorAgentPath = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
 
         $script:ExtractFrontmatter = {
             param([string]$Content)

--- a/.github/scripts/Tests/code-conductor-spine-dispatch.Tests.ps1
+++ b/.github/scripts/Tests/code-conductor-spine-dispatch.Tests.ps1
@@ -19,8 +19,8 @@ Describe 'Code-Conductor frame-spine dispatch contract' -Tag 'contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CodeConductor = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
-        $script:FrameSpineCore = Join-Path $script:RepoRoot '.github\scripts\lib\frame-spine-core.ps1'
+        $script:CodeConductor = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
+        $script:FrameSpineCore = Join-Path $script:RepoRoot '.github/scripts/lib/frame-spine-core.ps1'
 
         if (Test-Path $script:FrameSpineCore) {
             . $script:FrameSpineCore

--- a/.github/scripts/Tests/composite-skill-structure.Tests.ps1
+++ b/.github/scripts/Tests/composite-skill-structure.Tests.ps1
@@ -35,8 +35,8 @@ Describe 'Composite skill structure contract' {
         $script:CompositeSkills = @(
             @{
                 Name                      = 'customer-experience'
-                SkillPath                 = Join-Path $script:RepoRoot 'skills\customer-experience\SKILL.md'
-                ReferencesPath            = Join-Path $script:RepoRoot 'skills\customer-experience\references'
+                SkillPath                 = Join-Path $script:RepoRoot 'skills/customer-experience/SKILL.md'
+                ReferencesPath            = Join-Path $script:RepoRoot 'skills/customer-experience/references'
                 DisallowedHeadingPatterns = @(
                     '(?m)^## Customer Experience Gate \(CE Gate\)\s*$',
                     '(?m)^## Two-Track Defect Response\s*$'
@@ -44,8 +44,8 @@ Describe 'Composite skill structure contract' {
             },
             @{
                 Name                      = 'calibration-pipeline'
-                SkillPath                 = Join-Path $script:RepoRoot 'skills\calibration-pipeline\SKILL.md'
-                ReferencesPath            = Join-Path $script:RepoRoot 'skills\calibration-pipeline\references'
+                SkillPath                 = Join-Path $script:RepoRoot 'skills/calibration-pipeline/SKILL.md'
+                ReferencesPath            = Join-Path $script:RepoRoot 'skills/calibration-pipeline/references'
                 DisallowedHeadingPatterns = @(
                     '(?m)^## Pipeline Metrics\s*$',
                     '(?m)^## Verdict Mapping\s*$',
@@ -54,8 +54,8 @@ Describe 'Composite skill structure contract' {
             },
             @{
                 Name                      = 'validation-methodology'
-                SkillPath                 = Join-Path $script:RepoRoot 'skills\validation-methodology\SKILL.md'
-                ReferencesPath            = Join-Path $script:RepoRoot 'skills\validation-methodology\references'
+                SkillPath                 = Join-Path $script:RepoRoot 'skills/validation-methodology/SKILL.md'
+                ReferencesPath            = Join-Path $script:RepoRoot 'skills/validation-methodology/references'
                 DisallowedHeadingPatterns = @(
                     '(?m)^## Review Reconciliation Loop\s*$',
                     '(?m)^## Post-Judgment Re-Activation Detection\s*$'
@@ -63,16 +63,16 @@ Describe 'Composite skill structure contract' {
             },
             @{
                 Name                      = 'code-review-intake'
-                SkillPath                 = Join-Path $script:RepoRoot 'skills\code-review-intake\SKILL.md'
-                ReferencesPath            = Join-Path $script:RepoRoot 'skills\code-review-intake\references'
+                SkillPath                 = Join-Path $script:RepoRoot 'skills/code-review-intake/SKILL.md'
+                ReferencesPath            = Join-Path $script:RepoRoot 'skills/code-review-intake/references'
                 DisallowedHeadingPatterns = @(
                     '(?m)^## Express Lane Gate.*$'
                 )
             },
             @{
                 Name                      = 'parallel-execution'
-                SkillPath                 = Join-Path $script:RepoRoot 'skills\parallel-execution\SKILL.md'
-                ReferencesPath            = Join-Path $script:RepoRoot 'skills\parallel-execution\references'
+                SkillPath                 = Join-Path $script:RepoRoot 'skills/parallel-execution/SKILL.md'
+                ReferencesPath            = Join-Path $script:RepoRoot 'skills/parallel-execution/references'
                 DisallowedHeadingPatterns = @(
                     '(?m)^## Subagent Call Resilience \(R5\)\s*$',
                     '(?m)^## Error Handling\s*$',

--- a/.github/scripts/Tests/conductor-body-size.Tests.ps1
+++ b/.github/scripts/Tests/conductor-body-size.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Code-Conductor shared-body size contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ConductorBodyPath = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
+        $script:ConductorBodyPath = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
         $script:ConductorBody = (Get-Content -Path $script:ConductorBodyPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
         $script:ConductorLineCount = if ([string]::IsNullOrEmpty($script:ConductorBody)) {
             0

--- a/.github/scripts/Tests/conductor-hub-mode-planning-regression.Tests.ps1
+++ b/.github/scripts/Tests/conductor-hub-mode-planning-regression.Tests.ps1
@@ -15,8 +15,8 @@ Describe 'Code-Conductor hub-mode planning regression contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:OrchestrateCommandPath = Join-Path $script:RepoRoot 'commands\orchestrate.md'
-        $script:ConductorBodyPath = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
+        $script:OrchestrateCommandPath = Join-Path $script:RepoRoot 'commands/orchestrate.md'
+        $script:ConductorBodyPath = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
 
         $script:OrchestrateCommand = (Get-Content -Path $script:OrchestrateCommandPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
         $script:ConductorBody = (Get-Content -Path $script:ConductorBodyPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"

--- a/.github/scripts/Tests/conductor-review-routing-regression.Tests.ps1
+++ b/.github/scripts/Tests/conductor-review-routing-regression.Tests.ps1
@@ -15,8 +15,8 @@ Describe 'Code-Conductor review routing regression contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ConductorBodyPath = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
-        $script:ReviewReferencePath = Join-Path $script:RepoRoot 'skills\validation-methodology\references\review-reconciliation.md'
+        $script:ConductorBodyPath = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
+        $script:ReviewReferencePath = Join-Path $script:RepoRoot 'skills/validation-methodology/references/review-reconciliation.md'
 
         $script:ConductorBody = (Get-Content -Path $script:ConductorBodyPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
         $script:ReviewReference = (Get-Content -Path $script:ReviewReferencePath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"

--- a/.github/scripts/Tests/continuation-contract.Tests.ps1
+++ b/.github/scripts/Tests/continuation-contract.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'continuation contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CodeConductor = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
+        $script:CodeConductor = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
 
         $script:ReadContent = {
             param([string]$Path)

--- a/.github/scripts/Tests/copilot-ce-gate-regression.Tests.ps1
+++ b/.github/scripts/Tests/copilot-ce-gate-regression.Tests.ps1
@@ -15,8 +15,8 @@ Describe 'Copilot CE Gate regression contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ConductorBodyPath = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
-        $script:OrchestratePromptPath = Join-Path $script:RepoRoot '.github\prompts\orchestrate.prompt.md'
+        $script:ConductorBodyPath = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
+        $script:OrchestratePromptPath = Join-Path $script:RepoRoot '.github/prompts/orchestrate.prompt.md'
         $script:CanonicalReference = 'skills/customer-experience/references/orchestration-protocol.md'
         $script:CompositeSkillPath = 'skills/customer-experience/SKILL.md'
 

--- a/.github/scripts/Tests/cost-anomaly.Tests.ps1
+++ b/.github/scripts/Tests/cost-anomaly.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe 'Get-CostAnomalyFlags' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\cost-anomaly.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-anomaly.ps1'
         if (Test-Path $script:LibPath) {
             . $script:LibPath
         }

--- a/.github/scripts/Tests/cost-attribution.Tests.ps1
+++ b/.github/scripts/Tests/cost-attribution.Tests.ps1
@@ -3,9 +3,9 @@
 
 Describe 'Get-CostAttribution' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\cost-attribution.ps1'
-        $script:RendererPath = Join-Path $PSScriptRoot '..\lib\cost-pattern-renderer.ps1'
-        $script:RateTablePath = Join-Path $PSScriptRoot '..\lib\cost-rate-table.json'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-attribution.ps1'
+        $script:RendererPath = Join-Path $PSScriptRoot '../lib/cost-pattern-renderer.ps1'
+        $script:RateTablePath = Join-Path $PSScriptRoot '../lib/cost-rate-table.json'
 
         if (Test-Path $script:LibPath) {
             . $script:LibPath

--- a/.github/scripts/Tests/cost-completeness.Tests.ps1
+++ b/.github/scripts/Tests/cost-completeness.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe 'Get-SessionCompleteness' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\cost-completeness.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-completeness.ps1'
         if (Test-Path $script:LibPath) {
             . $script:LibPath
         }
@@ -180,7 +180,7 @@ Describe 'Get-SessionCompleteness' {
 
 Describe 'Resolve-CostDataPreservation' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\cost-completeness.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-completeness.ps1'
         if (Test-Path $script:LibPath) {
             . $script:LibPath
         }

--- a/.github/scripts/Tests/cost-pattern-renderer.Tests.ps1
+++ b/.github/scripts/Tests/cost-pattern-renderer.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe 'Format-CostPatternMarkdown' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\cost-pattern-renderer.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-pattern-renderer.ps1'
         if (Test-Path $script:LibPath) {
             . $script:LibPath
         }
@@ -480,7 +480,7 @@ Describe 'Format-CostPatternMarkdown' {
 
 Describe 'Format-CostPatternYaml' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\cost-pattern-renderer.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-pattern-renderer.ps1'
         if (Test-Path $script:LibPath) {
             . $script:LibPath
         }
@@ -676,7 +676,7 @@ Describe 'Format-CostPatternYaml' {
 
 Describe 'cost-pattern-data schema documentation' {
     It 'documents the post-#488 additive YAML fields' {
-        $schemaPath = Join-Path $PSScriptRoot '..\lib\cost-pattern-data-schema.md'
+        $schemaPath = Join-Path $PSScriptRoot '../lib/cost-pattern-data-schema.md'
         $schemaPath | Should -Exist
         $schema = Get-Content -LiteralPath $schemaPath -Raw
 

--- a/.github/scripts/Tests/cost-rate-table.Tests.ps1
+++ b/.github/scripts/Tests/cost-rate-table.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'cost-rate-table.json' {
     BeforeAll {
-        $script:TablePath = Join-Path $PSScriptRoot '..\lib\cost-rate-table.json'
-        $script:AttributionLibPath = Join-Path $PSScriptRoot '..\lib\cost-attribution.ps1'
+        $script:TablePath = Join-Path $PSScriptRoot '../lib/cost-rate-table.json'
+        $script:AttributionLibPath = Join-Path $PSScriptRoot '../lib/cost-attribution.ps1'
         $script:Table = $null
         if (Test-Path $script:TablePath) {
             $script:Table = Get-Content $script:TablePath -Raw | ConvertFrom-Json

--- a/.github/scripts/Tests/cost-walker-copilot.Tests.ps1
+++ b/.github/scripts/Tests/cost-walker-copilot.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe 'Copilot cost walker helpers' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\cost-walker-copilot.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-walker-copilot.ps1'
         if (Test-Path $script:LibPath) {
             . $script:LibPath
         }
@@ -61,12 +61,12 @@ Describe 'Copilot cost walker helpers' {
 
 Describe 'Invoke-CostCopilotWalk' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\cost-walker-copilot.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-walker-copilot.ps1'
         if (Test-Path $script:LibPath) {
             . $script:LibPath
         }
 
-        $script:FixtureDir = Join-Path $PSScriptRoot 'fixtures\cost-walker-copilot'
+        $script:FixtureDir = Join-Path $PSScriptRoot 'fixtures/cost-walker-copilot'
         $script:FixtureJsonl = Join-Path $script:FixtureDir 'copilot-chat.jsonl'
         $script:SyntheticReflog = Join-Path $script:FixtureDir 'synthetic-reflog.txt'
         $script:RepoRoot = 'C:\Users\Micah\Code 2\copilot-orchestra'

--- a/.github/scripts/Tests/cost-walker-coverage-doc.Tests.ps1
+++ b/.github/scripts/Tests/cost-walker-coverage-doc.Tests.ps1
@@ -3,7 +3,7 @@
 Describe 'cost walker coverage design documentation' {
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:DocPath = Join-Path $script:RepoRoot 'Documents\Design\cost-walker-coverage.md'
+        $script:DocPath = Join-Path $script:RepoRoot 'Documents/Design/cost-walker-coverage.md'
         $script:ExpectedH2Headings = @(
             '## Active attribution rules'
             '## Ambiguous-prompt fallback'

--- a/.github/scripts/Tests/cost-walker.Tests.ps1
+++ b/.github/scripts/Tests/cost-walker.Tests.ps1
@@ -3,10 +3,10 @@
 
 Describe 'Get-CostTranscriptSlug' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\cost-walker.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-walker.ps1'
         if (Test-Path $script:LibPath) {
             . $script:LibPath
-            . (Join-Path $PSScriptRoot '..\lib\path-normalize.ps1')
+            . (Join-Path $PSScriptRoot '../lib/path-normalize.ps1')
         }
     }
 
@@ -36,10 +36,10 @@ Describe 'Get-CostTranscriptSlug' {
 
 Describe 'Invoke-CostTranscriptWalk' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\cost-walker.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-walker.ps1'
         if (Test-Path $script:LibPath) {
             . $script:LibPath
-            . (Join-Path $PSScriptRoot '..\lib\path-normalize.ps1')
+            . (Join-Path $PSScriptRoot '../lib/path-normalize.ps1')
         }
 
         # Helper: write a JSONL file from an array of event hashtables
@@ -441,7 +441,7 @@ Describe 'Invoke-CostTranscriptWalk' {
                 $null = New-Item -ItemType Directory -Path $slugDir -Force
 
                 # Copy committed fixtures into the temp slug dir
-                $fixtureDir = Join-Path $PSScriptRoot 'fixtures\phase-marker-sessions'
+                $fixtureDir = Join-Path $PSScriptRoot 'fixtures/phase-marker-sessions'
                 Copy-Item -Path (Join-Path $fixtureDir 'phase-marker-529.jsonl') -Destination (Join-Path $slugDir 'session.jsonl')
                 Copy-Item -Path (Join-Path $fixtureDir 'phase-marker-529b.jsonl') -Destination (Join-Path $slugDir 'session2.jsonl')
 
@@ -541,7 +541,7 @@ Describe 'Invoke-CostTranscriptWalk' {
                 $subagDir = Join-Path $slugDir 'subagents'
                 $null = New-Item -ItemType Directory -Path $subagDir -Force
 
-                $fixtureDir = Join-Path $PSScriptRoot 'fixtures\phase-marker-sessions'
+                $fixtureDir = Join-Path $PSScriptRoot 'fixtures/phase-marker-sessions'
                 Copy-Item -Path (Join-Path $fixtureDir 'phase-marker-529.jsonl') -Destination (Join-Path $slugDir 'session.jsonl')
                 Copy-Item -Path (Join-Path $fixtureDir 'phase-marker-529b.jsonl') -Destination (Join-Path $slugDir 'session2.jsonl')
 
@@ -568,7 +568,7 @@ Describe 'Invoke-CostTranscriptWalk' {
                 $slugDir = Join-Path $tmp $slug
                 $null = New-Item -ItemType Directory -Path $slugDir -Force
 
-                $fixtureDir = Join-Path $PSScriptRoot 'fixtures\phase-marker-sessions'
+                $fixtureDir = Join-Path $PSScriptRoot 'fixtures/phase-marker-sessions'
                 Copy-Item -Path (Join-Path $fixtureDir 'phase-marker-529.jsonl') -Destination (Join-Path $slugDir 'session.jsonl')
                 Copy-Item -Path (Join-Path $fixtureDir 'phase-marker-529b.jsonl') -Destination (Join-Path $slugDir 'session2.jsonl')
 

--- a/.github/scripts/Tests/create-improvement-issue.Tests.ps1
+++ b/.github/scripts/Tests/create-improvement-issue.Tests.ps1
@@ -14,8 +14,8 @@
 Describe 'Invoke-CreateImprovementIssue' -Tag 'no-gh' {
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CorePath = Join-Path $script:RepoRoot 'skills\calibration-pipeline\scripts\create-improvement-issue-core.ps1'
-        $script:WrapperPath = Join-Path $script:RepoRoot 'skills\calibration-pipeline\scripts\create-improvement-issue.ps1'
+        $script:CorePath = Join-Path $script:RepoRoot 'skills/calibration-pipeline/scripts/create-improvement-issue-core.ps1'
+        $script:WrapperPath = Join-Path $script:RepoRoot 'skills/calibration-pipeline/scripts/create-improvement-issue.ps1'
         . $script:CorePath
 
         # ── temp root for all test data ──────────────────────────────

--- a/.github/scripts/Tests/credit-row-schema-conformance.Tests.ps1
+++ b/.github/scripts/Tests/credit-row-schema-conformance.Tests.ps1
@@ -37,10 +37,10 @@ BeforeAll {
         . $script:BackDeriveLib
     }
 
-    $script:AuditFixtureDir = Join-Path $script:RepoRoot 'frame\audit-fixtures'
+    $script:AuditFixtureDir = Join-Path $script:RepoRoot 'frame/audit-fixtures'
     $script:FixtureDir = Join-Path $PSScriptRoot 'fixtures'
-    $script:PortsDir = Join-Path $script:RepoRoot 'frame\ports'
-    $script:CeGateAdaptersDir = Join-Path $script:RepoRoot 'skills\customer-experience\adapters'
+    $script:PortsDir = Join-Path $script:RepoRoot 'frame/ports'
+    $script:CeGateAdaptersDir = Join-Path $script:RepoRoot 'skills/customer-experience/adapters'
 
     # Per-port allowed-status enum map.
     $script:AllowedStatusByPortPattern = @{

--- a/.github/scripts/Tests/find-or-upsert-comment.Tests.ps1
+++ b/.github/scripts/Tests/find-or-upsert-comment.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe 'Find-OrUpsertComment' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\find-or-upsert-comment.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/find-or-upsert-comment.ps1'
     }
 
     BeforeEach {
@@ -231,7 +231,7 @@ Describe 'Find-OrUpsertComment' {
 Describe 'Get-RestCommentId helper — static structure (AC6)' {
 
     BeforeAll {
-        $script:Ac6LibPath = Join-Path $PSScriptRoot '..\lib\find-or-upsert-comment.ps1'
+        $script:Ac6LibPath = Join-Path $PSScriptRoot '../lib/find-or-upsert-comment.ps1'
         $libContent = Get-Content -Path $script:Ac6LibPath -Raw
         $script:Ac6ParseErrors = $null
         $script:Ac6LibAst = [System.Management.Automation.Language.Parser]::ParseInput(

--- a/.github/scripts/Tests/frame-architecture-anchors.Tests.ps1
+++ b/.github/scripts/Tests/frame-architecture-anchors.Tests.ps1
@@ -5,7 +5,7 @@ Describe 'frame-architecture.md anchor presence' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:DocPath = Join-Path $script:RepoRoot 'Documents\Design\frame-architecture.md'
+        $script:DocPath = Join-Path $script:RepoRoot 'Documents/Design/frame-architecture.md'
         $script:DocContent = if (Test-Path $script:DocPath) { Get-Content -Raw -Path $script:DocPath } else { '' }
     }
 

--- a/.github/scripts/Tests/frame-audit-report.Tests.ps1
+++ b/.github/scripts/Tests/frame-audit-report.Tests.ps1
@@ -5,10 +5,10 @@ Describe 'Invoke-FrameAuditReport' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:LibFile = Join-Path $script:RepoRoot '.github\scripts\lib\frame-audit-report-core.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot '.github/scripts/lib/frame-audit-report-core.ps1'
         $script:FixtureDir = Join-Path $PSScriptRoot 'fixtures'
-        $script:AuditFixtureDir = Join-Path $script:RepoRoot 'frame\audit-fixtures'
-        $script:PortsDir = Join-Path $script:RepoRoot 'frame\ports'
+        $script:AuditFixtureDir = Join-Path $script:RepoRoot 'frame/audit-fixtures'
+        $script:PortsDir = Join-Path $script:RepoRoot 'frame/ports'
 
         if (Test-Path $script:LibFile) {
             . $script:LibFile

--- a/.github/scripts/Tests/frame-back-derive.Tests.ps1
+++ b/.github/scripts/Tests/frame-back-derive.Tests.ps1
@@ -22,10 +22,10 @@ Describe 'Invoke-FrameBackDerive' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:LibFile = Join-Path $script:RepoRoot '.github\scripts\lib\frame-back-derive-core.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot '.github/scripts/lib/frame-back-derive-core.ps1'
         $script:FixtureDir = Join-Path $PSScriptRoot 'fixtures'
-        $script:AuditFixtureDir = Join-Path $script:RepoRoot 'frame\audit-fixtures'
-        $script:PortsDir = Join-Path $script:RepoRoot 'frame\ports'
+        $script:AuditFixtureDir = Join-Path $script:RepoRoot 'frame/audit-fixtures'
+        $script:PortsDir = Join-Path $script:RepoRoot 'frame/ports'
 
         if (Test-Path $script:LibFile) {
             . $script:LibFile

--- a/.github/scripts/Tests/frame-no-enforcement.Tests.ps1
+++ b/.github/scripts/Tests/frame-no-enforcement.Tests.ps1
@@ -6,14 +6,14 @@ Describe 'frame audit-only boundary' {
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         $script:FrameWrappers = @(
-            (Join-Path $script:RepoRoot '.github\scripts\frame-back-derive.ps1'),
-            (Join-Path $script:RepoRoot '.github\scripts\frame-audit-report.ps1')
+            (Join-Path $script:RepoRoot '.github/scripts/frame-back-derive.ps1'),
+            (Join-Path $script:RepoRoot '.github/scripts/frame-audit-report.ps1')
         )
         $script:HookFiles = @(
             (Join-Path $script:RepoRoot 'hooks.json'),
-            (Join-Path $script:RepoRoot 'hooks\hooks.json')
+            (Join-Path $script:RepoRoot 'hooks/hooks.json')
         ) | Where-Object { Test-Path $_ }
-        $script:WorkflowDir = Join-Path $script:RepoRoot '.github\workflows'
+        $script:WorkflowDir = Join-Path $script:RepoRoot '.github/workflows'
 
         $script:RequireWrappers = {
             $missing = @($script:FrameWrappers | Where-Object { -not (Test-Path $_) })

--- a/.github/scripts/Tests/frame-port-files.Tests.ps1
+++ b/.github/scripts/Tests/frame-port-files.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'frame port manifest' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:PortsDir = Join-Path $script:RepoRoot 'frame\ports'
+        $script:PortsDir = Join-Path $script:RepoRoot 'frame/ports'
 
         $script:RequirePortsDir = {
             if (-not (Test-Path $script:PortsDir)) {

--- a/.github/scripts/Tests/frame-predicate.Tests.ps1
+++ b/.github/scripts/Tests/frame-predicate.Tests.ps1
@@ -303,7 +303,7 @@ Describe 'ConvertTo-FVPredicate' -Tag 'unit' {
 
 Describe 'Test-FVPredicateAgainstChangeset' {
     BeforeAll {
-        $script:CorePath = Join-Path $PSScriptRoot '..\lib\frame-predicate-core.ps1'
+        $script:CorePath = Join-Path $PSScriptRoot '../lib/frame-predicate-core.ps1'
         . $script:CorePath
     }
 

--- a/.github/scripts/Tests/frame-spine-lookup-skill.Tests.ps1
+++ b/.github/scripts/Tests/frame-spine-lookup-skill.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'frame-spine-lookup skill contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:SkillPath = Join-Path $script:RepoRoot 'skills\frame-spine-lookup\SKILL.md'
+        $script:SkillPath = Join-Path $script:RepoRoot 'skills/frame-spine-lookup/SKILL.md'
         $script:ClaudeSpecialistShellPaths = @(
             'agents/code-smith.md',
             'agents/test-writer.md',
@@ -33,7 +33,7 @@ Describe 'frame-spine-lookup skill contract' {
         )
 
         # Research-Agent deferral: excluded because it has no execute/* grant; Copilot spine lookup deferred per #514 Step 12
-        $script:ClaudePlatformPath = Join-Path $script:RepoRoot 'skills\frame-spine-lookup\platforms\claude.md'
+        $script:ClaudePlatformPath = Join-Path $script:RepoRoot 'skills/frame-spine-lookup/platforms/claude.md'
 
         $script:ReadContent = {
             param([Parameter(Mandatory)][string]$Path)
@@ -134,7 +134,7 @@ Describe 'frame-spine-lookup skill contract' {
             # Copilot parity shipped in #514 - the "deferred to #514" claim must be retired
             $script:SkillContent | Should -Not -Match '(?is)Copilot\s+tool\s+shim.{0,160}deferred' -Because 'Copilot spine lookup shipped in #514; the deferred claim must be retired'
             # platforms/copilot.md must exist as evidence Copilot parity landed
-            Test-Path -LiteralPath (Join-Path $script:RepoRoot 'skills\frame-spine-lookup\platforms\copilot.md') | Should -BeTrue -Because 'Copilot parity shipped in #514 requires platforms/copilot.md to exist'
+            Test-Path -LiteralPath (Join-Path $script:RepoRoot 'skills/frame-spine-lookup/platforms/copilot.md') | Should -BeTrue -Because 'Copilot parity shipped in #514 requires platforms/copilot.md to exist'
             $script:SkillContent | Should -Match '(?is)custom\s+MCP\s+server.{0,160}(deferred|non-goals?|non-goal)|(deferred|non-goals?|non-goal).{0,160}custom\s+MCP\s+server' -Because 'custom MCP server work is out of scope for this skill'
         }
     }

--- a/.github/scripts/Tests/handoff-persistence-contract.Tests.ps1
+++ b/.github/scripts/Tests/handoff-persistence-contract.Tests.ps1
@@ -33,15 +33,15 @@ Describe 'execution handoff persistence contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:IssuePlanner = Join-Path $script:RepoRoot 'agents\Issue-Planner.agent.md'
-        $script:CodeConductor = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
-        $script:CopilotInstructions = Join-Path $script:RepoRoot '.github\copilot-instructions.md'
-        $script:ExperienceOwner = Join-Path $script:RepoRoot 'agents\Experience-Owner.agent.md'
-        $script:SolutionDesigner = Join-Path $script:RepoRoot 'agents\Solution-Designer.agent.md'
-        $script:TrackingInstructions = Join-Path $script:RepoRoot 'skills\tracking-format\SKILL.md'
-        $script:StartIssuePrompt = Join-Path $script:RepoRoot '.github\prompts\start-issue.prompt.md'
-        $script:PlanStorage = Join-Path $script:RepoRoot 'Documents\Design\plan-storage.md'
-        $script:HubModeUx = Join-Path $script:RepoRoot 'Documents\Design\hub-mode-ux.md'
+        $script:IssuePlanner = Join-Path $script:RepoRoot 'agents/Issue-Planner.agent.md'
+        $script:CodeConductor = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
+        $script:CopilotInstructions = Join-Path $script:RepoRoot '.github/copilot-instructions.md'
+        $script:ExperienceOwner = Join-Path $script:RepoRoot 'agents/Experience-Owner.agent.md'
+        $script:SolutionDesigner = Join-Path $script:RepoRoot 'agents/Solution-Designer.agent.md'
+        $script:TrackingInstructions = Join-Path $script:RepoRoot 'skills/tracking-format/SKILL.md'
+        $script:StartIssuePrompt = Join-Path $script:RepoRoot '.github/prompts/start-issue.prompt.md'
+        $script:PlanStorage = Join-Path $script:RepoRoot 'Documents/Design/plan-storage.md'
+        $script:HubModeUx = Join-Path $script:RepoRoot 'Documents/Design/hub-mode-ux.md'
         $script:PipelineEntryAgents = @(
             @{
                 Name = 'Experience-Owner'

--- a/.github/scripts/Tests/inline-dispatch-contract.Tests.ps1
+++ b/.github/scripts/Tests/inline-dispatch-contract.Tests.ps1
@@ -31,12 +31,12 @@ Describe 'inline dispatch contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:SessionStartupSkill = Join-Path $script:RepoRoot 'skills\session-startup\SKILL.md'
-        $script:ClaudeDispatcherPath = Join-Path $script:RepoRoot 'skills\adversarial-review\platforms\claude.md'
+        $script:SessionStartupSkill = Join-Path $script:RepoRoot 'skills/session-startup/SKILL.md'
+        $script:ClaudeDispatcherPath = Join-Path $script:RepoRoot 'skills/adversarial-review/platforms/claude.md'
         $script:ClaudeDispatcherContent = Get-Content -Path $script:ClaudeDispatcherPath -Raw -ErrorAction Stop
 
         $script:GetPlanEffectiveContract = {
-            $planContent = Get-Content -Path (Join-Path $script:RepoRoot 'commands\plan.md') -Raw -ErrorAction Stop
+            $planContent = Get-Content -Path (Join-Path $script:RepoRoot 'commands/plan.md') -Raw -ErrorAction Stop
             return ($planContent + "`n" + $script:ClaudeDispatcherContent)
         }
 
@@ -272,7 +272,7 @@ Describe 'inline dispatch contract' {
     }
 
     It 'requires /orchestrate to adopt Code-Conductor inline after D1 body resolution' {
-        $content = Get-Content -Path (Join-Path $script:RepoRoot 'commands\orchestrate.md') -Raw -ErrorAction Stop
+        $content = Get-Content -Path (Join-Path $script:RepoRoot 'commands/orchestrate.md') -Raw -ErrorAction Stop
 
         $content | Should -Match '(?is)(load|resolve).{0,300}agents/Code-Conductor\.agent\.md' -Because '/orchestrate must carry the session-startup load reference naming the Code-Conductor paired body'
 
@@ -280,7 +280,7 @@ Describe 'inline dispatch contract' {
     }
 
     It 'requires /orchestrate to reconstruct downstream Agent handshakes live per dispatch' {
-        $content = Get-Content -Path (Join-Path $script:RepoRoot 'commands\orchestrate.md') -Raw -ErrorAction Stop
+        $content = Get-Content -Path (Join-Path $script:RepoRoot 'commands/orchestrate.md') -Raw -ErrorAction Stop
 
         $content | Should -Match '(?is)(before each|immediately before each|for each|for every|per-dispatch).{0,180}`?Agent`?.{0,160}dispatch.{0,240}(reconstruct|recapture|capture).{0,220}(HEAD|branch).{0,220}(CWD|dirty)' -Because '/orchestrate must document live handshake reconstruction for each downstream Agent dispatch'
         $content | Should -Match '(?is)((do not|must not).{0,160}(reuse|carry forward).{0,160}(command-entry|entry-time|single).{0,120}handshake|(command-entry|entry-time|single).{0,120}handshake.{0,160}(must not|do not).{0,120}(reuse|carry forward))' -Because '/orchestrate must explicitly reject a single command-entry-captured handshake for downstream Agent calls'
@@ -314,7 +314,7 @@ Describe 'inline dispatch contract' {
     }
 
     It 'forbids /plan from documenting a single once-per-invocation pipeline handshake' {
-        $content = Get-Content -Path (Join-Path $script:RepoRoot 'commands\plan.md') -Raw -ErrorAction Stop
+        $content = Get-Content -Path (Join-Path $script:RepoRoot 'commands/plan.md') -Raw -ErrorAction Stop
 
         $content | Should -Not -Match '(?is)construct.{0,100}parent-side\s+environment\s+handshake.{0,100}once.{0,80}`?/plan`?.{0,80}invocation' -Because '/plan must not say or imply that one handshake is constructed once for the whole command invocation'
     }
@@ -384,7 +384,7 @@ Describe 'inline dispatch contract' {
     }
 
     It 'documents the #498 DRY reshape, provenance-gate retirement, and #414 Copilot asymmetry in the test header' {
-        $content = Get-Content -Path (Join-Path $script:RepoRoot '.github\scripts\Tests\inline-dispatch-contract.Tests.ps1') -Raw -ErrorAction Stop
+        $content = Get-Content -Path (Join-Path $script:RepoRoot '.github/scripts/Tests/inline-dispatch-contract.Tests.ps1') -Raw -ErrorAction Stop
 
         $content | Should -Match ([regex]::Escape('Issue #498 reshaped the command-file pre-flight surface')) -Because 'the test header must explain the #498 DRY reshape of the command-file pre-flight prose'
         $content | Should -Match ([regex]::Escape('provenance-gate retirement')) -Because 'the test header must explain the provenance-gate retirement and upstream-onboarding ownership transfer'

--- a/.github/scripts/Tests/intent-routing-collisions.Tests.ps1
+++ b/.github/scripts/Tests/intent-routing-collisions.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Natural-language intent routing collision fixture contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:FixturePath = Join-Path $script:RepoRoot '.github\scripts\Tests\fixtures\intent-routing-collisions.yml'
+        $script:FixturePath = Join-Path $script:RepoRoot '.github/scripts/Tests/fixtures/intent-routing-collisions.yml'
         $script:YamlText = Get-Content -Path $script:FixturePath -Raw
 
         $script:ConvertCollisionFixtureValue = {

--- a/.github/scripts/Tests/measure-guidance-complexity.Tests.ps1
+++ b/.github/scripts/Tests/measure-guidance-complexity.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'measure-guidance-complexity.ps1' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:LibFile = Join-Path $script:RepoRoot 'skills\guidance-measurement\scripts\measure-guidance-complexity-core.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot 'skills/guidance-measurement/scripts/measure-guidance-complexity-core.ps1'
         . $script:LibFile
 
         # Session-scoped temp root — all per-test dirs live under here

--- a/.github/scripts/Tests/nl-intent-routing.Tests.ps1
+++ b/.github/scripts/Tests/nl-intent-routing.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Natural-language intent routing table contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:RoutingTablesCore = Join-Path $script:RepoRoot 'skills\routing-tables\scripts\routing-tables-core.ps1'
+        $script:RoutingTablesCore = Join-Path $script:RepoRoot 'skills/routing-tables/scripts/routing-tables-core.ps1'
 
         . $script:RoutingTablesCore
 

--- a/.github/scripts/Tests/normalize-whitespace.Tests.ps1
+++ b/.github/scripts/Tests/normalize-whitespace.Tests.ps1
@@ -24,8 +24,8 @@ Describe 'normalize-whitespace.ps1' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:HelperPath = Join-Path $script:RepoRoot '.github\scripts\normalize-whitespace.ps1'
-        $script:LibFile = Join-Path $script:RepoRoot '.github\scripts\lib\normalize-whitespace-core.ps1'
+        $script:HelperPath = Join-Path $script:RepoRoot '.github/scripts/normalize-whitespace.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot '.github/scripts/lib/normalize-whitespace-core.ps1'
         . $script:LibFile
 
         $script:TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
@@ -255,7 +255,7 @@ Describe '.githooks/pre-commit whitespace-lane ownership contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:HookPath = Join-Path $script:RepoRoot '.githooks\pre-commit'
+        $script:HookPath = Join-Path $script:RepoRoot '.githooks/pre-commit'
         $script:HookContent = Get-Content -Path $script:HookPath -Raw
 
         $script:GetGenericSelectorPattern = {

--- a/.github/scripts/Tests/orchestra-review-commands.Tests.ps1
+++ b/.github/scripts/Tests/orchestra-review-commands.Tests.ps1
@@ -19,9 +19,9 @@ Describe 'orchestra-review command contract' {
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         $script:CommandsDirectory = Join-Path $script:RepoRoot 'commands'
-        $script:ClaudeDispatcherPath = Join-Path $script:RepoRoot 'skills\adversarial-review\platforms\claude.md'
+        $script:ClaudeDispatcherPath = Join-Path $script:RepoRoot 'skills/adversarial-review/platforms/claude.md'
         $script:ClaudeDispatcherContent = Get-Content -Path $script:ClaudeDispatcherPath -Raw -ErrorAction Stop
-        $script:RoutingConfigPath = Join-Path $script:RepoRoot 'skills\routing-tables\assets\routing-config.json'
+        $script:RoutingConfigPath = Join-Path $script:RepoRoot 'skills/routing-tables/assets/routing-config.json'
         $script:RoutingConfig = Get-Content -Path $script:RoutingConfigPath -Raw | ConvertFrom-Json -AsHashtable
         $script:CanonicalMarkers = @(
             $script:RoutingConfig.review_mode_routing.entries |

--- a/.github/scripts/Tests/orchestra-review-handshake.Tests.ps1
+++ b/.github/scripts/Tests/orchestra-review-handshake.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'orchestra-review handshake contract' {
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         $script:CommandsDirectory = Join-Path $script:RepoRoot 'commands'
-        $script:ClaudeDispatcherPath = Join-Path $script:RepoRoot 'skills\adversarial-review\platforms\claude.md'
+        $script:ClaudeDispatcherPath = Join-Path $script:RepoRoot 'skills/adversarial-review/platforms/claude.md'
         $script:ClaudeDispatcherContent = Get-Content -Path $script:ClaudeDispatcherPath -Raw -ErrorAction Stop
         $script:RequiredHandshakeCommands = @(
             [pscustomobject]@{ Name = 'orchestra-review'; Path = Join-Path $script:CommandsDirectory 'orchestra-review.md' },

--- a/.github/scripts/Tests/orchestra-review-ledger-schema.Tests.ps1
+++ b/.github/scripts/Tests/orchestra-review-ledger-schema.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'orchestra-review ledger schema compatibility contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ReviewJudgmentSkillPath = Join-Path $script:RepoRoot 'skills\review-judgment\SKILL.md'
+        $script:ReviewJudgmentSkillPath = Join-Path $script:RepoRoot 'skills/review-judgment/SKILL.md'
         $script:ReviewJudgmentSkill = Get-Content -Path $script:ReviewJudgmentSkillPath -Raw
         $script:ExpectedKeys = @('id', 'judge_ruling', 'judge_confidence', 'points_awarded')
 

--- a/.github/scripts/Tests/orchestra-review-marker-emission.Tests.ps1
+++ b/.github/scripts/Tests/orchestra-review-marker-emission.Tests.ps1
@@ -19,9 +19,9 @@ Describe 'orchestra-review marker emission contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CodeReviewResponseShellPath = Join-Path $script:RepoRoot 'agents\code-review-response.md'
-        $script:CodeReviewResponseBodyPath = Join-Path $script:RepoRoot 'agents\Code-Review-Response.agent.md'
-        $script:ReviewJudgmentSkillPath = Join-Path $script:RepoRoot 'skills\review-judgment\SKILL.md'
+        $script:CodeReviewResponseShellPath = Join-Path $script:RepoRoot 'agents/code-review-response.md'
+        $script:CodeReviewResponseBodyPath = Join-Path $script:RepoRoot 'agents/Code-Review-Response.agent.md'
+        $script:ReviewJudgmentSkillPath = Join-Path $script:RepoRoot 'skills/review-judgment/SKILL.md'
         $script:JudgeRulingsPattern = '(?s)<!--\s*judge-rulings\s*\r?\n.*?\r?\n-->'
         $script:ScoreSummaryPattern = '###\s+Adversarial Review Score Summary'
         $script:SamePayloadPattern = '(?s)###\s+Adversarial Review Score Summary.*<!--\s*judge-rulings\s*\r?\n.*?\r?\n-->'

--- a/.github/scripts/Tests/orchestra-review-mode-trigger.Tests.ps1
+++ b/.github/scripts/Tests/orchestra-review-mode-trigger.Tests.ps1
@@ -15,11 +15,11 @@ Describe 'orchestra-review lite mode trigger contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:CodeCriticBodyPath = Join-Path $script:RepoRoot 'agents\Code-Critic.agent.md'
-        $script:CodeReviewResponseBodyPath = Join-Path $script:RepoRoot 'agents\Code-Review-Response.agent.md'
-        $script:CodeReviewIntakeSkillPath = Join-Path $script:RepoRoot 'skills\code-review-intake\SKILL.md'
-        $script:RoutingTablesSkillPath = Join-Path $script:RepoRoot 'skills\routing-tables\SKILL.md'
-        $script:RoutingConfigPath = Join-Path $script:RepoRoot 'skills\routing-tables\assets\routing-config.json'
+        $script:CodeCriticBodyPath = Join-Path $script:RepoRoot 'agents/Code-Critic.agent.md'
+        $script:CodeReviewResponseBodyPath = Join-Path $script:RepoRoot 'agents/Code-Review-Response.agent.md'
+        $script:CodeReviewIntakeSkillPath = Join-Path $script:RepoRoot 'skills/code-review-intake/SKILL.md'
+        $script:RoutingTablesSkillPath = Join-Path $script:RepoRoot 'skills/routing-tables/SKILL.md'
+        $script:RoutingConfigPath = Join-Path $script:RepoRoot 'skills/routing-tables/assets/routing-config.json'
         $script:CodeCriticBody = Get-Content -Path $script:CodeCriticBodyPath -Raw
         $script:CodeReviewResponseBody = Get-Content -Path $script:CodeReviewResponseBodyPath -Raw
         $script:CodeReviewIntakeSkill = Get-Content -Path $script:CodeReviewIntakeSkillPath -Raw
@@ -33,7 +33,7 @@ Describe 'orchestra-review lite mode trigger contract' {
             '(?ms)^## Review Mode Routing\s*\r?\n(?<body>.*?)(?=^## |\z)'
         ).Groups['body'].Value
 
-        $script:LiteCommandPath = Join-Path $script:RepoRoot 'commands\orchestra-review-lite.md'
+        $script:LiteCommandPath = Join-Path $script:RepoRoot 'commands/orchestra-review-lite.md'
         $script:LiteCommand = Get-Content -Path $script:LiteCommandPath -Raw
     }
 

--- a/.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1
+++ b/.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1
@@ -318,7 +318,8 @@ Describe 'Issue #664 backslash-Join-Path hygiene gate' -Tag 'issue-664', 'sweep-
             $script:Violations664 | Should -BeNullOrEmpty -Because (
                 "Join-Path child paths must not contain backslashes — use forward slashes or " +
                 "separate path segments as additional Join-Path arguments. " +
-                "To suppress a legitimate Windows-only reference add '# host-path-ok' on the same line. " +
+                "See .github/architecture-rules.md §Validation for the convention. " +
+                "To suppress a documented Windows-only exception add '# host-path-ok' on the same line. " +
                 "Violations:`n  " + ($script:Violations664 -join "`n  ")
             )
         }

--- a/.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1
+++ b/.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1
@@ -232,3 +232,119 @@ Describe 'Issue #367 path-migration sweep gate' -Tag 'issue-367', 'sweep-gate' {
         }
     }
 }
+
+Describe 'Issue #664 backslash-Join-Path hygiene gate' -Tag 'issue-664', 'sweep-gate' {
+    # Gate: no tracked .ps1 file may pass a single-quoted child path containing a
+    # backslash to Join-Path (e.g. Join-Path $x 'a\b') unless exempted.
+    #
+    # Detection regex (verbatim): Join-Path\s.*'[^']*\\[^']*'
+    #
+    # Matches any source line where:
+    #   1. The token "Join-Path" appears.
+    #   2. Followed by at least one whitespace character (\s).
+    #   3. Followed by any characters (.*).
+    #   4. Followed by a single-quoted string containing at least one backslash.
+    #
+    # Documented miss: double-quoted child paths (Join-Path $x "a\b") are NOT
+    # caught because the regex requires a single-quoted string. No known in-tree
+    # double-quoted backslash Join-Path calls exist at the time of authoring.
+    #
+    # Exemption mechanism (same convention as script-safety-contract.Tests.ps1):
+    #   - Full-line comments (TrimStart starts with '#') are skipped.
+    #   - Lines inside block comments are skipped.
+    #   - Lines containing the inline comment "# host-path-ok" are skipped.
+    #
+    # Scope: all git-ls-files-tracked .ps1 files, Tests-inclusive,
+    # excluding paths under .claude/worktrees and excluding this gate file
+    # itself (self-exclusion).
+    #
+    # Gate invariant: AC1 = guard-green.
+    # Non-goal: no conversions in this slice (s1). The gate is intentionally
+    # RED after s1 until s2 (production fixes) and s3 (Tests sweep) complete.
+    #
+    # To suppress a legitimate reference, add '# host-path-ok' on the same line.
+
+    BeforeAll {
+        $script:RepoRoot664 = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:GatePattern = "Join-Path\s.*'[^']*\\[^']*'"
+        # Self-exclusion: the gate file itself contains the pattern string and
+        # self-test literals — exclude it from the production scan.
+        $script:GateRelPath = '.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1'
+
+        Push-Location $script:RepoRoot664
+        try {
+            $allTracked = (& git ls-files) -split "`n" | Where-Object { $_ }
+        }
+        finally {
+            Pop-Location
+        }
+
+        # Scope: tracked .ps1 files, excluding .claude/worktrees, excluding gate file
+        $script:ScanFiles664 = $allTracked | Where-Object {
+            $_ -match '\.ps1$' -and
+            $_ -notmatch '^\.claude[/\\]worktrees[/\\]' -and
+            ($_ -replace '\\', '/') -ne $script:GateRelPath
+        }
+
+        $script:Violations664 = [System.Collections.Generic.List[string]]::new()
+        foreach ($rel in $script:ScanFiles664) {
+            $full = Join-Path $script:RepoRoot664 $rel
+            if (-not (Test-Path -LiteralPath $full -PathType Leaf)) { continue }
+            $lines = Get-Content -LiteralPath $full -ErrorAction SilentlyContinue
+            if (-not $lines) { continue }
+            $inBlock = $false
+            for ($i = 0; $i -lt $lines.Count; $i++) {
+                $line = $lines[$i]
+                # Track block-comment state (<# opens, #> closes)
+                if ($line -match '<#') { $inBlock = $true }
+                if ($inBlock) {
+                    if ($line -match '#>') { $inBlock = $false }
+                    continue
+                }
+                # Skip full-line comments
+                if ($line.TrimStart() -like '#*') { continue }
+                # Skip exempted lines
+                if ($line -match '# host-path-ok') { continue }
+                # Detect the pattern
+                if ($line -match $script:GatePattern) {
+                    $script:Violations664.Add(('{0}:{1}: {2}' -f $rel, ($i + 1), $line.Trim()))
+                }
+            }
+        }
+    }
+
+    Context 'Production scan' {
+        It 'No tracked .ps1 passes a backslash child path to Join-Path' {
+            $script:Violations664 | Should -BeNullOrEmpty -Because (
+                "Join-Path child paths must not contain backslashes — use forward slashes or " +
+                "separate path segments as additional Join-Path arguments. " +
+                "To suppress a legitimate Windows-only reference add '# host-path-ok' on the same line. " +
+                "Violations:`n  " + ($script:Violations664 -join "`n  ")
+            )
+        }
+    }
+
+    Context 'Self-tests' {
+        It 'Falsifiability: injected backslash child path is detected' {
+            # A literal that should match the detection regex
+            $injected = "Join-Path `$PSScriptRoot '..\assets\routing-config.json'"
+            $injected | Should -Match $script:GatePattern
+        }
+
+        It 'No false positives: in-tree negative patterns are not flagged' {
+            # Regex character class with backslash — no Join-Path prefix
+            $regexClass = "if (`$rel -match '[/\\]Tests([/\\]|`$)')"
+            $regexClass | Should -Not -Match $script:GatePattern
+
+            # Content assertion with backslash — no Join-Path prefix
+            $contentAssert = "`$content | Should -Be 'path\to\file'"
+            $contentAssert | Should -Not -Match $script:GatePattern
+        }
+
+        It 'Documented miss: double-quoted child path is not caught by regex' {
+            # Double-quoted form is the documented miss — outside regex scope
+            $doubleQuoted = 'Join-Path $x "a\b.md"'
+            $doubleQuoted | Should -Not -Match $script:GatePattern
+        }
+    }
+}

--- a/.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1
+++ b/.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1
@@ -237,17 +237,30 @@ Describe 'Issue #664 backslash-Join-Path hygiene gate' -Tag 'issue-664', 'sweep-
     # Gate: no tracked .ps1 file may pass a single-quoted child path containing a
     # backslash to Join-Path (e.g. Join-Path $x 'a\b') unless exempted.
     #
-    # Detection regex (verbatim): Join-Path\s.*'[^']*\\[^']*'
+    # Detection regex (verbatim): Join-Path\s.*'[^'\\]+\\[^']*'
     #
     # Matches any source line where:
     #   1. The token "Join-Path" appears.
     #   2. Followed by at least one whitespace character (\s).
     #   3. Followed by any characters (.*).
-    #   4. Followed by a single-quoted string containing at least one backslash.
+    #   4. Followed by a single-quoted string whose FIRST backslash is preceded
+    #      by at least one non-backslash, non-quote character ([^'\\]+) — i.e. a
+    #      relative-path child argument like '..\assets\x.json' or 'lib\y.ps1'.
     #
-    # Documented miss: double-quoted child paths (Join-Path $x "a\b") are NOT
-    # caught because the regex requires a single-quoted string. No known in-tree
-    # double-quoted backslash Join-Path calls exist at the time of authoring.
+    # Why the leading-char guard ([^'\\]+ rather than [^']*): the original
+    # [^']* form let greedy .* on a Join-Path line reach forward to an unrelated
+    # single-quoted regex operand later on the same line — e.g. a
+    # `-replace '\s+', '-'` argument — and mis-flag it as a path violation
+    # (false positive on review-completion-gate.Tests.ps1:167, issue #664 review).
+    # Requiring a non-backslash char before the first backslash excludes
+    # leading-backslash regex/escape literals ('\s+', '\d', '\.') while still
+    # catching every relative-path literal (which never leads with a separator).
+    #
+    # Documented misses (outside regex scope, no known in-tree instances):
+    #   - Double-quoted child paths (Join-Path $x "a\b") — regex requires a
+    #     single-quoted string.
+    #   - Leading-backslash single-quoted literals (Join-Path $x '\abs\path') —
+    #     absolute-from-root paths; excluded by the [^'\\]+ guard above.
     #
     # Exemption mechanism (same convention as script-safety-contract.Tests.ps1):
     #   - Full-line comments (TrimStart starts with '#') are skipped.
@@ -266,7 +279,7 @@ Describe 'Issue #664 backslash-Join-Path hygiene gate' -Tag 'issue-664', 'sweep-
 
     BeforeAll {
         $script:RepoRoot664 = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:GatePattern = "Join-Path\s.*'[^']*\\[^']*'"
+        $script:GatePattern = "Join-Path\s.*'[^'\\]+\\[^']*'"
         # Self-exclusion: the gate file itself contains the pattern string and
         # self-test literals — exclude it from the production scan.
         $script:GateRelPath = '.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1'
@@ -340,6 +353,19 @@ Describe 'Issue #664 backslash-Join-Path hygiene gate' -Tag 'issue-664', 'sweep-
             # Content assertion with backslash — no Join-Path prefix
             $contentAssert = "`$content | Should -Be 'path\to\file'"
             $contentAssert | Should -Not -Match $script:GatePattern
+        }
+
+        It 'No false positives: a regex operand on a Join-Path line is not flagged' {
+            # Regression guard (issue #664 review F1): a Join-Path with a
+            # double-quoted child path AND an unrelated -replace '\s+' regex
+            # operand later on the same line must NOT be flagged. The greedy
+            # .* in the original [^']* form mis-matched the '\s+' literal.
+            $regexOperandOnJoinPathLine = "`$path = Join-Path `$script:TempRoot (`"review-state-malformed-{0}.md`" -f (`$case.Name -replace '\s+', '-'))"
+            $regexOperandOnJoinPathLine | Should -Not -Match $script:GatePattern
+
+            # Leading-backslash literal (absolute-from-root) — documented miss
+            $leadingBackslash = "Join-Path `$x '\abs\path'"
+            $leadingBackslash | Should -Not -Match $script:GatePattern
         }
 
         It 'Documented miss: double-quoted child path is not caught by regex' {

--- a/.github/scripts/Tests/path-normalize.Tests.ps1
+++ b/.github/scripts/Tests/path-normalize.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe 'Get-NormalizedPath' {
     BeforeAll {
-        $script:LibPath = Join-Path $PSScriptRoot '..\lib\path-normalize.ps1'
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/path-normalize.ps1'
         if (Test-Path $script:LibPath) { . $script:LibPath }
     }
 

--- a/.github/scripts/Tests/plan-approval-prompt-contract.Tests.ps1
+++ b/.github/scripts/Tests/plan-approval-prompt-contract.Tests.ps1
@@ -24,8 +24,8 @@ Describe 'plan approval prompt contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:IssuePlanner = Join-Path $script:RepoRoot 'agents\Issue-Planner.agent.md'
-        $script:HubModeUx = Join-Path $script:RepoRoot 'Documents\Design\hub-mode-ux.md'
+        $script:IssuePlanner = Join-Path $script:RepoRoot 'agents/Issue-Planner.agent.md'
+        $script:HubModeUx = Join-Path $script:RepoRoot 'Documents/Design/hub-mode-ux.md'
 
         $script:ReadContent = {
             param([string]$Path)

--- a/.github/scripts/Tests/plan-authoring-tree-state-contract.Tests.ps1
+++ b/.github/scripts/Tests/plan-authoring-tree-state-contract.Tests.ps1
@@ -15,8 +15,8 @@ Describe 'Plan-authoring tree-state verification contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:PlanAuthoringPath = Join-Path $script:RepoRoot 'skills\plan-authoring\SKILL.md'
-        $script:IssuePlannerPath = Join-Path $script:RepoRoot 'agents\Issue-Planner.agent.md'
+        $script:PlanAuthoringPath = Join-Path $script:RepoRoot 'skills/plan-authoring/SKILL.md'
+        $script:IssuePlannerPath = Join-Path $script:RepoRoot 'agents/Issue-Planner.agent.md'
 
         $script:GetNormalizedContent = {
             param([string]$Path)

--- a/.github/scripts/Tests/plugin-hooks-config-contract.Tests.ps1
+++ b/.github/scripts/Tests/plugin-hooks-config-contract.Tests.ps1
@@ -6,11 +6,11 @@ Describe 'plugin hooks config contract' -Tag 'unit' {
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         $script:CopilotHooksConfig = Join-Path $script:RepoRoot 'hooks.json'
-        $script:ClaudeHooksConfig = Join-Path $script:RepoRoot 'hooks\hooks.json'
+        $script:ClaudeHooksConfig = Join-Path $script:RepoRoot 'hooks/hooks.json'
         $script:RootPluginManifest = Join-Path $script:RepoRoot 'plugin.json'
-        $script:ClaudePluginManifest = Join-Path $script:RepoRoot '.claude-plugin\plugin.json'
-        $script:CopilotMarketplaceManifest = Join-Path $script:RepoRoot '.github\plugin\marketplace.json'
-        $script:ClaudeMarketplaceManifest = Join-Path $script:RepoRoot '.claude-plugin\marketplace.json'
+        $script:ClaudePluginManifest = Join-Path $script:RepoRoot '.claude-plugin/plugin.json'
+        $script:CopilotMarketplaceManifest = Join-Path $script:RepoRoot '.github/plugin/marketplace.json'
+        $script:ClaudeMarketplaceManifest = Join-Path $script:RepoRoot '.claude-plugin/marketplace.json'
         $script:SessionStartScript = 'skills/session-startup/scripts/session-cleanup-detector.ps1'
         $script:ReleaseHygieneScript = 'skills/plugin-release-hygiene/scripts/plugin-release-hygiene-hook.ps1'
         $script:SessionStartMatcher = 'startup'

--- a/.github/scripts/Tests/plugin-release-hygiene.Tests.ps1
+++ b/.github/scripts/Tests/plugin-release-hygiene.Tests.ps1
@@ -5,8 +5,8 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:HookScript = Join-Path $script:RepoRoot 'skills\plugin-release-hygiene\scripts\plugin-release-hygiene-hook.ps1'
-        $script:SkillFile = Join-Path $script:RepoRoot 'skills\plugin-release-hygiene\SKILL.md'
+        $script:HookScript = Join-Path $script:RepoRoot 'skills/plugin-release-hygiene/scripts/plugin-release-hygiene-hook.ps1'
+        $script:SkillFile = Join-Path $script:RepoRoot 'skills/plugin-release-hygiene/SKILL.md'
         $script:ClaudeGuide = Join-Path $script:RepoRoot 'CLAUDE.md'
         $script:Readme = Join-Path $script:RepoRoot 'README.md'
         $script:FixtureRoots = [System.Collections.Generic.List[string]]::new()
@@ -29,7 +29,7 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
             $root = Join-Path ([System.IO.Path]::GetTempPath()) $Name
             $agentsDir = Join-Path $root 'agents'
-            $scriptsDir = Join-Path $root '.github\scripts'
+            $scriptsDir = Join-Path $root '.github/scripts'
 
             New-Item -ItemType Directory -Path $agentsDir -Force | Out-Null
             New-Item -ItemType Directory -Path $scriptsDir -Force | Out-Null
@@ -61,12 +61,12 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
             )
 
             New-Item -ItemType Directory -Path (Join-Path $Root '.claude-plugin') -Force | Out-Null
-            New-Item -ItemType Directory -Path (Join-Path $Root '.github\plugin') -Force | Out-Null
+            New-Item -ItemType Directory -Path (Join-Path $Root '.github/plugin') -Force | Out-Null
 
             Set-Content -Path (Join-Path $Root 'plugin.json') -Value "{`"version`":`"$Version`"}" -Encoding UTF8
-            Set-Content -Path (Join-Path $Root '.claude-plugin\plugin.json') -Value "{`"version`":`"$Version`"}" -Encoding UTF8
-            Set-Content -Path (Join-Path $Root '.claude-plugin\marketplace.json') -Value "{`"metadata`":{`"version`":`"$Version`"},`"plugins`": [{`"version`":`"$Version`"}]}" -Encoding UTF8
-            Set-Content -Path (Join-Path $Root '.github\plugin\marketplace.json') -Value "{`"metadata`":{`"version`":`"$Version`"},`"plugins`": [{`"version`":`"$Version`"}]}" -Encoding UTF8
+            Set-Content -Path (Join-Path $Root '.claude-plugin/plugin.json') -Value "{`"version`":`"$Version`"}" -Encoding UTF8
+            Set-Content -Path (Join-Path $Root '.claude-plugin/marketplace.json') -Value "{`"metadata`":{`"version`":`"$Version`"},`"plugins`": [{`"version`":`"$Version`"}]}" -Encoding UTF8
+            Set-Content -Path (Join-Path $Root '.github/plugin/marketplace.json') -Value "{`"metadata`":{`"version`":`"$Version`"},`"plugins`": [{`"version`":`"$Version`"}]}" -Encoding UTF8
             Set-Content -Path (Join-Path $Root 'README.md') -Value "[![Version](https://img.shields.io/badge/version-v$Version-blue.svg)](../../releases)" -Encoding UTF8
         }
 
@@ -119,7 +119,7 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
     It 'emits the hook JSON contract for the first entry-point edit' {
         $fixture = New-PluginReleaseHygieneFixture
-        $target = Join-Path $fixture 'agents\Example.agent.md'
+        $target = Join-Path $fixture 'agents/Example.agent.md'
         Set-Content -Path $target -Value '# Example' -Encoding UTF8
 
         $raw = Invoke-HookInFixture -FixtureRoot $fixture -FilePath $target
@@ -132,7 +132,7 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
     It 'emits hook JSON through the production entrypoint using stdin payload' {
         $fixture = New-PluginReleaseHygieneFixture
-        $target = Join-Path $fixture 'agents\Entrypoint.agent.md'
+        $target = Join-Path $fixture 'agents/Entrypoint.agent.md'
         Set-Content -Path $target -Value '# Entrypoint' -Encoding UTF8
         $payload = [PSCustomObject]@{
             hook_event_name = 'PostToolUse'
@@ -175,15 +175,15 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
     It 'coalesces repeated entry-point edits into one state file' {
         $fixture = New-PluginReleaseHygieneFixture
-        $first = Join-Path $fixture 'agents\First.agent.md'
-        $second = Join-Path $fixture 'commands\design.md'
+        $first = Join-Path $fixture 'agents/First.agent.md'
+        $second = Join-Path $fixture 'commands/design.md'
         New-Item -ItemType Directory -Path (Split-Path $second) -Force | Out-Null
         Set-Content -Path $first -Value '# First' -Encoding UTF8
         Set-Content -Path $second -Value '# Design' -Encoding UTF8
 
         $firstResult = Invoke-HookInFixture -FixtureRoot $fixture -FilePath $first
         $secondResult = Invoke-HookInFixture -FixtureRoot $fixture -FilePath $second
-        $statePath = Join-Path $fixture '.claude\.state\release-hygiene-389.json'
+        $statePath = Join-Path $fixture '.claude/.state/release-hygiene-389.json'
         $state = Get-Content -Path $statePath -Raw | ConvertFrom-Json
 
         [string]::IsNullOrWhiteSpace($firstResult) | Should -BeFalse
@@ -196,8 +196,8 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
     It 'coalesces repeated entry-point edits by session_id and records the strategy' {
         $fixture = New-PluginReleaseHygieneFixture
-        $first = Join-Path $fixture 'agents\First.agent.md'
-        $second = Join-Path $fixture 'commands\design.md'
+        $first = Join-Path $fixture 'agents/First.agent.md'
+        $second = Join-Path $fixture 'commands/design.md'
         $sessionId = 'session-422'
         New-Item -ItemType Directory -Path (Split-Path $second) -Force | Out-Null
         Set-Content -Path $first -Value '# First' -Encoding UTF8
@@ -205,7 +205,7 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
         $firstResult = Invoke-HookInFixture -FixtureRoot $fixture -FilePath $first -SessionId $sessionId
         $secondResult = Invoke-HookInFixture -FixtureRoot $fixture -FilePath $second -SessionId $sessionId
-        $statePath = Join-Path $fixture '.claude\.state\release-hygiene-session-422.json'
+        $statePath = Join-Path $fixture '.claude/.state/release-hygiene-session-422.json'
         $state = Get-Content -Path $statePath -Raw | ConvertFrom-Json
 
         [string]::IsNullOrWhiteSpace($firstResult) | Should -BeFalse
@@ -217,8 +217,8 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
     It 'updates keying_strategy when a later invocation uses a session_id for the same slug' {
         $fixture = New-PluginReleaseHygieneFixture
-        $first = Join-Path $fixture 'agents\First.agent.md'
-        $second = Join-Path $fixture 'commands\design.md'
+        $first = Join-Path $fixture 'agents/First.agent.md'
+        $second = Join-Path $fixture 'commands/design.md'
         New-Item -ItemType Directory -Path (Split-Path $second) -Force | Out-Null
         Set-Content -Path $first -Value '# First' -Encoding UTF8
         Set-Content -Path $second -Value '# Design' -Encoding UTF8
@@ -233,7 +233,7 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
         $firstResult = Invoke-HookInFixture -FixtureRoot $fixture -FilePath $first
         $secondResult = Invoke-HookInFixture -FixtureRoot $fixture -FilePath $second -SessionId '422'
-        $statePath = Join-Path $fixture '.claude\.state\release-hygiene-422.json'
+        $statePath = Join-Path $fixture '.claude/.state/release-hygiene-422.json'
         $state = Get-Content -Path $statePath -Raw | ConvertFrom-Json
 
         [string]::IsNullOrWhiteSpace($firstResult) | Should -BeFalse
@@ -243,7 +243,7 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
     It 'stays silent (no output) when plugin.json is already ahead of main but writes symmetric-bump credit to state file (issue #441, Step 7a)' {
         $fixture = New-PluginReleaseHygieneFixture
-        $target = Join-Path $fixture 'agents\Example.agent.md'
+        $target = Join-Path $fixture 'agents/Example.agent.md'
         Set-Content -Path $target -Value '# Example' -Encoding UTF8
 
         Push-Location $fixture
@@ -265,7 +265,7 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
         [string]::IsNullOrWhiteSpace($raw) | Should -BeTrue
 
         # Step 7a: hook now writes symmetric-bump credit to state file when version is already bumped.
-        $statePath = Join-Path $fixture '.claude\.state\release-hygiene-session-422-bumped.json'
+        $statePath = Join-Path $fixture '.claude/.state/release-hygiene-session-422-bumped.json'
         Test-Path $statePath | Should -BeTrue -Because 'symmetric-bump credit must be persisted when version is already bumped'
         $state = Get-Content $statePath -Raw | ConvertFrom-Json
         $state.symmetric_bump_credit        | Should -Not -BeNullOrEmpty
@@ -275,7 +275,7 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
     It 'does not stay silent when only part of the version set is bumped' {
         $fixture = New-PluginReleaseHygieneFixture
-        $target = Join-Path $fixture 'agents\Example.agent.md'
+        $target = Join-Path $fixture 'agents/Example.agent.md'
         Set-Content -Path $target -Value '# Example' -Encoding UTF8
 
         Push-Location $fixture
@@ -332,23 +332,23 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
     It 'fails open when the state path cannot be created' {
         $fixture = New-PluginReleaseHygieneFixture
-        $target = Join-Path $fixture 'agents\Example.agent.md'
+        $target = Join-Path $fixture 'agents/Example.agent.md'
         Set-Content -Path $target -Value '# Example' -Encoding UTF8
         New-Item -ItemType Directory -Path (Join-Path $fixture '.claude') -Force | Out-Null
-        Set-Content -Path (Join-Path $fixture '.claude\.state') -Value 'blocked' -Encoding UTF8
+        Set-Content -Path (Join-Path $fixture '.claude/.state') -Value 'blocked' -Encoding UTF8
 
         $raw = Invoke-HookInFixture -FixtureRoot $fixture -FilePath $target
         $result = $raw | ConvertFrom-Json
 
         $result.hookSpecificOutput.hookEventName | Should -Be 'PostToolUse'
-        Test-Path (Join-Path $fixture '.claude\.state\release-hygiene-389.json') | Should -BeFalse
+        Test-Path (Join-Path $fixture '.claude/.state/release-hygiene-389.json') | Should -BeFalse
     }
 
     It 'reuses the same state file across linked worktrees for the same session_id' {
         $fixture = New-PluginReleaseHygieneFixture
-        $first = Join-Path $fixture 'agents\First.agent.md'
+        $first = Join-Path $fixture 'agents/First.agent.md'
         $worktreeRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("prh-worktree-$([guid]::NewGuid().ToString('N'))")
-        $second = Join-Path $worktreeRoot 'commands\design.md'
+        $second = Join-Path $worktreeRoot 'commands/design.md'
         New-Item -ItemType Directory -Path (Split-Path $first) -Force | Out-Null
         Set-Content -Path $first -Value '# First' -Encoding UTF8
         $script:FixtureRoots.Add($worktreeRoot)
@@ -366,7 +366,7 @@ Describe 'plugin release hygiene hook contract' -Tag 'unit' {
 
         $firstResult = Invoke-HookInFixture -FixtureRoot $fixture -FilePath $first -SessionId 'shared-worktree-session'
         $secondResult = Invoke-HookInFixture -FixtureRoot $worktreeRoot -FilePath $second -SessionId 'shared-worktree-session'
-        $state = Get-Content -Path (Join-Path $fixture '.claude\.state\release-hygiene-shared-worktree-session.json') -Raw | ConvertFrom-Json
+        $state = Get-Content -Path (Join-Path $fixture '.claude/.state/release-hygiene-shared-worktree-session.json') -Raw | ConvertFrom-Json
 
         [string]::IsNullOrWhiteSpace($firstResult) | Should -BeFalse
         [string]::IsNullOrWhiteSpace($secondResult) | Should -BeTrue

--- a/.github/scripts/Tests/post-merge-cleanup.Tests.ps1
+++ b/.github/scripts/Tests/post-merge-cleanup.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'post-merge-cleanup.ps1 — new parameters (Issue #500)' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ScriptFile = Join-Path $script:RepoRoot 'skills\session-startup\scripts\post-merge-cleanup.ps1'
+        $script:ScriptFile = Join-Path $script:RepoRoot 'skills/session-startup/scripts/post-merge-cleanup.ps1'
         $script:SavedPath = $env:PATH
 
         # Record pre-test branch state for leak detection in AfterAll
@@ -705,7 +705,7 @@ exit $LASTEXITCODE
             New-Item -ItemType Directory -Path $workDir -Force | Out-Null
 
             # Create a tracking file without issue_id frontmatter
-            $trackingDir = Join-Path $workDir '.copilot-tracking\research'
+            $trackingDir = Join-Path $workDir '.copilot-tracking/research'
             New-Item -ItemType Directory -Path $trackingDir -Force | Out-Null
             $trackingFile = Join-Path $trackingDir 'unknown-tracking.md'
             Set-Content -Path $trackingFile -Value "# No issue_id header`nSome content" -Encoding UTF8
@@ -736,8 +736,8 @@ exit $LASTEXITCODE
             New-Item -ItemType Directory -Path $workDir -Force | Out-Null
 
             # Create two tracking files with the same name in different subdirs
-            $trackingDir1 = Join-Path $workDir '.copilot-tracking\research'
-            $trackingDir2 = Join-Path $workDir '.copilot-tracking\planning'
+            $trackingDir1 = Join-Path $workDir '.copilot-tracking/research'
+            $trackingDir2 = Join-Path $workDir '.copilot-tracking/planning'
             New-Item -ItemType Directory -Path $trackingDir1, $trackingDir2 -Force | Out-Null
             $file1 = Join-Path $trackingDir1 'issue-plan.md'
             $file2 = Join-Path $trackingDir2 'issue-plan.md'
@@ -1010,7 +1010,7 @@ exit $LASTEXITCODE
             New-Item -ItemType Directory -Path $workDir -Force | Out-Null
 
             # Create a tracking file for issue 42
-            $trackingDir = Join-Path $workDir '.copilot-tracking\research'
+            $trackingDir = Join-Path $workDir '.copilot-tracking/research'
             New-Item -ItemType Directory -Path $trackingDir -Force | Out-Null
             Set-Content -Path (Join-Path $trackingDir 'issue-42-plan.md') -Value @"
 ---
@@ -1058,7 +1058,7 @@ title: "Issue 42 back-compat test"
             New-Item -ItemType Directory -Path $script:CombinedWorkDir, $script:CombinedSiblingDir -Force | Out-Null
 
             # Create untagged tracking file in the work dir
-            $trackingDir = Join-Path $script:CombinedWorkDir '.copilot-tracking\misc'
+            $trackingDir = Join-Path $script:CombinedWorkDir '.copilot-tracking/misc'
             New-Item -ItemType Directory -Path $trackingDir -Force | Out-Null
             $script:CombinedTrackingFile = Join-Path $trackingDir 'combined-untagged.md'
             Set-Content -Path $script:CombinedTrackingFile -Value '# No issue_id frontmatter' -Encoding UTF8

--- a/.github/scripts/Tests/quick-validate.Tests.ps1
+++ b/.github/scripts/Tests/quick-validate.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Invoke-QuickValidate' -Tag 'unit' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:LibFile = Join-Path $script:RepoRoot '.github\scripts\lib\quick-validate-core.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot '.github/scripts/lib/quick-validate-core.ps1'
         . $script:LibFile
 
         # ---------------------------------------------------------------
@@ -48,8 +48,8 @@ Describe 'Invoke-QuickValidate' -Tag 'unit' {
             param([string]$Root = "TestDrive:\qv-$([System.Guid]::NewGuid().ToString('N'))")
 
             $agentsDir = Join-Path $Root 'agents'
-            $skillDir = Join-Path $Root 'skills\test-skill'
-            $scriptsDir = Join-Path $Root '.github\scripts'
+            $skillDir = Join-Path $Root 'skills/test-skill'
+            $scriptsDir = Join-Path $Root '.github/scripts'
 
             New-Item -ItemType Directory -Path $agentsDir  -Force | Out-Null
             New-Item -ItemType Directory -Path $skillDir   -Force | Out-Null
@@ -133,7 +133,7 @@ Write-Output 'ok'
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
                 -PSScriptAnalyzerSettingsPath $mockSettings `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $legacyChecks = $result.Results | Where-Object {
                 $_.Name -in @('Plan-Architect', 'Janitor', 'Issue-Designer', 'workflow-template')
@@ -145,7 +145,7 @@ Write-Output 'ok'
 
         It 'reports FAIL when Plan-Architect reference found' {
             $root = & $script:NewFixture
-            $agentFile = Join-Path $root 'agents\tainted.agent.md'
+            $agentFile = Join-Path $root 'agents/tainted.agent.md'
             Set-Content -Path $agentFile -Value 'Delegate to Plan-Architect for planning.' -Encoding UTF8
 
             $mockScript = & $script:NewMockComplexityScript -Dir $root -AgentsOverCeiling @()
@@ -153,7 +153,7 @@ Write-Output 'ok'
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'Plan-Architect' }
             $check.Passed | Should -BeFalse -Because 'fixture contains a Plan-Architect reference'
@@ -162,7 +162,7 @@ Write-Output 'ok'
 
         It 'reports FAIL when Janitor reference found' {
             $root = & $script:NewFixture
-            $skillFile = Join-Path $root 'skills\test-skill\SKILL.md'
+            $skillFile = Join-Path $root 'skills/test-skill/SKILL.md'
             # Overwrite with content that still passes SKILL frontmatter checks but has Janitor
             Set-Content -Path $skillFile -Value @'
 ---
@@ -184,7 +184,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'Janitor' }
             $check.Passed | Should -BeFalse -Because 'fixture contains a Janitor reference'
@@ -192,7 +192,7 @@ None.
 
         It 'reports FAIL when Issue-Designer reference found' {
             $root = & $script:NewFixture
-            $agentFile = Join-Path $root 'agents\bad.agent.md'
+            $agentFile = Join-Path $root 'agents/bad.agent.md'
             Set-Content -Path $agentFile -Value 'Route to Issue-Designer.' -Encoding UTF8
 
             $mockScript = & $script:NewMockComplexityScript -Dir $root -AgentsOverCeiling @()
@@ -200,7 +200,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'Issue-Designer' }
             $check.Passed | Should -BeFalse -Because 'fixture contains an Issue-Designer reference'
@@ -208,7 +208,7 @@ None.
 
         It 'reports FAIL when workflow-template reference found' {
             $root = & $script:NewFixture
-            $agentFile = Join-Path $root 'agents\bad.agent.md'
+            $agentFile = Join-Path $root 'agents/bad.agent.md'
             Set-Content -Path $agentFile -Value 'Uses the workflow-template pattern.' -Encoding UTF8
 
             $mockScript = & $script:NewMockComplexityScript -Dir $root -AgentsOverCeiling @()
@@ -216,7 +216,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'workflow-template' }
             $check.Passed | Should -BeFalse -Because 'fixture contains a workflow-template reference'
@@ -224,7 +224,7 @@ None.
 
         It 'excludes copilot-instructions.md from legacy reference checks' {
             $root = & $script:NewFixture
-            $ciFile = Join-Path $root '.github\copilot-instructions.md'
+            $ciFile = Join-Path $root '.github/copilot-instructions.md'
             Set-Content -Path $ciFile -Value 'Plan-Architect is mentioned here for documentation.' -Encoding UTF8
 
             $mockScript = & $script:NewMockComplexityScript -Dir $root -AgentsOverCeiling @()
@@ -232,7 +232,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'Plan-Architect' }
             $check.Passed | Should -BeTrue -Because 'copilot-instructions.md is excluded from legacy reference scanning'
@@ -240,7 +240,7 @@ None.
 
         It 'excludes architecture-rules.md from legacy reference checks' {
             $root = & $script:NewFixture
-            $arFile = Join-Path $root '.github\architecture-rules.md'
+            $arFile = Join-Path $root '.github/architecture-rules.md'
             Set-Content -Path $arFile -Value 'Plan-Architect mentioned in architecture rules.' -Encoding UTF8
 
             $mockScript = & $script:NewMockComplexityScript -Dir $root -AgentsOverCeiling @()
@@ -248,7 +248,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'Plan-Architect' }
             $check.Passed | Should -BeTrue -Because 'architecture-rules.md is excluded from legacy reference scanning'
@@ -256,7 +256,7 @@ None.
 
         It 'excludes setup.prompt.md from workflow-template check' {
             $root = & $script:NewFixture
-            $promptFile = Join-Path $root '.github\prompts\setup.prompt.md'
+            $promptFile = Join-Path $root '.github/prompts/setup.prompt.md'
             New-Item -ItemType Directory -Path (Split-Path $promptFile) -Force | Out-Null
             Set-Content -Path $promptFile -Value 'Clone the workflow-template repo.' -Encoding UTF8
 
@@ -265,7 +265,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'workflow-template' }
             $check.Passed | Should -BeTrue -Because 'setup.prompt is excluded from workflow-template scanning'
@@ -284,7 +284,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $skillChecks = $result.Results | Where-Object {
                 $_.Name -in @('SKILL-UseWhen', 'SKILL-DoNotUseFor', 'SKILL-Gotchas')
@@ -296,7 +296,7 @@ None.
 
         It 'reports FAIL when SKILL.md missing Use when/before in description' {
             $root = & $script:NewFixture
-            $skillFile = Join-Path $root 'skills\test-skill\SKILL.md'
+            $skillFile = Join-Path $root 'skills/test-skill/SKILL.md'
             Set-Content -Path $skillFile -Value @'
 ---
 name: test-skill
@@ -315,7 +315,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'SKILL-UseWhen' }
             $check.Passed | Should -BeFalse -Because 'SKILL.md is missing Use when/before in description'
@@ -324,7 +324,7 @@ None.
 
         It 'reports FAIL when SKILL.md missing DO NOT USE FOR: in description' {
             $root = & $script:NewFixture
-            $skillFile = Join-Path $root 'skills\test-skill\SKILL.md'
+            $skillFile = Join-Path $root 'skills/test-skill/SKILL.md'
             Set-Content -Path $skillFile -Value @'
 ---
 name: test-skill
@@ -343,7 +343,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'SKILL-DoNotUseFor' }
             $check.Passed | Should -BeFalse -Because 'SKILL.md is missing DO NOT USE FOR: in description'
@@ -351,7 +351,7 @@ None.
 
         It 'reports FAIL when SKILL.md missing ## Gotchas heading' {
             $root = & $script:NewFixture
-            $skillFile = Join-Path $root 'skills\test-skill\SKILL.md'
+            $skillFile = Join-Path $root 'skills/test-skill/SKILL.md'
             Set-Content -Path $skillFile -Value @'
 ---
 name: test-skill
@@ -368,7 +368,7 @@ No gotchas section here.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'SKILL-Gotchas' }
             $check.Passed | Should -BeFalse -Because 'SKILL.md is missing ## Gotchas heading'
@@ -387,7 +387,7 @@ No gotchas section here.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'GuidanceComplexity' }
             $check.Passed | Should -BeTrue -Because 'mock returns empty agents_over_ceiling'
@@ -400,7 +400,7 @@ No gotchas section here.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'GuidanceComplexity' }
             $check.Passed | Should -BeFalse -Because 'mock returns a non-empty agents_over_ceiling array'
@@ -415,7 +415,7 @@ No gotchas section here.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $badScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             # 1. GuidanceComplexity should FAIL
             $check = $result.Results | Where-Object { $_.Name -eq 'GuidanceComplexity' }
@@ -443,7 +443,7 @@ No gotchas section here.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'PSScriptAnalyzer' }
             $check.Passed | Should -Be 'SKIP' -Because 'PSScriptAnalyzer is not installed; check should be skipped, not passed or failed'
@@ -464,7 +464,7 @@ No gotchas section here.
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
                 -PSScriptAnalyzerSettingsPath $mockSettings `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'PSScriptAnalyzer' }
             $check.Passed | Should -BeTrue -Because 'PSScriptAnalyzer found no issues'
@@ -488,7 +488,7 @@ No gotchas section here.
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
                 -PSScriptAnalyzerSettingsPath $mockSettings `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'PSScriptAnalyzer' }
             $check.Passed | Should -BeFalse -Because 'PSScriptAnalyzer found 2 issues'
@@ -508,7 +508,7 @@ No gotchas section here.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'SkillNameMatch' }
             $check.Passed | Should -BeTrue -Because 'fixture SKILL.md has name: test-skill matching directory test-skill'
@@ -516,7 +516,7 @@ No gotchas section here.
 
         It 'reports FAIL when name field does not match directory name' {
             $root = & $script:NewFixture
-            $skillFile = Join-Path $root 'skills\test-skill\SKILL.md'
+            $skillFile = Join-Path $root 'skills/test-skill/SKILL.md'
             Set-Content -Path $skillFile -Value @'
 ---
 name: wrong-name
@@ -537,7 +537,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'SkillNameMatch' }
             $check.Passed | Should -BeFalse -Because "name 'wrong-name' does not match directory 'test-skill'"
@@ -547,7 +547,7 @@ None.
 
         It 'reports FAIL when name contains an invalid character (slash)' {
             $root = & $script:NewFixture
-            $skillFile = Join-Path $root 'skills\test-skill\SKILL.md'
+            $skillFile = Join-Path $root 'skills/test-skill/SKILL.md'
             Set-Content -Path $skillFile -Value @'
 ---
 name: test-skill/bad
@@ -568,7 +568,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'SkillNameMatch' }
             $check.Passed | Should -BeFalse -Because 'name containing / is invalid for VS Code skill loading'
@@ -576,7 +576,7 @@ None.
 
         It 'reports FAIL when name field is missing from SKILL.md' {
             $root = & $script:NewFixture
-            $skillFile = Join-Path $root 'skills\test-skill\SKILL.md'
+            $skillFile = Join-Path $root 'skills/test-skill/SKILL.md'
             Set-Content -Path $skillFile -Value @'
 ---
 description: Test skill. Use when testing. DO NOT USE FOR: nothing.
@@ -596,7 +596,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'SkillNameMatch' }
             $check.Passed | Should -BeFalse -Because 'SKILL.md has no name: field'
@@ -605,7 +605,7 @@ None.
 
         It 'reports FAIL when name appears only in body (not frontmatter)' {
             $root = & $script:NewFixture
-            $skillFile = Join-Path $root 'skills\test-skill\SKILL.md'
+            $skillFile = Join-Path $root 'skills/test-skill/SKILL.md'
             Set-Content -Path $skillFile -Value @'
 ---
 description: Test skill. Use when testing. DO NOT USE FOR: nothing.
@@ -625,7 +625,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'SkillNameMatch' }
             $check.Passed | Should -BeFalse -Because 'name in body should not satisfy frontmatter requirement'
@@ -634,7 +634,7 @@ None.
 
         It 'reports PASS when name has indented frontmatter key' {
             $root = & $script:NewFixture
-            $skillFile = Join-Path $root 'skills\test-skill\SKILL.md'
+            $skillFile = Join-Path $root 'skills/test-skill/SKILL.md'
             Set-Content -Path $skillFile -Value @'
 ---
   name: test-skill
@@ -653,7 +653,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'SkillNameMatch' }
             $check.Passed | Should -BeTrue -Because 'leading whitespace before name: is valid YAML'
@@ -662,13 +662,13 @@ None.
         It 'reports PASS when no skills directory exists' {
             $root = "TestDrive:\qv-noskills-$([System.Guid]::NewGuid().ToString('N'))"
             New-Item -ItemType Directory -Path (Join-Path $root 'agents') -Force | Out-Null
-            New-Item -ItemType Directory -Path (Join-Path $root '.github\scripts') -Force | Out-Null
+            New-Item -ItemType Directory -Path (Join-Path $root '.github/scripts') -Force | Out-Null
             $mockScript = & $script:NewMockComplexityScript -Dir $root -AgentsOverCeiling @()
 
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $check = $result.Results | Where-Object { $_.Name -eq 'SkillNameMatch' }
             $check.Passed | Should -BeTrue -Because 'no skills directory means no mismatches to detect'
@@ -694,7 +694,7 @@ None.
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
                 -PSScriptAnalyzerSettingsPath $mockSettings `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $result.ExitCode | Should -Be 0 -Because 'all checks pass in a clean fixture'
         }
@@ -702,7 +702,7 @@ None.
         It 'returns ExitCode 1 when any check fails' {
             $root = & $script:NewFixture
             # Inject a single legacy reference to cause one failure
-            $agentFile = Join-Path $root 'agents\tainted.agent.md'
+            $agentFile = Join-Path $root 'agents/tainted.agent.md'
             Set-Content -Path $agentFile -Value 'See Plan-Architect for details.' -Encoding UTF8
 
             $mockScript = & $script:NewMockComplexityScript -Dir $root -AgentsOverCeiling @()
@@ -710,7 +710,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $result.ExitCode | Should -Be 1 -Because 'at least one check failed (Plan-Architect reference)'
         }
@@ -723,7 +723,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts') `
+                -ScriptsPath (Join-Path $root '.github/scripts') `
                 -InformationVariable infoOutput
 
             $summaryLine = ($infoOutput | Out-String) + ($result | Out-String)
@@ -739,7 +739,7 @@ None.
             $result = Invoke-QuickValidate `
                 -RootPath $root `
                 -GuidanceComplexityScriptPath $mockScript `
-                -ScriptsPath (Join-Path $root '.github\scripts')
+                -ScriptsPath (Join-Path $root '.github/scripts')
 
             $result.Results | Should -Not -BeNullOrEmpty -Because 'Results array must be populated'
             $result.TotalCount | Should -BeGreaterOrEqual 9 -Because 'there are at least 9 structural checks'

--- a/.github/scripts/Tests/reference-preflight-hook.Tests.ps1
+++ b/.github/scripts/Tests/reference-preflight-hook.Tests.ps1
@@ -5,9 +5,9 @@ Describe 'reference-preflight-hook contract' -Tag 'unit' {
 
     BeforeAll {
         $script:RepoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:HookScript = Join-Path $script:RepoRoot 'skills\project-references\scripts\reference-preflight-hook.ps1'
-        $script:LoaderScript = Join-Path $script:RepoRoot 'skills\project-references\scripts\invoke-reference-loader.ps1'
-        $script:FixtureBase = Join-Path $PSScriptRoot 'fixtures\project-references\valid-repo'
+        $script:HookScript = Join-Path $script:RepoRoot 'skills/project-references/scripts/reference-preflight-hook.ps1'
+        $script:LoaderScript = Join-Path $script:RepoRoot 'skills/project-references/scripts/invoke-reference-loader.ps1'
+        $script:FixtureBase = Join-Path $PSScriptRoot 'fixtures/project-references/valid-repo'
 
         # Dot-source the hook to get all functions in scope
         . $script:HookScript

--- a/.github/scripts/Tests/review-completion-gate.Tests.ps1
+++ b/.github/scripts/Tests/review-completion-gate.Tests.ps1
@@ -5,8 +5,8 @@ Describe 'review completion gate contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        . (Join-Path $script:RepoRoot 'skills\routing-tables\scripts\routing-tables-core.ps1')
-        . (Join-Path $script:RepoRoot 'skills\routing-tables\scripts\review-state-reader.ps1')
+        . (Join-Path $script:RepoRoot 'skills/routing-tables/scripts/routing-tables-core.ps1')
+        . (Join-Path $script:RepoRoot 'skills/routing-tables/scripts/review-state-reader.ps1')
 
         $script:TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "pester-review-completion-$([System.Guid]::NewGuid().ToString('N'))"
         New-Item -ItemType Directory -Path $script:TempRoot -Force | Out-Null
@@ -164,7 +164,7 @@ last_updated: 2026-04-24 14:00:00
         )
 
         foreach ($case in $cases) {
-            $path = Join-Path $script:TempRoot ("review-state-malformed-{0}.md" -f ($case.Name -replace '\s+', '-'))
+            $path = Join-Path $script:TempRoot ("review-state-malformed-{0}.md" -f ($case.Name -replace '/s+', '-'))
             $case.Content | Set-Content -Path $path -Encoding UTF8
 
             Read-ReviewStateFile -Path $path | Should -BeNullOrEmpty -Because "$($case.Name) must fail closed"

--- a/.github/scripts/Tests/review-completion-gate.Tests.ps1
+++ b/.github/scripts/Tests/review-completion-gate.Tests.ps1
@@ -164,7 +164,7 @@ last_updated: 2026-04-24 14:00:00
         )
 
         foreach ($case in $cases) {
-            $path = Join-Path $script:TempRoot ("review-state-malformed-{0}.md" -f ($case.Name -replace '/s+', '-'))
+            $path = Join-Path $script:TempRoot ("review-state-malformed-{0}.md" -f ($case.Name -replace '\s+', '-'))
             $case.Content | Set-Content -Path $path -Encoding UTF8
 
             Read-ReviewStateFile -Path $path | Should -BeNullOrEmpty -Because "$($case.Name) must fail closed"

--- a/.github/scripts/Tests/review-disposition-audit.Tests.ps1
+++ b/.github/scripts/Tests/review-disposition-audit.Tests.ps1
@@ -13,14 +13,14 @@ BeforeAll {
         if ($gitRoot) { $script:RepoRoot = $gitRoot.Trim().Replace('/', '\') }
     }
 
-    $script:LibDir              = Join-Path $script:RepoRoot '.github\scripts\lib'
+    $script:LibDir              = Join-Path $script:RepoRoot '.github/scripts/lib'
     $script:ValidatorScript     = Join-Path $script:LibDir 'review-dispositions-validator-core.ps1'
     $script:GateReconciliation  = Join-Path $script:LibDir 'gate-reconciliation-core.ps1'
     $script:EngagementRecord    = Join-Path $script:LibDir 'frame-engagement-record-core.ps1'
-    $script:TokenSchema         = Join-Path $script:RepoRoot 'skills\solution-authoring\schemas\gate-decision-token.schema.json'
-    $script:ReviewJudgeCmd      = Join-Path $script:RepoRoot 'commands\orchestra-review-judge.md'
-    $script:ReviewCmd           = Join-Path $script:RepoRoot 'commands\orchestra-review.md'
-    $script:ReviewJudgmentSkill = Join-Path $script:RepoRoot 'skills\review-judgment\SKILL.md'
+    $script:TokenSchema         = Join-Path $script:RepoRoot 'skills/solution-authoring/schemas/gate-decision-token.schema.json'
+    $script:ReviewJudgeCmd      = Join-Path $script:RepoRoot 'commands/orchestra-review-judge.md'
+    $script:ReviewCmd           = Join-Path $script:RepoRoot 'commands/orchestra-review.md'
+    $script:ReviewJudgmentSkill = Join-Path $script:RepoRoot 'skills/review-judgment/SKILL.md'
     $script:DesignDispositionTestFile = Join-Path $PSScriptRoot 'design-disposition-audit.Tests.ps1'
 
     # ── Helper: invoke review-dispositions-validator-core.ps1 in-process ─────

--- a/.github/scripts/Tests/routing-tables.Tests.ps1
+++ b/.github/scripts/Tests/routing-tables.Tests.ps1
@@ -21,8 +21,8 @@ Describe 'routing tables deterministic contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:RoutingTablesCore = Join-Path $script:RepoRoot 'skills\routing-tables\scripts\routing-tables-core.ps1'
-        $script:RoutingConfigAssetSourcePath = Join-Path $script:RepoRoot 'skills\routing-tables\assets\routing-config.json'
+        $script:RoutingTablesCore = Join-Path $script:RepoRoot 'skills/routing-tables/scripts/routing-tables-core.ps1'
+        $script:RoutingConfigAssetSourcePath = Join-Path $script:RepoRoot 'skills/routing-tables/assets/routing-config.json'
         $script:RoutingConfigTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
             "pester-routing-tables-$([System.Guid]::NewGuid().ToString('N'))"
         New-Item -ItemType Directory -Path $script:RoutingConfigTempRoot -Force | Out-Null
@@ -162,8 +162,8 @@ Describe 'routing tables asset parity contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:RoutingConfigAssetPath = Join-Path $script:RepoRoot 'skills\routing-tables\assets\routing-config.json'
-        $script:ScriptSafetyContract = Join-Path $script:RepoRoot '.github\scripts\Tests\script-safety-contract.Tests.ps1'
+        $script:RoutingConfigAssetPath = Join-Path $script:RepoRoot 'skills/routing-tables/assets/routing-config.json'
+        $script:ScriptSafetyContract = Join-Path $script:RepoRoot '.github/scripts/Tests/script-safety-contract.Tests.ps1'
     }
 
     It 'keeps routing-config category enums aligned with the script safety contract taxonomy' {

--- a/.github/scripts/Tests/script-safety-contract.Tests.ps1
+++ b/.github/scripts/Tests/script-safety-contract.Tests.ps1
@@ -21,8 +21,8 @@ Describe 'script safety contract' {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         $script:ScriptsRoot = Join-Path -Path $script:RepoRoot -ChildPath '.github' -AdditionalChildPath 'scripts'
         $script:SkillsRoot = Join-Path -Path $script:RepoRoot -ChildPath 'skills'
-        $script:AggregateReviewScores = Join-Path $script:SkillsRoot 'calibration-pipeline\scripts\aggregate-review-scores.ps1'
-        $script:AggregateReviewScoresCore = Join-Path $script:SkillsRoot 'calibration-pipeline\scripts\aggregate-review-scores-core.ps1'
+        $script:AggregateReviewScores = Join-Path $script:SkillsRoot 'calibration-pipeline/scripts/aggregate-review-scores.ps1'
+        $script:AggregateReviewScoresCore = Join-Path $script:SkillsRoot 'calibration-pipeline/scripts/aggregate-review-scores-core.ps1'
 
         $script:ProductionScripts = @(
             Get-ChildItem -Path $script:ScriptsRoot -Recurse -Filter '*.ps1' |

--- a/.github/scripts/Tests/script-wording-contract.Tests.ps1
+++ b/.github/scripts/Tests/script-wording-contract.Tests.ps1
@@ -19,8 +19,8 @@ Describe 'cleanup script wording contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:DetectorCore = Get-Content (Join-Path $script:RepoRoot 'skills\session-startup\scripts\session-cleanup-detector-core.ps1') -Raw
-        $script:PostMergeCleanup = Get-Content (Join-Path $script:RepoRoot 'skills\session-startup\scripts\post-merge-cleanup.ps1') -Raw
+        $script:DetectorCore = Get-Content (Join-Path $script:RepoRoot 'skills/session-startup/scripts/session-cleanup-detector-core.ps1') -Raw
+        $script:PostMergeCleanup = Get-Content (Join-Path $script:RepoRoot 'skills/session-startup/scripts/post-merge-cleanup.ps1') -Raw
 
         # Extract Remove-OrphanBranch function body (from "function Remove-OrphanBranch" to the next "^function ")
         # This scopes assertions to avoid false matches from Remove-SiblingWorktree

--- a/.github/scripts/Tests/senior-engineer-skill-adapter.Tests.ps1
+++ b/.github/scripts/Tests/senior-engineer-skill-adapter.Tests.ps1
@@ -15,18 +15,18 @@ Describe 'Issue #552 Senior Engineer skill-as-adapter contracts (grep/YAML/valid
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:SeniorEngineerBodyPath = Join-Path $script:RepoRoot 'agents\Senior-Engineer.agent.md'
-        $script:SeniorEngineerShellPath = Join-Path $script:RepoRoot 'agents\senior-engineer.md'
-        $script:SpineRunnerPath = Join-Path $script:RepoRoot 'agents\Spine-Runner.agent.md'
-        $script:FrameValidateLibPath = Join-Path $script:RepoRoot '.github\scripts\lib\frame-validate-core.ps1'
-        $script:FrameCreditEmissionPath = Join-Path $script:RepoRoot 'skills\frame-credit-emission\SKILL.md'
-        $script:LedgerCorePath = Join-Path $script:RepoRoot '.github\scripts\lib\frame-credit-ledger-core.ps1'
+        $script:SeniorEngineerBodyPath = Join-Path $script:RepoRoot 'agents/Senior-Engineer.agent.md'
+        $script:SeniorEngineerShellPath = Join-Path $script:RepoRoot 'agents/senior-engineer.md'
+        $script:SpineRunnerPath = Join-Path $script:RepoRoot 'agents/Spine-Runner.agent.md'
+        $script:FrameValidateLibPath = Join-Path $script:RepoRoot '.github/scripts/lib/frame-validate-core.ps1'
+        $script:FrameCreditEmissionPath = Join-Path $script:RepoRoot 'skills/frame-credit-emission/SKILL.md'
+        $script:LedgerCorePath = Join-Path $script:RepoRoot '.github/scripts/lib/frame-credit-ledger-core.ps1'
         $script:ClaudeMdPath = Join-Path $script:RepoRoot 'CLAUDE.md'
-        $script:PlanAuthoringPath = Join-Path $script:RepoRoot 'skills\plan-authoring\SKILL.md'
-        $script:FrameArchitecturePath = Join-Path $script:RepoRoot 'Documents\Design\frame-architecture.md'
-        $script:ImplementCodeAdapterPath = Join-Path $script:RepoRoot 'skills\implementation-discipline\adapters\implement-code-adapter.md'
-        $script:AdversarialAdaptersPath = Join-Path $script:RepoRoot 'skills\adversarial-review\adapters'
-        $script:CanonicalHandshakeShellPath = Join-Path $script:RepoRoot 'agents\code-critic.md'
+        $script:PlanAuthoringPath = Join-Path $script:RepoRoot 'skills/plan-authoring/SKILL.md'
+        $script:FrameArchitecturePath = Join-Path $script:RepoRoot 'Documents/Design/frame-architecture.md'
+        $script:ImplementCodeAdapterPath = Join-Path $script:RepoRoot 'skills/implementation-discipline/adapters/implement-code-adapter.md'
+        $script:AdversarialAdaptersPath = Join-Path $script:RepoRoot 'skills/adversarial-review/adapters'
+        $script:CanonicalHandshakeShellPath = Join-Path $script:RepoRoot 'agents/code-critic.md'
 
         . $script:FrameValidateLibPath
         . $script:LedgerCorePath

--- a/.github/scripts/Tests/session-cleanup-detector.Tests.ps1
+++ b/.github/scripts/Tests/session-cleanup-detector.Tests.ps1
@@ -24,8 +24,8 @@ Describe 'session-cleanup-detector.ps1 — repo root resolution' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ScriptFile = Join-Path $script:RepoRoot 'skills\session-startup\scripts\session-cleanup-detector.ps1'
-        $script:LibFile = Join-Path $script:RepoRoot 'skills\session-startup\scripts\session-cleanup-detector-core.ps1'
+        $script:ScriptFile = Join-Path $script:RepoRoot 'skills/session-startup/scripts/session-cleanup-detector.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot 'skills/session-startup/scripts/session-cleanup-detector-core.ps1'
         . $script:LibFile
     }
 
@@ -67,10 +67,10 @@ Describe 'session-cleanup-detector.ps1 — calibration tracking exclusion' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ScriptFile = Join-Path $script:RepoRoot 'skills\session-startup\scripts\session-cleanup-detector.ps1'
-        . (Join-Path $script:RepoRoot 'skills\session-startup\scripts\session-cleanup-detector-core.ps1')
+        $script:ScriptFile = Join-Path $script:RepoRoot 'skills/session-startup/scripts/session-cleanup-detector.ps1'
+        . (Join-Path $script:RepoRoot 'skills/session-startup/scripts/session-cleanup-detector-core.ps1')
 
-        $script:CopilotBaselineFixturePath = Join-Path $PSScriptRoot 'fixtures\copilot-baseline-additional-context.txt'
+        $script:CopilotBaselineFixturePath = Join-Path $PSScriptRoot 'fixtures/copilot-baseline-additional-context.txt'
         $script:SavedPath = $env:PATH
 
         $script:NewMockGitDir = {
@@ -1373,7 +1373,7 @@ exit $LASTEXITCODE
             New-Item -ItemType Directory -Path $workDir -Force | Out-Null
 
             # Create an untagged tracking file (no issue_id frontmatter)
-            $trackingDir = Join-Path $workDir '.copilot-tracking\research'
+            $trackingDir = Join-Path $workDir '.copilot-tracking/research'
             New-Item -ItemType Directory -Path $trackingDir -Force | Out-Null
             Set-Content -Path (Join-Path $trackingDir 'orphan-no-id.md') -Value "# No issue_id header`nSome content" -Encoding UTF8
 
@@ -1441,7 +1441,7 @@ Describe 'Get-OrphanBranchLines — per-line suffix and composite invocation' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        . (Join-Path $script:RepoRoot 'skills\session-startup\scripts\session-cleanup-detector-core.ps1')
+        . (Join-Path $script:RepoRoot 'skills/session-startup/scripts/session-cleanup-detector-core.ps1')
     }
 
     It 'appends "; eligible for auto-resolve at cleanup time" to feature/issue-N orphan lines' {

--- a/.github/scripts/Tests/session-memory-contract.Tests.ps1
+++ b/.github/scripts/Tests/session-memory-contract.Tests.ps1
@@ -16,8 +16,8 @@ Describe 'session-memory contract structural surface' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ContractSkill = Join-Path $script:RepoRoot 'skills\session-memory-contract\SKILL.md'
-        $script:RoutingConfigPath = Join-Path $script:RepoRoot 'skills\routing-tables\assets\routing-config.json'
+        $script:ContractSkill = Join-Path $script:RepoRoot 'skills/session-memory-contract/SKILL.md'
+        $script:RoutingConfigPath = Join-Path $script:RepoRoot 'skills/routing-tables/assets/routing-config.json'
 
         $script:ReadContent = {
             param([string]$Path)
@@ -223,7 +223,7 @@ Describe 'session-memory contract structural surface' {
 
     It 'documents rate-limit deferred work as bounded same-conversation state' {
         $segment = & $script:GetContractRowSegment -RowId 'SMC-15'
-        $errorHandlingContent = & $script:ReadContent -Path (Join-Path $script:RepoRoot 'skills\parallel-execution\references\error-handling.md')
+        $errorHandlingContent = & $script:ReadContent -Path (Join-Path $script:RepoRoot 'skills/parallel-execution/references/error-handling.md')
         $rateLimitSection = ([regex]::Match($errorHandlingContent, '(?is)## Subagent Call Resilience \(R5\).*?(?=## Error Handling)')).Value
 
         $segment | Should -Match '^\s*SMC-15\s*\|[^|]*\|\s*`within-conversation`\s*\|' -Because 'SMC-15 must be bounded to the current conversation rather than durable resume'
@@ -302,7 +302,7 @@ Describe 'session-memory contract structural surface' {
     }
 
     It 'requires /orchestrate command handoff prose to anchor plan, design, and phase markers to SMC rows' {
-        $path = Join-Path $script:RepoRoot 'commands\orchestrate.md'
+        $path = Join-Path $script:RepoRoot 'commands/orchestrate.md'
         $content = & $script:ReadContent -Path $path
 
         $content | Should -Match '(?is)<!-- plan-issue-\{ID\} -->.{0,420}SMC-01|SMC-01.{0,420}<!-- plan-issue-\{ID\} -->' -Because '/orchestrate must tie the durable plan handoff marker to SMC-01'
@@ -311,7 +311,7 @@ Describe 'session-memory contract structural surface' {
     }
 
     It 'requires tracking-format to delegate or retire the Cloud Agent Handoff Protocol' {
-        $path = Join-Path $script:RepoRoot 'skills\tracking-format\SKILL.md'
+        $path = Join-Path $script:RepoRoot 'skills/tracking-format/SKILL.md'
         $content = & $script:ReadContent -Path $path
 
         $content | Should -Match '(?is)Cloud Agent Handoff Protocol.{0,500}(skills/session-memory-contract/SKILL\.md|SMC-\d{2}).{0,500}(delegat|retir|canonical|contract)' -Because 'tracking-format must delegate the old cloud handoff guidance to the canonical session-memory contract'

--- a/.github/scripts/Tests/session-startup-wording-contract.Tests.ps1
+++ b/.github/scripts/Tests/session-startup-wording-contract.Tests.ps1
@@ -21,8 +21,8 @@ Describe 'session startup wording contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:SessionStartupSkill = Join-Path $script:RepoRoot 'skills\session-startup\SKILL.md'
-        $script:SessionStartupClaudePlatform = Join-Path $script:RepoRoot 'skills\session-startup\platforms\claude.md'
+        $script:SessionStartupSkill = Join-Path $script:RepoRoot 'skills/session-startup/SKILL.md'
+        $script:SessionStartupClaudePlatform = Join-Path $script:RepoRoot 'skills/session-startup/platforms/claude.md'
         $script:CanonicalMarkerPath = '/memories/session/session-startup-check-complete.md'
         $script:RetiredTriggerText = 'Before the first substantive response in a new conversation, load the `session-startup` skill and follow its protocol.'
         $script:LegacySilentSkipSummary = 'Skip the automatic startup check silently when neither `$env:COPILOT_ORCHESTRA_ROOT` nor `$env:WORKFLOW_TEMPLATE_ROOT` is set, `pwsh` is unavailable, or the detector returns non-JSON output.'
@@ -33,19 +33,19 @@ Describe 'session startup wording contract' {
         $script:PipelineEntryAgents = @(
             @{
                 Name = 'Experience-Owner'
-                Path = Join-Path $script:RepoRoot 'agents\Experience-Owner.agent.md'
+                Path = Join-Path $script:RepoRoot 'agents/Experience-Owner.agent.md'
             },
             @{
                 Name = 'Solution-Designer'
-                Path = Join-Path $script:RepoRoot 'agents\Solution-Designer.agent.md'
+                Path = Join-Path $script:RepoRoot 'agents/Solution-Designer.agent.md'
             },
             @{
                 Name = 'Issue-Planner'
-                Path = Join-Path $script:RepoRoot 'agents\Issue-Planner.agent.md'
+                Path = Join-Path $script:RepoRoot 'agents/Issue-Planner.agent.md'
             },
             @{
                 Name = 'Code-Conductor'
-                Path = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
+                Path = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
             }
         )
         # Issue #498 DRY pass: command files no longer duplicate Step 7b prose — owning skill and

--- a/.github/scripts/Tests/solution-authoring.Tests.ps1
+++ b/.github/scripts/Tests/solution-authoring.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'solution-authoring SKILL body' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:SkillPath = Join-Path $script:RepoRoot 'skills\solution-authoring\SKILL.md'
+        $script:SkillPath = Join-Path $script:RepoRoot 'skills/solution-authoring/SKILL.md'
         $script:Content = (Get-Content -Path $script:SkillPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
     }
 
@@ -88,8 +88,8 @@ Describe 'solution-authoring platforms parity' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ClaudePath  = Join-Path $script:RepoRoot 'skills\solution-authoring\platforms\claude.md'
-        $script:CopilotPath = Join-Path $script:RepoRoot 'skills\solution-authoring\platforms\copilot.md'
+        $script:ClaudePath  = Join-Path $script:RepoRoot 'skills/solution-authoring/platforms/claude.md'
+        $script:CopilotPath = Join-Path $script:RepoRoot 'skills/solution-authoring/platforms/copilot.md'
 
         $script:GetH2Headings = {
             param([string]$Content)
@@ -203,7 +203,7 @@ Describe 'upstream-onboarding sweep' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:UOPath    = Join-Path $script:RepoRoot 'skills\upstream-onboarding\SKILL.md'
+        $script:UOPath    = Join-Path $script:RepoRoot 'skills/upstream-onboarding/SKILL.md'
         $script:UOContent = (Get-Content -Path $script:UOPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
     }
 
@@ -238,15 +238,15 @@ Describe 'escalation tier — issue #556 structural assertions' {
 
     BeforeAll {
         $script:RepoRoot     = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:SkillPath    = Join-Path $script:RepoRoot 'skills\solution-authoring\SKILL.md'
+        $script:SkillPath    = Join-Path $script:RepoRoot 'skills/solution-authoring/SKILL.md'
         $script:Content      = (Get-Content -Path $script:SkillPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
-        $script:ClaudeMdPath = Join-Path $script:RepoRoot 'skills\solution-authoring\platforms\claude.md'
+        $script:ClaudeMdPath = Join-Path $script:RepoRoot 'skills/solution-authoring/platforms/claude.md'
         $script:ClaudeMdContent = (Get-Content -Path $script:ClaudeMdPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
-        $copilotMdPath = Join-Path $script:RepoRoot 'skills\solution-authoring\platforms\copilot.md'
+        $copilotMdPath = Join-Path $script:RepoRoot 'skills/solution-authoring/platforms/copilot.md'
         $script:CopilotMdContent = (Get-Content -Path $copilotMdPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
-        $script:SDAgentPath  = Join-Path $script:RepoRoot 'agents\Solution-Designer.agent.md'
+        $script:SDAgentPath  = Join-Path $script:RepoRoot 'agents/Solution-Designer.agent.md'
         $script:SDContent    = (Get-Content -Path $script:SDAgentPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
-        $script:DEPath       = Join-Path $script:RepoRoot 'skills\design-exploration\SKILL.md'
+        $script:DEPath       = Join-Path $script:RepoRoot 'skills/design-exploration/SKILL.md'
         $script:DEContent    = (Get-Content -Path $script:DEPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
     }
 
@@ -309,7 +309,7 @@ Describe 'frame-architecture stacking note' {
 
     BeforeAll {
         $script:RepoRoot  = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:FAPath    = Join-Path $script:RepoRoot 'Documents\Design\frame-architecture.md'
+        $script:FAPath    = Join-Path $script:RepoRoot 'Documents/Design/frame-architecture.md'
         $script:FAContent = (Get-Content -Path $script:FAPath -Raw -ErrorAction Stop) -replace "`r`n?", "`n"
     }
 

--- a/.github/scripts/Tests/spine-runner.Tests.ps1
+++ b/.github/scripts/Tests/spine-runner.Tests.ps1
@@ -17,15 +17,15 @@ Describe 'Spine-Runner frame-walking contract' -Tag 'contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:SpineRunnerPath = Join-Path $script:RepoRoot 'agents\Spine-Runner.agent.md'
-        $script:ClaudeCommandPath = Join-Path $script:RepoRoot 'commands\spine-run.md'
-        $script:ClaudeShellPath = Join-Path $script:RepoRoot 'agents\spine-runner.md'
-        $script:FrameCreditEmissionPath = Join-Path $script:RepoRoot 'skills\frame-credit-emission\SKILL.md'
-        $script:PortsDirectory = Join-Path $script:RepoRoot 'frame\ports'
-        $script:CopilotPromptPath = Join-Path $script:RepoRoot '.github\prompts\spine-run.prompt.md'
-        $script:OrchestratePromptPath = Join-Path $script:RepoRoot '.github\prompts\orchestrate.prompt.md'
-        $script:FrameSpineParseTestsPath = Join-Path $script:RepoRoot '.github\scripts\Tests\frame-spine-parse.Tests.ps1'
-        $script:ConductorSpineDispatchTestsPath = Join-Path $script:RepoRoot '.github\scripts\Tests\code-conductor-spine-dispatch.Tests.ps1'
+        $script:SpineRunnerPath = Join-Path $script:RepoRoot 'agents/Spine-Runner.agent.md'
+        $script:ClaudeCommandPath = Join-Path $script:RepoRoot 'commands/spine-run.md'
+        $script:ClaudeShellPath = Join-Path $script:RepoRoot 'agents/spine-runner.md'
+        $script:FrameCreditEmissionPath = Join-Path $script:RepoRoot 'skills/frame-credit-emission/SKILL.md'
+        $script:PortsDirectory = Join-Path $script:RepoRoot 'frame/ports'
+        $script:CopilotPromptPath = Join-Path $script:RepoRoot '.github/prompts/spine-run.prompt.md'
+        $script:OrchestratePromptPath = Join-Path $script:RepoRoot '.github/prompts/orchestrate.prompt.md'
+        $script:FrameSpineParseTestsPath = Join-Path $script:RepoRoot '.github/scripts/Tests/frame-spine-parse.Tests.ps1'
+        $script:ConductorSpineDispatchTestsPath = Join-Path $script:RepoRoot '.github/scripts/Tests/code-conductor-spine-dispatch.Tests.ps1'
         $script:NoFrameRefusal = 'No frame found on plan-issue-{ID}. Run /plan first.'
 
         $script:Normalize = {

--- a/.github/scripts/Tests/terminal-hygiene-guardrails.Tests.ps1
+++ b/.github/scripts/Tests/terminal-hygiene-guardrails.Tests.ps1
@@ -26,9 +26,9 @@ Describe 'terminal hygiene guardrails contract' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:SkillPath     = Join-Path $script:RepoRoot 'skills\terminal-hygiene\SKILL.md'
-        $script:ConductorPath = Join-Path $script:RepoRoot 'agents\Code-Conductor.agent.md'
-        $script:DesignDocPath = Join-Path $script:RepoRoot 'Documents\Design\terminal-test-hygiene.md'
+        $script:SkillPath     = Join-Path $script:RepoRoot 'skills/terminal-hygiene/SKILL.md'
+        $script:ConductorPath = Join-Path $script:RepoRoot 'agents/Code-Conductor.agent.md'
+        $script:DesignDocPath = Join-Path $script:RepoRoot 'Documents/Design/terminal-test-hygiene.md'
 
         $script:MultilineHeading = '## Multiline Continuation-Prompt Hazard'
         $script:WrapperHeading   = '## Non-Fatal Diagnostic Wrapper Pattern'

--- a/.github/scripts/Tests/test-source-mutation-contract.Tests.ps1
+++ b/.github/scripts/Tests/test-source-mutation-contract.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'test source mutation contract' -Tag 'no-gh' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:TestsRoot = Join-Path $script:RepoRoot '.github\scripts\Tests'
+        $script:TestsRoot = Join-Path $script:RepoRoot '.github/scripts/Tests'
         $script:ThisFile = (Resolve-Path $PSCommandPath).Path
         $script:AssetPathPattern = 'skills[/\\][^/\\]+[/\\]assets(?:[/\\]|$)'
 

--- a/.github/scripts/Tests/validate-plugin-preflight.Tests.ps1
+++ b/.github/scripts/Tests/validate-plugin-preflight.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Invoke-PluginPreflight' -Tag 'unit' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:LibFile = Join-Path $script:RepoRoot '.github\scripts\lib\validate-plugin-preflight-core.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot '.github/scripts/lib/validate-plugin-preflight-core.ps1'
         . $script:LibFile
 
         # Helper: build a minimal valid fixture with plugin.json at the repo root,
@@ -164,7 +164,7 @@ $($skillEntries -join ",`n")
 
         It 'reports FAIL SkillCountMatch when filesystem has more skills than plugin.json' {
             $root = & $script:NewFixture -SkillCount 39
-            New-Item -ItemType Directory -Path (Join-Path $root 'skills\extra-skill') -Force | Out-Null
+            New-Item -ItemType Directory -Path (Join-Path $root 'skills/extra-skill') -Force | Out-Null
             $pjPath = Join-Path $root 'plugin.json'
             $result = Invoke-PluginPreflight -RootPath $root -PluginJsonPath $pjPath
             $check = $result.Results | Where-Object { $_.Name -eq 'SkillCountMatch' }
@@ -174,7 +174,7 @@ $($skillEntries -join ",`n")
 
         It 'reports FAIL SkillPathsExist when a declared skill directory is missing' {
             $root = & $script:NewFixture
-            Remove-Item -Path (Join-Path $root 'skills\skill-5') -Recurse -Force
+            Remove-Item -Path (Join-Path $root 'skills/skill-5') -Recurse -Force
             $pjPath = Join-Path $root 'plugin.json'
             $result = Invoke-PluginPreflight -RootPath $root -PluginJsonPath $pjPath
             $check = $result.Results | Where-Object { $_.Name -eq 'SkillPathsExist' }

--- a/.github/scripts/Tests/write-calibration-entry.Tests.ps1
+++ b/.github/scripts/Tests/write-calibration-entry.Tests.ps1
@@ -35,8 +35,8 @@ Describe 'write-calibration-entry.ps1' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-        $script:ScriptFile = Join-Path $script:RepoRoot 'skills\calibration-pipeline\scripts\write-calibration-entry.ps1'
-        $script:LibFile = Join-Path $script:RepoRoot 'skills\calibration-pipeline\scripts\write-calibration-entry-core.ps1'
+        $script:ScriptFile = Join-Path $script:RepoRoot 'skills/calibration-pipeline/scripts/write-calibration-entry.ps1'
+        $script:LibFile = Join-Path $script:RepoRoot 'skills/calibration-pipeline/scripts/write-calibration-entry-core.ps1'
         . $script:LibFile
 
         # Master temp root — all per-test dirs live under here
@@ -114,7 +114,7 @@ Describe 'write-calibration-entry.ps1' {
         # ------------------------------------------------------------------
         $script:SeedFile = {
             param([string]$WorkDir, [object]$Entry)
-            $calibDir = Join-Path $WorkDir '.copilot-tracking\calibration'
+            $calibDir = Join-Path $WorkDir '.copilot-tracking/calibration'
             New-Item -ItemType Directory -Path $calibDir -Force | Out-Null
             $data = [ordered]@{
                 calibration_version = 1
@@ -146,7 +146,7 @@ Describe 'write-calibration-entry.ps1' {
 
             & $script:Invoke -WorkDir $workDir -EntryJson $entryJson
 
-            $calibDir = Join-Path $workDir '.copilot-tracking\calibration'
+            $calibDir = Join-Path $workDir '.copilot-tracking/calibration'
             $calibDir | Should -Exist -Because 'the script must create the calibration directory on first run'
         }
 
@@ -156,7 +156,7 @@ Describe 'write-calibration-entry.ps1' {
 
             & $script:Invoke -WorkDir $workDir -EntryJson $entryJson
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $dataFile | Should -Exist -Because 'review-data.json must be created'
 
             $data = Get-Content $dataFile -Raw | ConvertFrom-Json
@@ -202,7 +202,7 @@ Describe 'write-calibration-entry.ps1' {
             $entryJson = $newEntry | ConvertTo-Json -Depth 10 -Compress
             & $script:Invoke -WorkDir $workDir -EntryJson $entryJson
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $data = Get-Content $dataFile -Raw | ConvertFrom-Json
             $data.entries.Count | Should -Be 2 -Because 'appending a different pr_number must result in two entries'
         }
@@ -239,7 +239,7 @@ Describe 'write-calibration-entry.ps1' {
             $entryJson = $updatedEntry | ConvertTo-Json -Depth 10 -Compress
             & $script:Invoke -WorkDir $workDir -EntryJson $entryJson
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $data = Get-Content $dataFile -Raw | ConvertFrom-Json
             $data.entries.Count | Should -Be 1 -Because 'same pr_number must be overwritten, not duplicated'
             # ConvertFrom-Json returns created_at as DateTime; normalise to UTC string for comparison
@@ -410,7 +410,7 @@ Describe 'write-calibration-entry.ps1' {
             $entryJson = $bad | ConvertTo-Json -Depth 10 -Compress
             & $script:Invoke -WorkDir $workDir -EntryJson $entryJson
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $dataFile | Should -Not -Exist `
                 -Because 'no file should be created or modified when validation fails'
         }
@@ -481,7 +481,7 @@ Describe 'write-calibration-entry.ps1' {
             $entryJson = $entry | ConvertTo-Json -Depth 10 -Compress
             & $script:Invoke -WorkDir $workDir -EntryJson $entryJson
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $data = Get-Content $dataFile -Raw | ConvertFrom-Json
             $data.entries[0].findings[0].systemic_fix_type | Should -Be 'refactor-extract-method' `
                 -Because 'systemic_fix_type must be stored as a passthrough field'
@@ -496,7 +496,7 @@ Describe 'write-calibration-entry.ps1' {
             $result.ExitCode | Should -Be 0 `
                 -Because 'absence of systemic_fix_type must not cause failure'
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $data = Get-Content $dataFile -Raw | ConvertFrom-Json
             $data.entries.Count | Should -Be 1 -Because 'entry without systemic_fix_type must be stored'
         }
@@ -531,7 +531,7 @@ Describe 'write-calibration-entry.ps1' {
             $result.ExitCode | Should -Be 0 `
                 -Because 'review_stage accepts any non-empty string — no enum restriction'
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $data = Get-Content $dataFile -Raw | ConvertFrom-Json
             $data.entries[0].findings[0].review_stage | Should -Be 'custom-stage' `
                 -Because 'custom review_stage value must be stored verbatim'
@@ -544,7 +544,7 @@ Describe 'write-calibration-entry.ps1' {
             $entryJson = $script:ValidEntry | ConvertTo-Json -Depth 10 -Compress
             & $script:Invoke -WorkDir $workDir -EntryJson $entryJson
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $data = Get-Content $dataFile -Raw | ConvertFrom-Json
             $findings = $data.entries[0].findings
             $findings.GetType().IsArray | Should -BeTrue `
@@ -565,7 +565,7 @@ Describe 'write-calibration-entry.ps1' {
 
             $result.ExitCode | Should -Be 0 -Because 'successful write must exit 0'
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $dataFile | Should -Exist -Because 'review-data.json must exist after a successful write'
 
             $raw = Get-Content $dataFile -Raw
@@ -573,7 +573,7 @@ Describe 'write-calibration-entry.ps1' {
                 -Because 'review-data.json must contain valid JSON'
 
             # No leftover .tmp file
-            $tmpFiles = Get-ChildItem -Path (Join-Path $workDir '.copilot-tracking\calibration') `
+            $tmpFiles = Get-ChildItem -Path (Join-Path $workDir '.copilot-tracking/calibration') `
                 -Filter '*.tmp' -ErrorAction SilentlyContinue
             $tmpFiles | Should -BeNullOrEmpty `
                 -Because 'atomic write must not leave .tmp files behind after success'
@@ -650,7 +650,7 @@ Describe 'write-calibration-entry.ps1' {
             $result.ExitCode | Should -Be 0 `
                 -Because 'a valid event-only write must succeed'
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $data = Get-Content $dataFile -Raw | ConvertFrom-Json
 
             # Existing entries must be preserved
@@ -676,7 +676,7 @@ Describe 'write-calibration-entry.ps1' {
             $result.ExitCode | Should -Be 0 `
                 -Because 'combined entry + event write must succeed'
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $data = Get-Content $dataFile -Raw | ConvertFrom-Json
 
             $data.entries.Count | Should -Be 1 `
@@ -705,7 +705,7 @@ Describe 'write-calibration-entry.ps1' {
             $eventJson2 = $updatedEvent | ConvertTo-Json -Depth 10 -Compress
             & $script:Invoke -WorkDir $workDir -EventJson $eventJson2
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $data = Get-Content $dataFile -Raw | ConvertFrom-Json
 
             $data.re_activation_events.Count | Should -Be 1 `
@@ -752,10 +752,10 @@ Describe 'write-calibration-entry.ps1' {
             $result.ExitCode | Should -Be 0 `
                 -Because 'valid event write must succeed'
 
-            $dataFile = Join-Path $workDir '.copilot-tracking\calibration\review-data.json'
+            $dataFile = Join-Path $workDir '.copilot-tracking/calibration/review-data.json'
             $dataFile | Should -Exist -Because 'review-data.json must exist after event write'
 
-            $tmpFiles = Get-ChildItem -Path (Join-Path $workDir '.copilot-tracking\calibration') `
+            $tmpFiles = Get-ChildItem -Path (Join-Path $workDir '.copilot-tracking/calibration') `
                 -Filter '*.tmp' -ErrorAction SilentlyContinue
             $tmpFiles | Should -BeNullOrEmpty `
                 -Because 'atomic write must not leave .tmp files behind after success'

--- a/.github/scripts/test-session-cleanup-detector.ps1
+++ b/.github/scripts/test-session-cleanup-detector.ps1
@@ -16,7 +16,7 @@ param([switch]$Verbose)
 
 $ErrorActionPreference = 'Stop'
 $scriptDir = Split-Path -Parent $PSCommandPath
-$detectorPath = Join-Path $scriptDir '..\skills\session-startup\scripts\session-cleanup-detector.ps1'
+$detectorPath = Join-Path $scriptDir '../skills/session-startup/scripts/session-cleanup-detector.ps1'
 
 $script:passed = 0
 $script:failed = 0

--- a/.github/scripts/validate-plugin-preflight.ps1
+++ b/.github/scripts/validate-plugin-preflight.ps1
@@ -19,7 +19,7 @@
 
 $ErrorActionPreference = 'Stop'
 
-$libFile = Join-Path $PSScriptRoot 'lib\validate-plugin-preflight-core.ps1'
+$libFile = Join-Path $PSScriptRoot 'lib/validate-plugin-preflight-core.ps1'
 . $libFile
 
 $result = Invoke-PluginPreflight

--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -35,7 +35,8 @@ jobs:
             '.github/scripts/Tests/Add-FollowUpIssue.Tests.ps1',
             '.github/scripts/Tests/code-review-deferral-integration.Tests.ps1',
             '.github/scripts/Tests/gate-reconciliation.Tests.ps1',
-            '.github/scripts/Tests/gate-hook-contract.Tests.ps1'
+            '.github/scripts/Tests/gate-hook-contract.Tests.ps1',
+            '.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1'
           )
           $config.Run.Exit = $true
           $config.Output.Verbosity = 'Detailed'

--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -36,7 +36,8 @@ jobs:
             '.github/scripts/Tests/code-review-deferral-integration.Tests.ps1',
             '.github/scripts/Tests/gate-reconciliation.Tests.ps1',
             '.github/scripts/Tests/gate-hook-contract.Tests.ps1',
-            '.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1'
+            '.github/scripts/Tests/path-migration-sweep-gate.Tests.ps1',
+            '.github/scripts/Tests/Ensure-ScratchGitignore.Tests.ps1'
           )
           $config.Run.Exit = $true
           $config.Output.Verbosity = 'Detailed'

--- a/Documents/Design/hub-artifact-paths-audit.md
+++ b/Documents/Design/hub-artifact-paths-audit.md
@@ -1,6 +1,6 @@
 <!-- audit-meta
-last-verified: 9f483ca2780a3b155a4f76b8efa9e1ba8d047a17
-generated-at: 2026-06-04T02:19:18Z
+last-verified: 32f983d4f2c599322c3a08b21516b7b06c9fd6e4
+generated-at: 2026-06-09T05:41:59Z
 -->
 
 ## Purpose
@@ -100,6 +100,16 @@ In a **hub-repo run** (the agent-orchestra repository itself, with `.claude-plug
 Copilot always reads from the source tree in the hub repo. This dual-resolved behavior is why the classification records `claude_resolves: both` and `copilot_resolves: source-tree` for the `agents/*.agent.md` family.
 
 ## Catalog
+
+### `../skills/*/scripts/*.ps1`
+
+- **claude_resolves**: both
+- **copilot_resolves**: source-tree
+- **requires_version_bump**: true
+- **experience**: visible-warning
+- **examples**:
+  - `../skills/session-startup/scripts/session-cleanup-detector.ps1`
+- **notes**: ../-prefixed form of 'skills/*/scripts/*.ps1' referenced from .github/scripts/ context (e.g., test-session-cleanup-detector.ps1). Resolves to the same physical scripts as the skills/*/scripts/*.ps1 family; introduced by #664 forward-slash path conversion which activated forward-slash path extraction.
 
 ### `.claude-plugin/*.json`
 

--- a/Documents/Design/hub-artifact-paths-classification.yml
+++ b/Documents/Design/hub-artifact-paths-classification.yml
@@ -145,6 +145,18 @@ families:
       Missing script produces visible-warning rather than hard-failure because the skill
       body can fall back to inline guidance."
 
+  "../skills/*/scripts/*.ps1":
+    claude_resolves: both
+    copilot_resolves: source-tree
+    requires_version_bump: true
+    experience: visible-warning
+    examples:
+      - ../skills/session-startup/scripts/session-cleanup-detector.ps1
+    notes: "../-prefixed form of 'skills/*/scripts/*.ps1' referenced from .github/scripts/
+      context (e.g., test-session-cleanup-detector.ps1). Resolves to the same physical
+      scripts as the skills/*/scripts/*.ps1 family; introduced by #664 forward-slash
+      path conversion which activated forward-slash path extraction."
+
   "skills/*/assets/*.json":
     claude_resolves: both
     copilot_resolves: source-tree

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > ⚠️ **GitHub Copilot / VS Code support is frozen and retiring after 2026-08-31.**
 > Claude Code is the actively supported path. See [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md) for details and the reach-out channel if you depend on Copilot support.
 
-[![Version](https://img.shields.io/badge/version-v2.24.0-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v2.25.1-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development through specialized Claude Code agents. *(GitHub Copilot/VS Code: frozen and retiring after 2026-08-31 — see [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md))*

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A multi-agent workflow system that orchestrates AI-assisted software development
 
 > ⚠️ **Copilot / VS Code support is frozen and retiring after 2026-08-31.**
 > Claude Code is the actively supported path — see [Install as Plugin (Claude Code)](#install-as-plugin-claude-code) below. If you depend on the Copilot/VS Code surface, start a [GitHub Discussion](https://github.com/Grimblaz/agent-orchestra/discussions) before the deadline. See [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md) for details.
-
 > **Experimental**: Agent plugins are available in VS Code 1.110 as an experimental feature. Plugin distribution is the fastest way to get started with no cloning required.
 
 ### Quick Setup (Plugin)

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-  "version": "2.24.0",
+  "version": "2.25.1",
   "author": {
     "name": "Grimblaz"
   },

--- a/skills/copilot-cost-collection/scripts/Initialize-CopilotCostCollection.ps1
+++ b/skills/copilot-cost-collection/scripts/Initialize-CopilotCostCollection.ps1
@@ -37,7 +37,7 @@ function Resolve-CopilotCostDefaultUserSettingsPath {
             throw 'APPDATA is not set; pass -UserSettingsPath for this VS Code installation.'
         }
 
-        return Join-Path -Path $env:APPDATA -ChildPath 'Code\User\settings.json'
+        return Join-Path -Path $env:APPDATA -ChildPath 'Code\User\settings.json' # host-path-ok
     }
 
     $profileHome = [Environment]::GetFolderPath('UserProfile')

--- a/skills/routing-tables/scripts/routing-tables-core.ps1
+++ b/skills/routing-tables/scripts/routing-tables-core.ps1
@@ -1,11 +1,11 @@
 #Requires -Version 7.0
 
 function Get-RTConfigPath {
-    return Join-Path $PSScriptRoot '..\assets\routing-config.json'
+    return Join-Path $PSScriptRoot '../assets/routing-config.json'
 }
 
 function Get-RTGateCriteriaPath {
-    return Join-Path $PSScriptRoot '..\assets\gate-criteria.json'
+    return Join-Path $PSScriptRoot '../assets/gate-criteria.json'
 }
 
 function Read-RTJsonFile {

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -222,3 +222,9 @@ For detailed examples of each anti-pattern, see `references/anti-patterns.md`.
 | `implement-test` | [agents/Test-Writer.agent.md](../../agents/Test-Writer.agent.md); [adapters/implement-test-adapter.md](adapters/implement-test-adapter.md) | [adapters/implement-test-auto-na-adapter.md](adapters/implement-test-auto-na-adapter.md) | [adapters/implement-test-explicit-skip-adapter.md](adapters/implement-test-explicit-skip-adapter.md) |
 
 In `/spine-run`, the `implement-test` port resolves through [adapters/implement-test-adapter.md](adapters/implement-test-adapter.md) as the work adapter executed by Senior Engineer. Hub-flow dispatch uses `agents/Test-Writer.agent.md` directly. This split-declaration state is documented in [Documents/Design/frame-architecture.md](../../Documents/Design/frame-architecture.md); see footnote ‡ (split-declaration #612).
+
+## Cross-platform path conventions
+
+When authoring tests that reference filesystem paths via `Join-Path`, use forward
+slashes in child-path arguments. See `.github/architecture-rules.md §Validation`
+for the authoritative convention and enforcement gate.


### PR DESCRIPTION
Closes #664

## Summary

- **s1 (test)**: Extended `path-migration-sweep-gate.Tests.ps1` with an Issue #664 `Describe` block — detection regex `Join-Path\s.*'[^']*\[^']*'`, self-test triplet (falsifiability/no-false-positive/documented-miss), exemption whitelist (`# host-path-ok`). Added gate to `pester.yml` allowlist.
- **s2 (code)**: Converted 4 production offenders to forward slashes (`routing-tables-core.ps1:4,8`, `validate-plugin-preflight.ps1:22`, `test-session-cleanup-detector.ps1:19`). Whitelisted `Initialize-CopilotCostCollection.ps1:40` as a documented Windows-only non-conversion. Version bump: 2.25.0 → 2.25.1.
- **s3 (test)**: Swept ~319 backslash `Join-Path` child-path literals across 69 `Tests/*.ps1` files to forward slashes (449 line changes; only path-separator chars changed).
- **s4 (docs)**: Documented the convention in `.github/architecture-rules.md §Validation` (authoritative) + thin `TDD SKILL.md` pointer. Gate failure message updated to reference `§Validation`.
- **s5 (test, terminal)**: Promoted `Ensure-ScratchGitignore.Tests.ps1` to `pester.yml` allowlist as proof-of-concept (AC4). Only prior Linux blocker was the s3-converted line 18 backslash. Follow-up: #672.
- **sym-bump completion**: Completed symmetric version bump — all 5 manifest files at 2.25.1.

## Test plan

- [ ] CI `ubuntu-latest` Pester suite green (154 tests including new gate + promoted file)
- [ ] Gate `Issue #664 backslash-Join-Path hygiene gate` passes with 0 violations
- [ ] `Ensure-ScratchGitignore.Tests.ps1` (5 tests) passes on ubuntu-latest

## Decisions (from plan stress-test)

| ID | Choice |
|----|--------|
| A (F1) | Atomic single PR — guard green at merge, never pushed RED |
| B (F5) | Proof-of-concept promotion only (≥1 file); full machinery → #672 |
| C (F2/F6) | Extended existing `#367 git ls-files` gate (`path-migration-sweep-gate.Tests.ps1`) |

<!-- pipeline-metrics -->
```yaml
metrics_version: 4
frame_version: 1
credits:
  - port: experience
    adapter: work-adapter
    status: passed
    evidence: "issue #664; experience completion marker posted"
  - port: design
    adapter: work-adapter
    status: passed
    evidence: "issue #664; design completion marker posted"
  - port: plan
    adapter: work-adapter
    status: passed
    evidence: "issue #664; plan completion marker posted"
  - port: implement-code
    adapter: skills/implementation-discipline/adapters/implement-code-adapter.md
    status: passed
    terminal-step-id: 2
    evidence: "Converted routing-tables-core.ps1:4,8; validate-plugin-preflight.ps1:22; test-session-cleanup-detector.ps1:19 to forward slashes. Initialize-CopilotCostCollection.ps1:40 whitelisted as Windows-only exempt (host-path-ok). Behavior-preserving; full pester.yml gate green after s2."
  - port: implement-test
    adapter: skills/test-driven-development/adapters/implement-test-adapter.md
    status: passed
    terminal-step-id: 5
    evidence: "Promoted Ensure-ScratchGitignore.Tests.ps1 to pester.yml allowlist (AC4 proof-of-concept). 154 Pester tests pass locally; only prior Linux blocker was the s3-converted Join-Path backslash literal at line 18. Follow-up #672 covers full promotion machinery."
  - port: implement-docs
    adapter: skills/documentation-finalization/adapters/implement-docs-adapter.md
    status: passed
    terminal-step-id: 4
    evidence: "architecture-rules.md §Validation documents authoritative Join-Path forward-slash convention; TDD SKILL.md adds pointer section; gate failure message updated to reference §Validation. No duplicated normative text."
  - port: release-hygiene
    adapter: symmetric-bump
    status: passed
    evidence: "All 5 manifest files at 2.25.1 (patch; behavior-preserving path-separator fix triggers routing-tables-core.ps1 cache key). Symmetric-bump-verifier reported passed."
    version-bump:
      from: "2.24.0"
      to: "2.25.1"
    symmetric-bump-verification:
      status: passed
      files-checked: ["plugin.json", ".claude-plugin/plugin.json", ".claude-plugin/marketplace.json", ".github/plugin/marketplace.json", "README.md"]
```
<!-- /pipeline-metrics -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated gate to detect disallowed backslash usage in Join-Path calls

* **Bug Fixes**
  * Standardized path separators across tests and scripts for better cross-platform reliability

* **Documentation**
  * Updated architecture guidelines and skill docs with the path-convention rule
  * Added hub artifact path classification and refreshed README version badge

* **Chores**
  * Bumped product/manifest versions to 2.25.1 and updated related metadata
<!-- end of auto-generated comment: release notes by coderabbit.ai -->