### PR TITLE
feat(#669): un-mirror implement-code adapter — fat-skills consolidation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.25.1"
+    "version": "2.25.2"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-      "version": "2.25.1",
+      "version": "2.25.2",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot",
-    "version": "2.25.1"
+    "version": "2.25.2"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot with 16 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.25.1"
+      "version": "2.25.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to agent-orchestra will be documented in this file.
 
+## [2.25.2] — 2026-06-09
+
+### Changed
+
+- **Fat-skills consolidation for the `implement-code` port** (`skills/implementation-discipline/SKILL.md`, `skills/implementation-discipline/adapters/implement-code-adapter.md`): migrated three adapter-only behaviors (scope-discipline standard, `scope-violation` halt trigger, `simplicity-violation` halt trigger) from the adapter into the skill, then slimmed `implement-code-adapter.md` from 123 to 52 lines into a thin port-binding that names the skill as execution authority. The Halt-Return shape and reason enum stay single-sourced in `agents/Senior-Engineer.agent.md § Halt-Return Contract`. Code-Smith reads only the skill (design D0), so the port-specific triggers must live there. Code-Smith `## Core Principles` annotated as intentional persona voice pending shell retirement (#669, capstone #671, umbrella #662).
+
 ## [2.25.0] — 2026-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > ⚠️ **GitHub Copilot / VS Code support is frozen and retiring after 2026-08-31.**
 > Claude Code is the actively supported path. See [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md) for details and the reach-out channel if you depend on Copilot support.
 
-[![Version](https://img.shields.io/badge/version-v2.25.1-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v2.25.2-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development through specialized Claude Code agents. *(GitHub Copilot/VS Code: frozen and retiring after 2026-08-31 — see [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md))*

--- a/agents/Code-Smith.agent.md
+++ b/agents/Code-Smith.agent.md
@@ -53,6 +53,8 @@ You are a craftsman who takes pride in clean, minimal implementation. You build 
 - **Requirements over tests.** Making tests pass is the mechanism, not the goal. If tests pass but requirements aren't met, the implementation is incomplete.
 - **Don't cross layer boundaries.** Keep business logic pure. Framework, UI, and runtime concerns belong in their own layer — always.
 
+*These principles are intentional persona voice for the Code-Smith shell; they retire with the shell in the SE-migrate capstone (#671, umbrella #662), not as method content.*
+
 ## Overview
 
 A focused implementation mode that executes code changes following approved plans. Implements the core logic but delegates test validation to test-writer and documentation updates to doc-keeper.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "author": {
     "name": "Grimblaz"
   },

--- a/skills/implementation-discipline/SKILL.md
+++ b/skills/implementation-discipline/SKILL.md
@@ -94,7 +94,7 @@ Halt and return without completing the slice when either of these `implement-cod
 - **Scope violation** — the slice requires touching files unrelated to the dispatched requirement. Halt with reason `scope-violation`.
 - **Simplicity violation** — the implementation would require a new architectural seam, substantial refactor, or cross-layer dependency not called for by the plan. Halt with reason `simplicity-violation`.
 
-For the halt return shape and the full reason enum, see `agents/Senior-Engineer.agent.md` § `## Halt-Return Contract` — that section is the single authoritative source.
+For the Halt-Return shape and the full reason enum, see `agents/Senior-Engineer.agent.md` § `## Halt-Return Contract` — that section is the single authoritative source.
 
 ## Implementation Requirements Verification
 

--- a/skills/implementation-discipline/SKILL.md
+++ b/skills/implementation-discipline/SKILL.md
@@ -35,6 +35,7 @@ Implement only what the requirements demand, with clear delegation boundaries an
 - Prefer minimal changes over broad rewrites
 - Extract helpers when complexity limits or readability clearly require it
 - Follow repo architecture and file-size rules before adding new structure
+- Leave adjacent cleanup and follow-up ideas out of the implementation unless they are required for correctness
 
 ## Requirements Verification
 
@@ -85,6 +86,15 @@ Returning to orchestrator for redirection to Test-Writer.
 ````
 
 Why this matters: implementing against a broken test wastes time and pushes the code away from the real requirement.
+
+## Halt-Return Conditions
+
+Halt and return without completing the slice when either of these `implement-code`-specific conditions is met:
+
+- **Scope violation** — the slice requires touching files unrelated to the dispatched requirement. Halt with reason `scope-violation`.
+- **Simplicity violation** — the implementation would require a new architectural seam, substantial refactor, or cross-layer dependency not called for by the plan. Halt with reason `simplicity-violation`.
+
+For the halt return shape and the full reason enum, see `agents/Senior-Engineer.agent.md` § `## Halt-Return Contract` — that section is the single authoritative source.
 
 ## Implementation Requirements Verification
 

--- a/skills/implementation-discipline/adapters/implement-code-adapter.md
+++ b/skills/implementation-discipline/adapters/implement-code-adapter.md
@@ -29,7 +29,7 @@ Apply `skills/implementation-discipline/SKILL.md` to the dispatched slice. Use t
 
 Keep this adapter distinct from `implement-refactor`: do not perform behavior-preserving structural cleanup under this label. If the slice is refactoring-only, route to the `implement-refactor` port instead.
 
-For the halt return shape when a halt condition is reached, see `agents/Senior-Engineer.agent.md` § `## Halt-Return Contract`.
+For the Halt-Return shape when a halt condition is reached, see `agents/Senior-Engineer.agent.md` § `## Halt-Return Contract`.
 
 ## Terminal credit step
 

--- a/skills/implementation-discipline/adapters/implement-code-adapter.md
+++ b/skills/implementation-discipline/adapters/implement-code-adapter.md
@@ -25,82 +25,11 @@ description: "Work adapter for bounded, requirements-first implementation slices
 
 ## Execution contract
 
-Run the smallest correct implementation that satisfies the dispatched requirement. Treat tests as evidence, not as the requirement itself: making a narrow assertion pass is insufficient when production wiring, integration points, or design acceptance criteria remain unmet.
+Apply `skills/implementation-discipline/SKILL.md` to the dispatched slice. Use the skill's pre-implementation review, implementation standards, halt-return conditions, and requirements verification as the authority for execution details; this adapter only binds that methodology to the `implement-code` port and terminal credit step.
 
-Use these coding principles while executing the slice:
+Keep this adapter distinct from `implement-refactor`: do not perform behavior-preserving structural cleanup under this label. If the slice is refactoring-only, route to the `implement-refactor` port instead.
 
-- Requirements over tests: implement the documented behavior even when current tests cover only part of it.
-- YAGNI: do not add speculative options, helpers, abstractions, configuration, or future-facing behavior.
-- Minimal change: prefer a direct local edit over a broad rewrite when both satisfy the requirement.
-- Layer boundaries: keep core behavior out of UI, shell, or runtime glue unless the requirement explicitly belongs there.
-- Scope discipline: leave adjacent cleanup and follow-up ideas out of the implementation unless they are required for correctness.
-- Delegation over duplication: search for existing formulas, validation, mapping, and serialization before adding new logic.
-
-## Pre-implementation review
-
-Before editing files:
-
-1. Read the frame slice, plan requirement contract, relevant design context, and any cited acceptance criteria.
-2. Identify the production behavior that must change and the expected validation evidence.
-3. Confirm the change belongs in the current layer. Apply the replaceability test: if changing UI technology would change this code, it should not live in core logic.
-4. Search the local area for existing behavior that should be reused instead of copied.
-5. Name the smallest file set likely to satisfy the requirement. If the slice requires unrelated files, halt with `scope-violation`.
-
-## Implementation discipline
-
-- Implement only the current slice. Do not pre-build later plan steps.
-- Keep names straightforward and control flow easy to inspect.
-- Extract a helper only when it removes real duplication or keeps required logic readable.
-- Prefer structured APIs and serializers over manual string construction for structured data.
-- Preserve required array typing and parseability when editing JSON or JSON-like output.
-- Keep existing user or agent changes intact; work with them when they affect the slice.
-
-If the implementation would need a new architectural seam, substantial refactor, or cross-layer dependency not called for by the plan, halt with `simplicity-violation` or `scope-violation` and cite the exact requirement conflict.
-
-```yaml
-halt_return:
-  halt_reason: simplicity-violation
-  adapter_path: "skills/implementation-discipline/adapters/implement-code-adapter.md"
-  slice_id: "s3"
-  summary: "The requested implementation requires a new framework adapter that is not part of this slice."
-  evidence:
-    - "The slice only authorizes the implement-code port for the current production behavior."
-    - "The proposed change would introduce a cross-layer dependency before the design documents that seam."
-  recommended_next_owner: "planner"
-```
-
-## Bad test and blocked-input handling
-
-Stop implementation when a failing or newly added test appears wrong instead of exposing a product gap. Bad-test signals include incorrect expectations, assertions on implementation details, mismatch with documented requirements, invalid setup, or multiple failures sharing a likely test-side root cause.
-
-Do not edit the test, distort production code to satisfy it, or continue as if the requirement is clear. Return a halt finding with concrete evidence.
-
-```yaml
-halt_return:
-  halt_reason: push-back
-  adapter_path: "skills/implementation-discipline/adapters/implement-code-adapter.md"
-  slice_id: "s3"
-  summary: "The blocking test expects behavior that conflicts with the accepted requirement."
-  evidence:
-    - "Requirement AC5 states the work adapter must omit applies-when."
-    - "The failing assertion requires applies-when to be present on every adapter file."
-  recommended_next_owner: "test writer"
-```
-
-Use `uncertainty` when the slice lacks required inputs, `confusion` when inputs conflict, and `verification-gap` when required evidence cannot be produced after implementation.
-
-## Requirements verification
-
-After editing:
-
-1. Confirm the new behavior is wired into production code, not only test fixtures.
-2. Confirm expected integration points are connected.
-3. Compare the implementation against the design requirements and acceptance criteria.
-4. Validate structured output with the relevant parser when you create or edit it.
-5. Run the cheapest relevant validation command for the slice, then widen only if the plan requires it.
-6. If a documented requirement is not covered by tests, implement it anyway and report the missing coverage in the completion evidence.
-
-Completion evidence must name the changed files, the validation commands, pass/fail counts when available, and any requirement coverage that relied on manual inspection.
+For the halt return shape when a halt condition is reached, see `agents/Senior-Engineer.agent.md` § `## Halt-Return Contract`.
 
 ## Terminal credit step
 


### PR DESCRIPTION
Closes #669. Parent: #662 (SE-migrate consolidation track).

## Summary

Migrates three adapter-only behaviors into `implementation-discipline/SKILL.md` (fat-skills consolidation per #662), then slims `implement-code-adapter.md` from 123 → 52 lines to a thin port-binding. Code-Smith's `## Core Principles` annotated as intentional persona voice pending shell retirement in #671.

This is a **fat-skills consolidation**, not a mirror of the refactor precedent. `implement-refactor-adapter.md` keeps its halt trigger adapter-inline because its executor (Senior-Engineer) reaches halt semantics through the SE body. `implement-code`'s hub-mode executor is Code-Smith, which reads only the skill — never `Senior-Engineer.agent.md` — so the port-specific triggers must live in the skill for Code-Smith to reach them (design D0, judge-confirmed).

## Before/after mapping

| Removed section | Maps to |
| --- | --- |
| `## Pre-implementation review` (adapter) | `SKILL.md § Pre-Implementation Review` (:24) |
| `## Implementation discipline` (adapter) | `SKILL.md § Implementation Standards` (:32) + new scope-discipline bullet (:38) |
| `## Bad test and blocked-input handling` (adapter) — push-back path | `SKILL.md § Bad Test Detection` (:51) |
| `## Bad test and blocked-input handling` (adapter) — scope-violation halt trigger | `SKILL.md § Halt-Return Conditions` (:90) — `scope-violation` |
| `## Bad test and blocked-input handling` (adapter) — simplicity-violation halt trigger | `SKILL.md § Halt-Return Conditions` (:90) — `simplicity-violation` |
| `halt_return:` YAML blocks (adapter) — return shape + 7-value enum | `agents/Senior-Engineer.agent.md § Halt-Return Contract` (pointed to, not duplicated) |
| `## Requirements verification` (adapter) | `SKILL.md § Requirements Verification` (:40) + `§ Implementation Requirements Verification` (:99) |

Every removed behavior is reachable via slim-adapter + skill + SE body (S2 satisfied).

## Files changed

- [`skills/implementation-discipline/SKILL.md`](skills/implementation-discipline/SKILL.md) — added scope-discipline bullet + `## Halt-Return Conditions` section (+10 lines)
- [`skills/implementation-discipline/adapters/implement-code-adapter.md`](skills/implementation-discipline/adapters/implement-code-adapter.md) — slimmed 123 → 52 lines; execution contract now names skill as authority
- [`agents/Code-Smith.agent.md`](agents/Code-Smith.agent.md) — one annotation line inside `## Core Principles` citing #671/#662

## Adversarial review

3 prosecution passes → merged 4-finding ledger → defense → judge. All structural findings (MF1 discoverability, MF3 structural) defended with tree evidence. Two low-severity doc fixes incorporated: MF3 narrative corrected to "fat-skills consolidation per #662"; MF4 citation gap fixed (added `#671/#662` to Code-Smith annotation).

## Pester suite

2383 passed · 14 failed (pre-existing, none in changed files) · 28 skipped

Key plan-guarded tests green:
- `senior-engineer-skill-adapter.Tests.ps1` ✅ (parity, `-Step`, `spine-omitted|legacy`, `Build-ImplementCodeCreditRow`)
- `frame-validate.Tests.ps1` ✅ (`provides: implement-code`)
- `specialist-shell-parity.Tests.ps1` ✅ (Code-Smith H2 bijection)

## Cross-branch coordination

The parallel `#612` branch (`feature/issue-612-implement-test-docs-adapters`) also edits `senior-engineer-skill-adapter.Tests.ps1`. Whichever of #669/#612 lands second must rebase and re-run the full Pester suite.

---

<!-- pipeline-metrics -->
```yaml
pipeline_schema_version: 1
issue: 669
pipeline_tier: abbreviated
ce_gate: false
frame:
  spine_omitted: plan-too-small
credits:
  - port: implement-code
    adapter: skills/implementation-discipline/adapters/implement-code-adapter.md
    status: complete
    evidence: "fat-skills consolidation: SKILL.md +10 lines (scope-discipline + Halt-Return Conditions), adapter 123→52 lines, Code-Smith annotation"
    validation:
      - name: senior-engineer-skill-adapter.Tests.ps1
        status: passed
      - name: frame-validate.Tests.ps1
        status: passed
      - name: specialist-shell-parity.Tests.ps1
        status: passed
      - name: full Pester suite (2383/2397 passed)
        status: passed
adversarial_review:
  pipeline: standard
  prosecution_passes: 3
  findings_total: 4
  findings_sustained: 2
  findings_dismissed: 2
  judge_confidence: high
  marker: "<!-- adversarial-pipeline-atomic-669 -->"
```
<!-- /pipeline-metrics -->

## Summary by Sourcery

Consolidate implement-code execution rules into the implementation-discipline skill and turn the implement-code adapter into a thin port binding that defers to the shared methodology.

Enhancements:
- Document implement-code-specific halt-return conditions and scope/simplicity discipline centrally in the implementation-discipline skill.
- Clarify Code-Smith persona principles as shell-specific and slated for retirement with the SE-migrate capstone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined implementation discipline standards with guidance to avoid unrelated cleanup tasks within implementation scope.
  * Defined explicit halt-return conditions (`scope-violation`, `simplicity-violation`) to establish clear stopping points during code work.
  * Reorganized implementation contracts for improved clarity and reference structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->