### PR TITLE
feat: add ai-first-documentation skill — research-backed docs standards (v2.27.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.25.2"
+    "version": "2.27.0"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-      "version": "2.25.2",
+      "version": "2.27.0",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot",
-    "version": "2.25.2"
+    "version": "2.27.0"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot with 16 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.25.2"
+      "version": "2.27.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > ⚠️ **GitHub Copilot / VS Code support is frozen and retiring after 2026-08-31.**
 > Claude Code is the actively supported path. See [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md) for details and the reach-out channel if you depend on Copilot support.
 
-[![Version](https://img.shields.io/badge/version-v2.25.2-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v2.27.0-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development through specialized Claude Code agents. *(GitHub Copilot/VS Code: frozen and retiring after 2026-08-31 — see [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md))*

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-  "version": "2.25.2",
+  "version": "2.27.0",
   "author": {
     "name": "Grimblaz"
   },

--- a/skills/ai-first-documentation/SKILL.md
+++ b/skills/ai-first-documentation/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: ai-first-documentation
+description: "Research-backed standards for documentation in AI-first codebases: context-file architecture (CLAUDE.md, skills, subagents, rules), multi-agent interop, and project-doc organization, with a tiered audit rubric. Use when authoring or auditing CLAUDE.md/AGENTS.md, deciding where guidance belongs, or running a documentation gap analysis. DO NOT USE FOR: post-implementation doc updates (use documentation-finalization) or reference sidecar setup (use project-references)."
+---
+
+<!-- platform-assumptions: markdown skill guidance for Claude Code and compatible agents; rubric evidence verified against live vendor docs on 2026-06-10/11 — re-verify concrete numbers before hard enforcement. -->
+<!-- markdownlint-disable-file MD041 MD003 -->
+
+# AI-First Documentation Standards
+
+Standards for structuring a repository's documentation when coding agents are primary readers and operators. Every practice here is backed by two adversarially-verified research passes (June 2026) across Anthropic official guidance (Tier 1), major vendor guidance (Tier 2), and evidenced practitioner sources (Tier 3). The testable rubric lives in [rubric.md](./rubric.md); citations, verification dates, refuted claims, and open gaps live in [sources.md](./sources.md).
+
+## When to Use
+
+- Authoring or auditing a CLAUDE.md, AGENTS.md, or other always-loaded context file
+- Deciding where a piece of guidance belongs (always-loaded vs. path-scoped vs. skill vs. plain doc)
+- Designing or reviewing skills, subagent definitions, or rules files
+- Running a documentation gap analysis of a repository against industry best practice
+- Configuring a repo that must serve multiple agent toolchains (Claude Code, Copilot, Cursor, Codex)
+
+## Core Principle
+
+The context window is the scarce resource. Performance degrades as it fills, so always-loaded files must be ruthlessly minimal — every line survives the deletion test ("Would removing this cause the agent to make mistakes?") — while everything else moves to on-demand mechanisms: skills with progressive disclosure, path-scoped rules, child-directory context files, and just-in-time retrieval via glob/grep rather than pre-built indexes. (Tier 1; corroborated by all surveyed vendors and an academic taxonomy of 13 open-source agents.)
+
+Minimal does not mean short for its own sake: the criterion is signal density plus behavioral sufficiency, not raw line count.
+
+## The Placement Model
+
+Route each piece of guidance to its cheapest sufficient home:
+
+| Content kind | Home | Loading cost |
+| --- | --- | --- |
+| Broadly-applicable facts: non-guessable commands, non-default conventions, testing instructions, repo etiquette, gotchas, "always do X" rules | Root CLAUDE.md / AGENTS.md | Every session |
+| Area-specific instructions tied to file paths | Path-scoped rules (`paths:`/glob frontmatter) or child-directory CLAUDE.md | Only when matching files are touched |
+| Multi-step procedures, domain workflows, methodology | Skill (SKILL.md) | Metadata always (~100 tokens); body on demand |
+| Deep reference material, schemas, long examples | Skill reference files or plain docs, pointed to one level deep | Zero until accessed |
+| Side-effectful workflows that must not auto-trigger | Skill with `disable-model-invocation: true` | Manual invocation only |
+| High-volume exploration or review output | Subagent with isolated context | Never enters main context |
+| Anything derivable by reading the code, standard language conventions, frequently-changing facts, file-by-file codebase tours | Nowhere — delete it | — |
+
+Two traps in this model: `@import`s in CLAUDE.md load at launch and save **no** context (only child-directory files and skills defer cost), and rules files **without** a path scope load unconditionally every session.
+
+## Audit Workflow
+
+To run a gap analysis of a repository:
+
+1. **Inventory** the documentation surface: root and nested context files (`CLAUDE.md`, `AGENTS.md`, `CLAUDE.local.md`), `.claude/rules/`, `skills/*/SKILL.md`, agent definitions, and the plain-doc tree (design docs, ADRs, runbooks, plans).
+2. **Classify** each artifact against the Placement Model: is anything always-loaded that could be on-demand? Is anything on-demand that the agent needs every session?
+3. **Test** each applicable practice in [rubric.md](./rubric.md), section by section (A: always-loaded context, B: skills, C: subagents, D: writing style, E: multi-agent interop, F: project docs).
+4. **Weight findings by tier and confidence** from the rubric: a Tier 1 high-confidence violation is a defect; a Tier 2 conflict is a trade-off to decide consciously; a Tier 3 divergence is informational.
+5. **Label house conventions in open-gap areas.** Where the rubric marks a topic as a confirmed industry open gap (Section F), a repo's own conventions are not violations — record them as house practice filling a documented gap, and consider them candidates for promotion if external standards later emerge.
+
+## Multi-Agent Repositories
+
+When one repo serves several agent toolchains, consult rubric Section E before restructuring. Key verified facts: AGENTS.md is the cross-vendor de facto standard, but Claude Code does not read it natively (use a CLAUDE.md containing `@AGENTS.md`); Copilot's cloud agent reads CLAUDE.md natively but only as a single flat root file; Copilot code review reads only the first 4,000 characters of any instruction file; Cursor silently ignores plain `.md` files in `.cursor/rules` (frontmatter `.mdc` or AGENTS.md only); Codex concatenates AGENTS.md files root-down with the closest file winning positionally.
+
+One genuine unresolved conflict exists: GitHub recommends embedding repo structure and dependency versions and warns that pointer references to other docs may be ineffective in large repos — the opposite of Anthropic's deletion-test minimalism and progressive disclosure. Neither side has measured evidence. Default to the Anthropic model for Claude-primary repos; consciously revisit if Copilot adherence problems appear.
+
+## Known Industry Open Gaps
+
+No credible verified guidance exists (as of June 2026) for: authoring ADRs/design docs differently for AI readers; whether llms.txt-style index files help or hurt vs. pure just-in-time search; wrapping general project docs as skills; doc-to-code linking that breaks loudly on drift; or doc-tree naming conventions optimized for agent navigation. The only verified adjacent practices are staleness automation (review-time flagging of doc drift — "a stale context file can be worse than no file at all") and the split-and-reference pattern (concise root file pointing to task-specific docs). Treat conventions in these areas as labeled house judgment, not settled standards. Details in [sources.md](./sources.md).
+
+## Quick Reference — Verified Numbers
+
+| Number | What it bounds | Tier |
+| --- | --- | --- |
+| < 200 lines | CLAUDE.md adherence target (not a truncation limit) | 1 |
+| < 500 lines | SKILL.md body; also Cursor's per-rule-file ceiling | 1 / 2 |
+| 64 / 1024 chars | Skill frontmatter `name` / `description` hard limits | 1 |
+| 1 level | Skill reference-file depth from SKILL.md (never nested chains) | 1 |
+| > 100 lines | Reference file size that requires a leading table of contents | 1 |
+| Depth 4 | Maximum recursive `@import` depth in CLAUDE.md | 1 |
+| 4,000 chars | Copilot code review reads only this much of any instruction file | 2 |
+| 32 KiB | Codex default combined instruction-file budget (`project_doc_max_bytes`) | 2 |
+
+All numbers live-verified 2026-06-10/11; vendor docs churn, so re-verify before hard enforcement (see [sources.md](./sources.md)).
+
+## See Also
+
+- [rubric.md](./rubric.md) — the practice-by-practice testable audit rubric
+- [sources.md](./sources.md) — citations, verification dates, refuted claims, open questions
+- `documentation-finalization` — updating implementation-facing docs after code changes
+- `project-references` — Agent Orchestra reference sidecars and index conventions (a house convention in open-gap territory)
+- `skill-creator` — repo-specific skill frontmatter and structure conventions
+
+## Gotchas
+
+| Trigger | Gotcha | Fix |
+| --- | --- | --- |
+| Moving CLAUDE.md overflow into `@import` files "to save context" | Imports load in full at launch — zero context savings, same adherence cost | Move content to a skill or child-directory CLAUDE.md, which load on demand |
+| Adding a rules file without a path scope | It loads every session, silently becoming always-loaded context | Add a `paths:`/glob scope, or move the content to a skill |
+| Writing a skill description in first person or omitting "when to use" | Description is the sole selection signal injected into the system prompt; the skill is never picked | Third person, state what it does AND when to use it, within 1024 chars |
+| Chaining reference files (SKILL.md → ref-a.md → ref-b.md) | Agents may partially read nested references (e.g., head-100 previews) and miss content | Link every reference file directly from SKILL.md, one level deep |
+| Assuming Copilot honors nested CLAUDE.md or `@`-imports | Copilot's cloud agent reads only a single flat root CLAUDE.md | Keep the root file self-sufficient for Copilot, or maintain AGENTS.md |
+| Padding CLAUDE.md with folder structure and dependency versions | JIT-discoverable, staleness-prone content that fails the deletion test (GitHub recommends it; Anthropic canon excludes it — known conflict) | Default to omitting; the agent can glob/grep it fresh |

--- a/skills/ai-first-documentation/rubric.md
+++ b/skills/ai-first-documentation/rubric.md
@@ -1,0 +1,92 @@
+<!-- markdownlint-disable-file MD041 MD003 -->
+
+# AI-First Documentation Audit Rubric
+
+Practice-by-practice testable rubric. Each practice carries a tier (1 = Anthropic official, 2 = major vendor, 3 = evidenced practitioner), a confidence level from adversarial verification, and a short test an auditor can apply. Full citations and verification dates are in [sources.md](./sources.md).
+
+## Table of Contents
+
+- [Section A — Always-loaded context (CLAUDE.md / AGENTS.md root)](#section-a--always-loaded-context-claudemd--agentsmd-root)
+- [Section B — Skills](#section-b--skills)
+- [Section C — Subagents](#section-c--subagents)
+- [Section D — Writing style for agent-facing docs](#section-d--writing-style-for-agent-facing-docs)
+- [Section E — Multi-agent and vendor interop](#section-e--multi-agent-and-vendor-interop)
+- [Section F — Project documentation (thin verified set)](#section-f--project-documentation-thin-verified-set)
+- [How to score](#how-to-score)
+
+## Section A — Always-loaded context (CLAUDE.md / AGENTS.md root)
+
+| ID | Practice and test | Tier | Confidence |
+| --- | --- | --- | --- |
+| A1 | **Deletion test.** Every line survives "Would removing this cause the agent to make mistakes?" Test: sample lines and ask whether removal changes agent behavior. | 1 | High |
+| A2 | **Under 200 lines per file.** An adherence target, not a truncation limit — longer files reduce instruction adherence. Test: `wc -l` each always-loaded file. | 1 | High |
+| A3 | **Include only broadly-applicable facts.** Non-guessable commands, non-default code style, testing instructions, repo etiquette, project-specific architecture decisions, environment quirks, gotchas, "always do X" rules. Test: each section applies to most sessions, not one area. | 1 | High |
+| A4 | **Exclude derivable and volatile content.** No content the agent can read from code, no standard language conventions, no detailed API docs (link instead), no frequently-changing facts, no file-by-file codebase tours, no tutorials. Test: grep for directory listings, version pins, restated public docs. | 1 | High |
+| A5 | **Commands are copy-paste executable** with explicit flags (e.g., `pytest -v`), not bare tool names. Test: paste each documented command into a shell. | 2 | High |
+| A6 | **Six-area coverage**: commands, testing, project structure, code style, git workflow, boundaries (do-not-touch zones). Observational top-tier pattern from 2,500+ repos; one verifier dissent — treat as a checklist, not a mandate. Note the tension between a "project structure" section and A4; keep any structure notes to stable, non-derivable facts. | 2 | Medium |
+| A7 | **Failure-driven growth.** Start minimal; add a rule only after observing repeated agent mistakes it would prevent. Test: rules trace to actual observed failures, not speculation. | 2 | High |
+| A8 | **Use the hierarchy correctly.** Parent/root files load in full at launch (concatenated root-to-cwd, not overriding); child-directory CLAUDE.md files load on demand when files there are read; `@import`s (max depth 4) load at launch and save no context. Test: nothing was moved to an import "for context savings"; area-specific content lives in child files or skills. | 1 | High |
+| A9 | **Rules files are path-scoped.** A rules file without a path scope loads every session. Test: every file in `.claude/rules/` carries a `paths:` (or equivalent glob) scope, or its unconditional load is intentional. | 1 | High |
+
+## Section B — Skills
+
+| ID | Practice and test | Tier | Confidence |
+| --- | --- | --- | --- |
+| B1 | **Progressive disclosure in three levels.** Only name+description preloads (~100 tokens); SKILL.md body reads on relevance; bundled files read on demand (zero cost until accessed). Test: no skill content is duplicated into always-loaded files; deep material sits in bundled files. | 1 | High |
+| B2 | **SKILL.md body under 500 lines.** Split into referenced files when approaching the limit. Test: `wc -l` each SKILL.md. | 1 | High |
+| B3 | **Frontmatter contract.** `name` ≤ 64 chars, lowercase/numbers/hyphens, no XML tags, no reserved words ("claude", "anthropic"); `description` non-empty, ≤ 1024 chars, no XML tags, third person, states what the skill does AND when to use it. Test: validate each skill's frontmatter against these limits. | 1 | High |
+| B4 | **References one level deep.** Every reference file links directly from SKILL.md; no nested reference chains (partial reads miss content beyond one hop). Test: trace links from each SKILL.md. | 1 | High |
+| B5 | **Table of contents in long references.** Reference files over 100 lines open with a ToC so partial reads reveal full scope. Test: check the head of each reference file. | 1 | High |
+| B6 | **Manual trigger for side effects.** Workflows with side effects that should not auto-fire declare `disable-model-invocation: true`. Note: such skills do NOT get their descriptions preloaded. Test: review side-effectful skills' frontmatter. | 1 | High |
+| B7 | **Separate rarely co-used contexts.** Mutually-exclusive or rarely co-used content lives in separate file paths to avoid loading both. Test: look for reference files bundling unrelated variants. | 1 | High |
+| B8 | **Execute scripts, don't read them.** Deterministic utility logic ships as scripts run via shell — contents never enter context, only output does. Test: procedural logic that could be a script isn't transcribed as prose steps. | 1 | High |
+
+## Section C — Subagents
+
+| ID | Practice and test | Tier | Confidence |
+| --- | --- | --- | --- |
+| C1 | **Format contract.** Markdown with YAML frontmatter; only `name` and `description` required; the body becomes the system prompt. Test: validate each agent definition. | 1 | High |
+| C2 | **One focused task each**, with detailed descriptions — delegation is driven by the description field ("use proactively" phrasing encourages proactive dispatch). Test: each agent's description states a single clear responsibility and dispatch trigger. | 1 | High |
+| C3 | **Least-privilege tools; version controlled.** Restrict tool access to what the role needs; check project agents into git. Test: review `tools:` lists against each agent's actual needs. | 1 | High |
+| C4 | **Plan for isolation semantics.** Subagents start with fresh context (no conversation history) but DO load the full CLAUDE.md hierarchy and a git-status snapshot — except built-in Explore and Plan, which skip both, non-configurably. Test: agent bodies don't assume conversation context; nothing relies on Explore/Plan seeing CLAUDE.md. | 1 | High |
+
+## Section D — Writing style for agent-facing docs
+
+| ID | Practice and test | Tier | Confidence |
+| --- | --- | --- | --- |
+| D1 | **Right altitude.** Neither hardcoded brittle if-else logic nor vague high-level platitudes; concrete heuristics the agent can apply with judgment. Test: sample instructions for both failure modes. | 1 | High |
+| D2 | **Delimited sections.** Organize instruction files into distinct sections with Markdown headers or XML tags. Test: visual scan of structure. | 1 | High |
+| D3 | **Canonical examples over edge-case lists.** A small set of diverse, representative examples beats exhaustive edge-case enumeration. Test: look for laundry-list rule dumps that could collapse into 2–3 worked examples. | 1 | High |
+
+## Section E — Multi-agent and vendor interop
+
+Apply only when the repo serves toolchains beyond Claude Code.
+
+| ID | Practice and test | Tier | Confidence |
+| --- | --- | --- | --- |
+| E1 | **AGENTS.md is the cross-vendor standard** (~60k–95k repos, Linux Foundation stewardship), with an explicit split: README for humans, AGENTS.md for agent-relevant build/test/convention detail. Test: multi-agent repos carry an AGENTS.md; READMEs aren't duplicating agent instructions. | 2 | High |
+| E2 | **Claude Code does not read AGENTS.md natively.** Official interop: a CLAUDE.md containing `@AGENTS.md` (import preferred over symlink on Windows). Test: repos standardizing on AGENTS.md have the shim. | 1 | High |
+| E3 | **Copilot's cloud agent reads CLAUDE.md natively — but only a single flat root file.** Nested CLAUDE.md and `@`-imports are not honored; VS Code Chat and Copilot CLI read AGENTS.md only. Test: content Copilot must see lives in the flat root file or AGENTS.md. | 2 | High |
+| E4 | **Copilot code review reads only the first 4,000 characters** of any instruction file (silently truncates; limit had a 2026 docs-churn episode — re-verify). Test: review-critical guidance sits within the first 4,000 chars. | 2 | High |
+| E5 | **Cursor ignores plain `.md` in `.cursor/rules`.** Rules require `.mdc` with frontmatter (`description`, `globs`, `alwaysApply`); empty frontmatter degrades to manual-only. Cursor also natively supports root and nested AGENTS.md as the metadata-free alternative. Test: no orphaned `.md` files in `.cursor/rules/`. | 2 | High |
+| E6 | **Codex concatenates AGENTS.md root-down**; the file closest to the working directory wins positionally; combined budget defaults to 32 KiB (`project_doc_max_bytes`); one file per directory. Test: nested AGENTS.md files don't restate parents; total size within budget. | 2 | High |
+| E7 | **Copilot precedence when formats collide**: personal > repo path-specific > repo-wide copilot-instructions.md > agent files (AGENTS.md/CLAUDE.md) > organization — all applicable sets merge rather than filter. AGENTS.md-vs-CLAUDE.md precedence at the same level is undocumented. Test: don't place contradictory instructions across layers. | 2 | High |
+| E8 | **CONFLICT (unresolved): GitHub vs. minimalism.** GitHub recommends embedding project overview, folder structure, coding standards, and dependency versions, and warns pointer references to other docs may be ineffective in large repos — opposing Tier 1 deletion-test minimalism and progressive disclosure. No measured evidence either way. Audit action: pick a side consciously per primary toolchain; default Anthropic-style for Claude-primary repos. | 2 | High (that the conflict exists) |
+
+## Section F — Project documentation (thin verified set)
+
+Verified practices are sparse here; see [sources.md](./sources.md) § Open gaps before treating anything beyond these rows as standard.
+
+| ID | Practice and test | Tier | Confidence |
+| --- | --- | --- | --- |
+| F1 | **Organize for just-in-time retrieval, not pre-built indexes.** Agents navigate via glob/grep at runtime (8 of 13 surveyed open-source agents implement pure JIT search). Docs should be findable by predictable paths and grep-able headings rather than relying on a maintained index. Test: can an agent locate the right doc with one glob + one grep? | 1 (+3 corroboration) | High |
+| F2 | **Split-and-reference.** Keep the root context file concise and reference task-specific markdown docs (planning, review, architecture) — a plain-markdown analog of progressive disclosure. Test: root file points to task docs instead of inlining them. | 2 | High |
+| F3 | **Automate staleness detection.** Close the loop with review-time automation that flags when code changes suggest context/docs need updating — rationale: "a stale AGENTS.md can be worse than no file at all." Evidence: one org at ~3,900-repo scale (capability statement, no published precision/recall). Test: some mechanism (reviewer prompt, CI check, hook) ties doc updates to code change review. | 3 | Medium |
+| F4 | **Machine-citable standards.** Give internal standards stable, citable identifiers (e.g., named rules/RFC numbers) so context files and reviews can reference them precisely. Evidence: same single-org source as F3. Test: conventions cited by anchor/name rather than restated. | 3 | Medium |
+
+## How to score
+
+- **Tier 1 + High** violation → defect; fix it.
+- **Tier 2 + High** violation → conscious trade-off; record the decision and which toolchain it favors.
+- **Tier 2 Medium / Tier 3** divergence → informational; note and move on.
+- **Open-gap territory** (anything Section F doesn't cover) → house convention; label it as such, don't score it.

--- a/skills/ai-first-documentation/sources.md
+++ b/skills/ai-first-documentation/sources.md
@@ -1,0 +1,75 @@
+<!-- markdownlint-disable-file MD041 MD003 -->
+
+# Sources, Verification Record, and Open Gaps
+
+Evidence record behind [rubric.md](./rubric.md). Two deep-research passes (June 2026), each with parallel multi-angle search, source fetching, and 3-vote adversarial verification per claim. Pass 1: 23 sources, 115 claims extracted, 25 verified (24 confirmed, 1 refuted). Pass 2: 26 sources, 128 claims extracted, 25 verified (22 confirmed, 3 refuted). All surviving claims were live-verified against their sources on **2026-06-10/11**.
+
+## Table of Contents
+
+- [Tier 1 — Anthropic official](#tier-1--anthropic-official)
+- [Tier 2 — Major vendor guidance](#tier-2--major-vendor-guidance)
+- [Tier 3 — Evidenced practitioners and research](#tier-3--evidenced-practitioners-and-research)
+- [Refuted claims (do not carry forward)](#refuted-claims-do-not-carry-forward)
+- [Confirmed open gaps](#confirmed-open-gaps)
+- [Re-verification guidance](#re-verification-guidance)
+
+## Tier 1 — Anthropic official
+
+| Source | Backs rubric items |
+| --- | --- |
+| [Claude Code best practices](https://code.claude.com/docs/en/best-practices) | A1–A4, A8, B1, F1 |
+| [Claude Code memory](https://code.claude.com/docs/en/memory) | A2–A4, A8, A9, E2 |
+| [Agent Skills best practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices) (redirects to platform.claude.com) | B1–B5, B7, B8 |
+| [Engineering: effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) | Core principle, A1, D1–D3, F1 |
+| [Engineering: equipping agents for the real world with Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) | B1, B2, B6, B7 |
+| [Claude Code sub-agents](https://code.claude.com/docs/en/sub-agents) | C1–C4 |
+| [anthropics/skills repo](https://github.com/anthropics/skills) | B3, B4 (corroboration) |
+
+Key verified quotes: the deletion test ("Would removing this cause Claude to make mistakes?... Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"); "target under 200 lines per CLAUDE.md file"; "Keep SKILL.md body under 500 lines"; "Keep references one level deep"; the hybrid retrieval model ("CLAUDE.md files are naively dropped into context up front, while primitives like glob and grep... bypass the issues of stale indexing").
+
+## Tier 2 — Major vendor guidance
+
+| Source | Backs rubric items |
+| --- | --- |
+| [agents.md spec](https://agents.md/) | E1 (60k+ claimed; ~95k independently verified via GitHub code search) |
+| [GitHub Blog: lessons from 2,500+ AGENTS.md files](https://github.blog/ai-and-ml/github-copilot/how-to-write-a-great-agents-md-lessons-from-over-2500-repositories/) | A5, A6 |
+| [GitHub Docs: response customization](https://docs.github.com/en/copilot/concepts/prompting/response-customization) | E3, E4, E7, E8 |
+| [GitHub Docs: custom-instructions support matrix](https://docs.github.com/en/copilot/reference/custom-instructions-support) | E3, E7 |
+| [GitHub Docs: customize code review](https://docs.github.com/en/copilot/tutorials/customize-code-review) | E4 |
+| [Cursor rules docs](https://cursor.com/docs/rules) | E5; <500-line rule-file ceiling |
+| [OpenAI Codex: AGENTS.md guide](https://developers.openai.com/codex/guides/agents-md) | E6 |
+| [OpenAI Codex: best practices](https://developers.openai.com/codex/learn/best-practices) | A7, F2 ("A short, accurate AGENTS.md is more useful than a long file full of vague rules") |
+
+## Tier 3 — Evidenced practitioners and research
+
+| Source | Backs rubric items | Evidence quality |
+| --- | --- | --- |
+| [Cloudflare: internal AI engineering stack](https://blog.cloudflare.com/internal-ai-engineering-stack/) (Apr 2026) | F3, F4 | n = 1 org, ~3,900 repos, self-reported; deployed pattern, not measured effectiveness |
+| [HumanLayer production CLAUDE.md](https://github.com/humanlayer/humanlayer/blob/main/CLAUDE.md) | A1, A2 confirmation | n = 1 repo; independently measured at 88 lines, 7 sections, deliberate pruning commits |
+| [arXiv 2604.03515: taxonomy of 13 open-source coding agents](https://arxiv.org/pdf/2604.03515) (Apr 2026) | F1 corroboration | Single-author preprint; open-source agents only — Cursor (proprietary) uses pre-built embedding indexes |
+| [Cline rules docs](https://docs.cline.bot/customization/cline-rules) | E1 corroboration (reads .cursorrules, .windsurfrules, AGENTS.md) | Vendor doc |
+
+## Refuted claims (do not carry forward)
+
+Adversarial verification killed these plausible-sounding claims; do not let them re-enter the canon:
+
+1. **"File metadata (names, sizes, timestamps) functions as freshness/relevance signals for agents"** — refuted 0-3. There is no verified freshness-signal prescription from Anthropic.
+2. **"AGENTS.md is the only universally honored instruction format across Copilot surfaces"** — refuted 0-3. Support is genuinely uneven per surface.
+3. **"Codex's 32 KiB cap constitutes a divergence from minimalism"** — refuted 0-3. The cap is a loading budget, not content guidance; OpenAI's content guidance is explicitly minimalist.
+4. **"Directory-scoped AGENTS.md overrides are OpenAI's official monorepo scoping prescription"** — refuted 0-3. The layered root-down merge is documented; the monorepo prescription framing is not.
+
+## Confirmed open gaps
+
+Two independent research passes converged on the same list. No credible Tier 1–3 guidance survived verification for:
+
+- How to author ADRs, design docs, and runbooks differently when an AI agent is a primary reader
+- Whether llms.txt-style indexes/manifests help or hurt vs. pure just-in-time glob/grep search (no comparative evidence exists)
+- Docs-as-skills: wrapping general project docs in SKILL.md beyond Anthropic's settled skills canon
+- Doc-to-code / code-to-doc linking conventions that break loudly on drift
+- Directory structure and naming conventions for doc trees optimized for agent navigation
+
+Sharpest unresolved cross-vendor question: does GitHub's warning against pointer references (rubric E8) hold for same-repo progressive-disclosure pointers? The doc's own example is cross-repo; no measured evidence either way.
+
+## Re-verification guidance
+
+Vendor documentation churns. Before enforcing any concrete number as a hard gate, re-verify against the live source — particularly: the Copilot 4,000-character code-review limit (had a Feb-2026 docs-churn episode); the Claude Code AGENTS.md non-support status (open feature request with 5,200+ reactions — if native support lands, the `@AGENTS.md` shim pattern becomes legacy); and the docs.claude.com → platform.claude.com skill-page redirects. The 200-line and 500-line targets are quality recommendations, not enforced limits, and should be treated as adherence guidance rather than CI failures.


### PR DESCRIPTION
## Summary

Adds `skills/ai-first-documentation/` — a reusable skill encoding industry best practices for documentation in AI-first codebases, backed by two adversarially-verified deep-research passes (June 2026):

- **Pass 1** (AI-context files): 23 sources, 115 claims extracted, top 25 verified by 3-vote adversarial panels — 24 confirmed, 1 refuted. Nearly all Tier 1 Anthropic official guidance, live-verified 2026-06-10.
- **Pass 2** (project docs + vendors/practitioners): 26 sources, 128 claims, 22 confirmed, 3 refuted. Mapped cross-vendor convergence and three concrete conflicts (GitHub embed-vs-JIT, Cursor mandatory `.mdc` frontmatter, Copilot flat-root-CLAUDE.md + 4,000-char review cap).

## What's in the skill

| File | Contents |
| --- | --- |
| `SKILL.md` (95 lines) | Core principle, placement model (where any guidance belongs: always-loaded → path-scoped → skill → reference → subagent → delete), 5-step audit workflow, multi-agent interop, verified-numbers quick reference, gotchas |
| `rubric.md` | 28 testable practices in 6 sections, each with source tier (1=Anthropic, 2=vendor, 3=practitioner), confidence from adversarial verification, and a concrete auditor test; tier-aware scoring rules |
| `sources.md` | Full citations + verification dates, 4 refuted claims that must not re-enter the canon, confirmed industry open gaps, re-verification guidance for churn-prone numbers |

The skill deliberately complies with its own rubric: under the line caps, references one level deep, ToCs in reference files, third-person what+when description.

## Version bump + lockstep repair

- Bumps **2.26.0 → 2.27.0** (minor: new user-visible skill surface, per plugin-release-hygiene).
- **Fixes pre-existing version drift on `main`**: #684 bumped only `.claude-plugin/plugin.json` to 2.26.0, leaving the other six occurrences at 2.25.2. Lockstep was restored at 2.26.0 (the version live plugin caches are serving) before `bump-version.ps1` wrote 2.27.0 across all 7 occurrences.

## Notable research outcomes

- Project-doc organization for agents (ADR/design-doc authoring for AI readers, llms.txt indexes, doc-to-code linking) is a **confirmed industry open gap** — two independent research passes converged on the same list. The rubric scores these areas as labeled house conventions, not violations; this repo's project-references system operates in exactly that unstandardized territory.
- Sharpest unresolved vendor conflict: GitHub recommends embedding repo structure/dependency versions and warns against pointer references in large repos — the opposite of Anthropic's deletion-test minimalism and progressive disclosure. No measured evidence on either side; the rubric flags it for conscious per-repo decision.

## Follow-up

Agreed next step: run the gap-analysis audit of this repo against `rubric.md`, using the skill as the audit instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a reusable, research-backed ai-first-documentation skill and align plugin versioning for the new release.

New Features:
- Introduce an ai-first-documentation skill providing standards and guidance for structuring AI-first repository documentation, context files, skills, and multi-agent setups.

Enhancements:
- Document a detailed, testable audit rubric and evidence record for AI-first documentation practices, including vendor interoperability and known industry gaps.

Build:
- Bump the documented/plugin version to 2.27.0 and restore consistent versioning across all plugin configuration files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 2.27.0 across all manifest and configuration files.

* **Documentation**
  * Introduced comprehensive AI-first documentation standards framework including context-file architecture guidelines, content placement model for different documentation types, audit rubric with structured scoring criteria, verification sources documenting vendor guidance and research, plus documented implementation gotchas, known gaps, and industry limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->