### PR TITLE
chore(release): bump plugin version to 2.28.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.27.0"
+    "version": "2.28.0"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-      "version": "2.27.0",
+      "version": "2.28.0",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot",
-    "version": "2.27.0"
+    "version": "2.28.0"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot with 16 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.27.0"
+      "version": "2.28.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to agent-orchestra will be documented in this file.
 
+## [2.28.0] — 2026-06-12
+
+### Added
+
+- **Plan-authoring Grounding Pass** (`skills/plan-authoring/SKILL.md`): a new `### 4. Grounding Pass` discipline in the Discovery Workflow that establishes the invariant "no plan step may name an ungrounded artifact." Before drafting, the planner verifies that every artifact a plan step names (file names, paths, exported symbols, shapes, counts) actually exists in the tree and corrects or updates the issue when it does not. Adds a `#591` migration-scan carve-out, a `#467` per-port observation note, a Research Subagent contradiction-reporting directive, a factual-correction exemption in the Alignment Workflow (factual corrections are not "material scope changes" that trigger loop-back), and a reciprocal cross-reference with the post-draft Tree-State Verification Discipline. Locked by the RED assertion-existence contract `.github/scripts/Tests/plan-authoring-grounding-pass.Tests.ps1` (#473).
+
+## [2.27.0] — 2026-06-11
+
+### Added
+
+- **`ai-first-documentation` skill** (`skills/ai-first-documentation/`): research-backed documentation standards skill for authoring docs optimized for AI-agent consumption (#686).
+
 ## [2.26.0] — 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > ⚠️ **GitHub Copilot / VS Code support is frozen and retiring after 2026-08-31.**
 > Claude Code is the actively supported path. See [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md) for details and the reach-out channel if you depend on Copilot support.
 
-[![Version](https://img.shields.io/badge/version-v2.27.0-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v2.28.0-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development through specialized Claude Code agents. *(GitHub Copilot/VS Code: frozen and retiring after 2026-08-31 — see [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md))*

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "author": {
     "name": "Grimblaz"
   },


### PR DESCRIPTION
## What

Bumps the plugin version `2.27.0 → 2.28.0` across all 7 occurrences (5 files) via `bump-version.ps1`, and updates the CHANGELOG.

## Why

PR #700 (plan-authoring Grounding Pass, issue #473) merged **without** a version bump. Claude Code keys its plugin cache by the `version` in `.claude-plugin/plugin.json`, so same-version installs would keep serving the stale `2.27.0` snapshot and consumers would never pick up the new Grounding Pass discipline. This fast-follow bump invalidates the cache.

Classified **minor** per `plugin-release-hygiene`: #700 introduces a new user-visible methodology surface (the `### 4. Grounding Pass` discipline and its "no plan step may name an ungrounded artifact" invariant).

## Changes

- `bump-version.ps1 -Version 2.28.0` → `plugin.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (×2), `.github/plugin/marketplace.json` (×2), `README.md` badge.
- CHANGELOG: added `[2.28.0]` entry for #700.
- CHANGELOG: backfilled the missing `[2.27.0]` entry (ai-first-documentation skill, #686) — it was never recorded when 2.27.0 shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the plugin version to 2.28.0 and document recent releases.

New Features:
- Document the new plan-authoring Grounding Pass discipline added in version 2.28.0.
- Document the ai-first-documentation skill introduced in version 2.27.0.

Enhancements:
- Update README version badge and all plugin metadata files to reflect version 2.28.0.