### PR TITLE
feat(#703): CI release gate — fail PRs touching entry points without version bump + CHANGELOG

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "2.30.0"
+    "version": "2.31.0"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-      "version": "2.30.0",
+      "version": "2.31.0",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot",
-    "version": "2.30.0"
+    "version": "2.31.0"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot with 16 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "2.30.0"
+      "version": "2.31.0"
     }
   ]
 }

--- a/.github/scripts/Tests/entry-point-scope-parity.Tests.ps1
+++ b/.github/scripts/Tests/entry-point-scope-parity.Tests.ps1
@@ -1,0 +1,53 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Parity test: skills/plugin-release-hygiene/SKILL.md § Entry-Point Scope vs
+    Get-FVPluginEntryPointPatterns in frame-predicate-core.ps1 (#703 s4).
+
+.DESCRIPTION
+    Asserts that the canonical entry-point set in the skill prose exactly mirrors
+    the function's output. Any drift causes CI to fail here rather than silently.
+#>
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..' 'lib' 'frame-predicate-core.ps1')
+}
+
+Describe 'Entry-point scope parity: SKILL.md vs Get-FVPluginEntryPointPatterns' {
+
+    It 'skill list and function output share the same canonical entry-point set' {
+        # --- Parse the skill's Entry-Point Scope section ---
+        $skillPath = Join-Path $PSScriptRoot '..' '..' '..' 'skills' 'plugin-release-hygiene' 'SKILL.md'
+        $skillContent = Get-Content -Path $skillPath -Raw
+
+        # Extract the section between ## Entry-Point Scope and the next ## (or EOF)
+        $sectionMatch = [regex]::Match($skillContent, '(?ms)^## Entry-Point Scope.*?(?=^##|\Z)')
+        $sectionMatch.Success | Should -BeTrue -Because 'SKILL.md must have an ## Entry-Point Scope section'
+
+        $section = $sectionMatch.Value
+
+        # Extract backtick-quoted entries from bullet lines: - `path/**`
+        $rawSkillEntries = [regex]::Matches($section, '(?m)^-\s+`([^`]+)`') |
+            ForEach-Object { $_.Groups[1].Value }
+
+        # Normalize: strip /**  /*  \* suffixes; convert \ to /
+        $skillCanonical = $rawSkillEntries | ForEach-Object {
+            $_ -replace '/\*\*$', '' -replace '/\*$', '' -replace '\\\*$', '' -replace '\\', '/'
+        } | Sort-Object -Unique
+
+        # --- Get function output and normalize ---
+        $functionPatterns = Get-FVPluginEntryPointPatterns
+
+        $functionCanonical = $functionPatterns | ForEach-Object {
+            $_ -replace '/\*$', '' -replace '\\\*$', '' -replace '\\', '/'
+        } | Sort-Object -Unique
+
+        # --- Assert parity ---
+        $skillCanonical | Should -BeExactly $functionCanonical -Because (
+            "The skill's Entry-Point Scope section must mirror Get-FVPluginEntryPointPatterns exactly. " +
+            "Skill canonical: [$($skillCanonical -join ', ')]. " +
+            "Function canonical: [$($functionCanonical -join ', ')]."
+        )
+    }
+}

--- a/.github/scripts/Tests/release-gate.Tests.ps1
+++ b/.github/scripts/Tests/release-gate.Tests.ps1
@@ -14,6 +14,10 @@
       - Invoke-ReleaseGateEvaluation      : pure orchestrator, waiver application
 
     Tests are RED until s2 creates release-gate-core.ps1.
+
+    Additional describe blocks added in the GitHub review pass (proxy prosecution G-1/G-2/G-9):
+      - Get-PluginVersionFromString (new shared extractor; folds G-3/G-6 base-version asymmetry)
+      - Get-ReleaseGateWaiver: regression for G-1 multi-line commit space-join bug
 #>
 
 BeforeAll {
@@ -99,14 +103,40 @@ Describe 'Get-PluginVersion' {
         }
     }
 
-    It 'returns $null or throws for a nonexistent file path' {
+    It 'returns $null for a nonexistent file path' {
         $nonExistentPath = Join-Path $PSScriptRoot 'does-not-exist-xyzzy-12345.json'
-        try {
-            $result = Get-PluginVersion -Path $nonExistentPath
-            $result | Should -BeNullOrEmpty
-        } catch {
-            $true | Should -Be $true
-        }
+        $result = Get-PluginVersion -Path $nonExistentPath
+        $result | Should -BeNullOrEmpty
+    }
+}
+
+# ===========================================================================
+Describe 'Get-PluginVersionFromString' {
+# ===========================================================================
+# Shared string extractor used by both Get-PluginVersion and the wrapper's base-branch
+# version parse. Ensures the same strict no-leading-zeros rule applies everywhere (G-3/G-6).
+
+    It 'returns the version string for a valid 3-segment version' {
+        $json = '{"name":"agent-orchestra","version":"2.31.0"}'
+        $result = Get-PluginVersionFromString -Content $json
+        $result | Should -Be '2.31.0'
+    }
+
+    It 'returns $null for a 2-segment version' {
+        $json = '{"name":"agent-orchestra","version":"2.31"}'
+        $result = Get-PluginVersionFromString -Content $json
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'returns $null for a leading-zero version (2.030.0) — strict rule applies to base JSON too' {
+        $json = '{"name":"agent-orchestra","version":"2.030.0"}'
+        $result = Get-PluginVersionFromString -Content $json
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'returns $null for empty content' {
+        $result = Get-PluginVersionFromString -Content ''
+        $result | Should -BeNullOrEmpty
     }
 }
 
@@ -205,6 +235,16 @@ Describe 'Get-ReleaseGateWaiver' {
         $result = Get-ReleaseGateWaiver -CommitMessage $msg
         $result | Should -BeNullOrEmpty
     }
+
+    It 'detects waiver in a realistic multi-line commit when lines are newline-separated (G-1 regression)' {
+        # Regression: git log -1 --format=%B returns Object[]; if space-joined instead of
+        # newline-joined, the line-anchored (?m)^Skip-Release-Check: regex fails silently.
+        # Fix: (@(git log ...) -join [Environment]::NewLine). This test documents the contract.
+        $nl = [Environment]::NewLine
+        $msg = "feat: add new feature${nl}${nl}This change ships CHANGELOG-only.${nl}Skip-Release-Check: changelog-only"
+        $result = Get-ReleaseGateWaiver -CommitMessage $msg
+        $result | Should -Be 'changelog-only'
+    }
 }
 
 # ===========================================================================
@@ -213,7 +253,6 @@ Describe 'Invoke-ReleaseGateEvaluation' {
 
     It 'returns Pass=$true and ExitCode=0 when both legs pass and no waiver is present' {
         $result = Invoke-ReleaseGateEvaluation `
-            -ChangedFiles      @('skills/foo/SKILL.md') `
             -HeadVersion       '2.31.0' `
             -BaseVersion       '2.30.0' `
             -ChangelogContent  "## [2.31.0] — 2026-06-21`nRelease notes." `
@@ -226,7 +265,6 @@ Describe 'Invoke-ReleaseGateEvaluation' {
 
     It 'returns Pass=$false and FailedLegs includes bump when base equals head (no version bump)' {
         $result = Invoke-ReleaseGateEvaluation `
-            -ChangedFiles      @('skills/foo/SKILL.md') `
             -HeadVersion       '2.30.0' `
             -BaseVersion       '2.30.0' `
             -ChangelogContent  "## [2.30.0] — 2026-06-12`nRelease notes." `
@@ -239,7 +277,6 @@ Describe 'Invoke-ReleaseGateEvaluation' {
 
     It 'returns Pass=$false and FailedLegs includes changelog when bump present but changelog section missing' {
         $result = Invoke-ReleaseGateEvaluation `
-            -ChangedFiles      @('skills/foo/SKILL.md') `
             -HeadVersion       '2.31.0' `
             -BaseVersion       '2.30.0' `
             -ChangelogContent  "## [2.30.0] — 2026-06-12`nPrevious release." `
@@ -252,7 +289,6 @@ Describe 'Invoke-ReleaseGateEvaluation' {
 
     It 'returns Pass=$true when bump present, CHANGELOG missing, but changelog-only waiver is applied' {
         $result = Invoke-ReleaseGateEvaluation `
-            -ChangedFiles      @('skills/foo/SKILL.md') `
             -HeadVersion       '2.31.0' `
             -BaseVersion       '2.30.0' `
             -ChangelogContent  "## [2.30.0] — 2026-06-12`nPrevious release." `
@@ -265,7 +301,6 @@ Describe 'Invoke-ReleaseGateEvaluation' {
 
     It 'returns Pass=$false when no bump but changelog present and changelog-only waiver — bump leg is NOT waived' {
         $result = Invoke-ReleaseGateEvaluation `
-            -ChangedFiles      @('skills/foo/SKILL.md') `
             -HeadVersion       '2.30.0' `
             -BaseVersion       '2.30.0' `
             -ChangelogContent  "## [2.30.0] — 2026-06-12`nRelease notes." `
@@ -278,7 +313,6 @@ Describe 'Invoke-ReleaseGateEvaluation' {
 
     It 'returns Pass=$true when both legs fail but all waiver is applied' {
         $result = Invoke-ReleaseGateEvaluation `
-            -ChangedFiles      @('skills/foo/SKILL.md') `
             -HeadVersion       '2.30.0' `
             -BaseVersion       '2.30.0' `
             -ChangelogContent  "## [2.29.0] — 2026-05-01`nOlder release." `

--- a/.github/scripts/Tests/release-gate.Tests.ps1
+++ b/.github/scripts/Tests/release-gate.Tests.ps1
@@ -1,0 +1,290 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    RED Pester v5 suite for release-gate-core.ps1 (issue #703, slice s1).
+
+.DESCRIPTION
+    Tests covering all six pure functions exposed by release-gate-core.ps1:
+      - Test-ReleaseGateEntryPointTouched : entry-point pattern matching via -like
+      - Get-PluginVersion                 : JSON parse, version format assertion
+      - Compare-PluginVersionIsGreater    : strict -gt comparison via [System.Version]
+      - Test-ChangelogSectionPresent      : heading-line detection, dash-agnostic
+      - Get-ReleaseGateWaiver             : commit-message trailer parsing
+      - Invoke-ReleaseGateEvaluation      : pure orchestrator, waiver application
+
+    Tests are RED until s2 creates release-gate-core.ps1.
+#>
+
+BeforeAll {
+    $corePath = Join-Path $PSScriptRoot '..' 'lib' 'release-gate-core.ps1'
+    # This will fail until s2 creates the core — making tests RED.
+    . $corePath
+}
+
+# ===========================================================================
+Describe 'Test-ReleaseGateEntryPointTouched' {
+# ===========================================================================
+
+    It 'returns $true for a nested path under skills/* (entry-point pattern)' {
+        $result = Test-ReleaseGateEntryPointTouched -ChangedFiles @('skills/plugin-release-hygiene/SKILL.md')
+        $result | Should -Be $true
+    }
+
+    It 'returns $true for a top-level agents/* path' {
+        $result = Test-ReleaseGateEntryPointTouched -ChangedFiles @('agents/code-conductor.md')
+        $result | Should -Be $true
+    }
+
+    It 'returns $true for hooks/hooks.json' {
+        $result = Test-ReleaseGateEntryPointTouched -ChangedFiles @('hooks/hooks.json')
+        $result | Should -Be $true
+    }
+
+    It 'returns $false for a Documents path (non-entry-point)' {
+        $result = Test-ReleaseGateEntryPointTouched -ChangedFiles @('Documents/Design/foo.md')
+        $result | Should -Be $false
+    }
+
+    It 'returns $false for a .github/scripts path (non-entry-point)' {
+        $result = Test-ReleaseGateEntryPointTouched -ChangedFiles @('.github/scripts/foo.ps1')
+        $result | Should -Be $false
+    }
+
+    It 'returns $true when array contains a mix of non-entry-point and entry-point paths' {
+        $result = Test-ReleaseGateEntryPointTouched -ChangedFiles @('Documents/Design/foo.md', 'skills/x/y/z.md')
+        $result | Should -Be $true
+    }
+
+    It 'returns $false for an empty array' {
+        $result = Test-ReleaseGateEntryPointTouched -ChangedFiles @()
+        $result | Should -Be $false
+    }
+}
+
+# ===========================================================================
+Describe 'Get-PluginVersion' {
+# ===========================================================================
+
+    It 'returns the version string for a valid 3-segment version (2.30.0)' {
+        $tmpFile = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.json'
+        try {
+            '{"name":"agent-orchestra","version":"2.30.0"}' | Set-Content -Path $tmpFile -Encoding utf8
+            $result = Get-PluginVersion -Path $tmpFile
+            $result | Should -Be '2.30.0'
+        } finally {
+            Remove-Item -Path $tmpFile -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'throws or returns $null for a 2-segment version (2.30) — must reject before [System.Version] cast' {
+        $tmpFile = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.json'
+        try {
+            '{"name":"agent-orchestra","version":"2.30"}' | Set-Content -Path $tmpFile -Encoding utf8
+            $result = Get-PluginVersion -Path $tmpFile
+            $result | Should -BeNullOrEmpty
+        } catch {
+            # Throwing is also acceptable
+            $true | Should -Be $true
+        } finally {
+            Remove-Item -Path $tmpFile -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'throws or returns $null for a leading-zero version (2.030.0) — must assert format before [System.Version] cast' {
+        $tmpFile = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.json'
+        try {
+            '{"name":"agent-orchestra","version":"2.030.0"}' | Set-Content -Path $tmpFile -Encoding utf8
+            $result = Get-PluginVersion -Path $tmpFile
+            $result | Should -BeNullOrEmpty
+        } catch {
+            $true | Should -Be $true
+        } finally {
+            Remove-Item -Path $tmpFile -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'returns $null or throws for a nonexistent file path' {
+        $nonExistentPath = Join-Path $PSScriptRoot 'does-not-exist-xyzzy-12345.json'
+        try {
+            $result = Get-PluginVersion -Path $nonExistentPath
+            $result | Should -BeNullOrEmpty
+        } catch {
+            $true | Should -Be $true
+        }
+    }
+}
+
+# ===========================================================================
+Describe 'Compare-PluginVersionIsGreater' {
+# ===========================================================================
+
+    It 'returns $true when minor version is higher (2.31.0 > 2.30.0)' {
+        $result = Compare-PluginVersionIsGreater -NewVersion '2.31.0' -BaseVersion '2.30.0'
+        $result | Should -Be $true
+    }
+
+    It 'returns $true when patch version is higher (2.30.1 > 2.30.0)' {
+        $result = Compare-PluginVersionIsGreater -NewVersion '2.30.1' -BaseVersion '2.30.0'
+        $result | Should -Be $true
+    }
+
+    It 'returns $true when major version is higher (3.0.0 > 2.30.0)' {
+        $result = Compare-PluginVersionIsGreater -NewVersion '3.0.0' -BaseVersion '2.30.0'
+        $result | Should -Be $true
+    }
+
+    It 'returns $false when versions are equal (2.30.0 == 2.30.0) — equal FAILS the gate' {
+        $result = Compare-PluginVersionIsGreater -NewVersion '2.30.0' -BaseVersion '2.30.0'
+        $result | Should -Be $false
+    }
+
+    It 'returns $false for a downgrade (2.29.0 < 2.30.0)' {
+        $result = Compare-PluginVersionIsGreater -NewVersion '2.29.0' -BaseVersion '2.30.0'
+        $result | Should -Be $false
+    }
+}
+
+# ===========================================================================
+Describe 'Test-ChangelogSectionPresent' {
+# ===========================================================================
+
+    It 'matches an em-dash header with date for the exact version' {
+        $content = "# CHANGELOG`n`n## [2.31.0] — 2026-06-21`n`nSome release notes."
+        $result = Test-ChangelogSectionPresent -ChangelogContent $content -Version '2.31.0'
+        $result | Should -Be $true
+    }
+
+    It 'matches a header with no date (dash-agnostic, date optional)' {
+        $content = "# CHANGELOG`n`n## [2.31.0]`n`nSome release notes."
+        $result = Test-ChangelogSectionPresent -ChangelogContent $content -Version '2.31.0'
+        $result | Should -Be $true
+    }
+
+    It 'returns $false when version appears only in body text (not as a heading line)' {
+        # The string "## [2.31.0]" appears inside a paragraph sentence, not as a standalone heading
+        $content = "# CHANGELOG`n`nSee ## [2.31.0] in the archive for details.`n`n## [2.30.0] — 2026-06-12`n`nPrevious release."
+        $result = Test-ChangelogSectionPresent -ChangelogContent $content -Version '2.31.0'
+        $result | Should -Be $false
+    }
+
+    It 'returns $false when the target version section is absent from the CHANGELOG' {
+        $content = "# CHANGELOG`n`n## [2.30.0] — 2026-06-12`n`nPrevious release notes."
+        $result = Test-ChangelogSectionPresent -ChangelogContent $content -Version '2.31.0'
+        $result | Should -Be $false
+    }
+}
+
+# ===========================================================================
+Describe 'Get-ReleaseGateWaiver' {
+# ===========================================================================
+
+    It "returns 'changelog-only' when commit message contains the changelog-only trailer" {
+        $msg = "chore(release): bump version`n`nSkip-Release-Check: changelog-only"
+        $result = Get-ReleaseGateWaiver -CommitMessage $msg
+        $result | Should -Be 'changelog-only'
+    }
+
+    It "returns 'all' when commit message contains the all trailer with reason" {
+        $msg = "fix: hotfix deploy`n`nSkip-Release-Check: all need to hotfix"
+        $result = Get-ReleaseGateWaiver -CommitMessage $msg
+        $result | Should -Be 'all'
+    }
+
+    It 'returns $null when commit message has no trailer' {
+        $msg = "feat: add new feature`n`nThis is a normal commit with no waiver."
+        $result = Get-ReleaseGateWaiver -CommitMessage $msg
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'returns $null when the passed commit message does not contain the trailer (simulates non-head commit)' {
+        # The function only looks at the passed-in message; this simulates
+        # a caller passing a non-HEAD commit message that lacks the trailer.
+        $msg = ''
+        $result = Get-ReleaseGateWaiver -CommitMessage $msg
+        $result | Should -BeNullOrEmpty
+    }
+}
+
+# ===========================================================================
+Describe 'Invoke-ReleaseGateEvaluation' {
+# ===========================================================================
+
+    It 'returns Pass=$true and ExitCode=0 when both legs pass and no waiver is present' {
+        $result = Invoke-ReleaseGateEvaluation `
+            -ChangedFiles      @('skills/foo/SKILL.md') `
+            -HeadVersion       '2.31.0' `
+            -BaseVersion       '2.30.0' `
+            -ChangelogContent  "## [2.31.0] — 2026-06-21`nRelease notes." `
+            -HeadCommitMessage 'chore(release): bump version to 2.31.0'
+
+        $result.Pass        | Should -Be $true
+        $result.FailedLegs  | Should -BeNullOrEmpty
+        $result.ExitCode    | Should -Be 0
+    }
+
+    It 'returns Pass=$false and FailedLegs includes bump when base equals head (no version bump)' {
+        $result = Invoke-ReleaseGateEvaluation `
+            -ChangedFiles      @('skills/foo/SKILL.md') `
+            -HeadVersion       '2.30.0' `
+            -BaseVersion       '2.30.0' `
+            -ChangelogContent  "## [2.30.0] — 2026-06-12`nRelease notes." `
+            -HeadCommitMessage 'fix: some fix without version bump'
+
+        $result.Pass | Should -Be $false
+        $result.FailedLegs | Should -Contain 'bump'
+        $result.ExitCode | Should -Be 1
+    }
+
+    It 'returns Pass=$false and FailedLegs includes changelog when bump present but changelog section missing' {
+        $result = Invoke-ReleaseGateEvaluation `
+            -ChangedFiles      @('skills/foo/SKILL.md') `
+            -HeadVersion       '2.31.0' `
+            -BaseVersion       '2.30.0' `
+            -ChangelogContent  "## [2.30.0] — 2026-06-12`nPrevious release." `
+            -HeadCommitMessage 'chore(release): bump version to 2.31.0'
+
+        $result.Pass | Should -Be $false
+        $result.FailedLegs | Should -Contain 'changelog'
+        $result.ExitCode | Should -Be 1
+    }
+
+    It 'returns Pass=$true when bump present, CHANGELOG missing, but changelog-only waiver is applied' {
+        $result = Invoke-ReleaseGateEvaluation `
+            -ChangedFiles      @('skills/foo/SKILL.md') `
+            -HeadVersion       '2.31.0' `
+            -BaseVersion       '2.30.0' `
+            -ChangelogContent  "## [2.30.0] — 2026-06-12`nPrevious release." `
+            -HeadCommitMessage "chore(release): bump`n`nSkip-Release-Check: changelog-only"
+
+        $result.Pass           | Should -Be $true
+        $result.WaiverApplied  | Should -Be 'changelog-only'
+        $result.ExitCode       | Should -Be 0
+    }
+
+    It 'returns Pass=$false when no bump but changelog present and changelog-only waiver — bump leg is NOT waived' {
+        $result = Invoke-ReleaseGateEvaluation `
+            -ChangedFiles      @('skills/foo/SKILL.md') `
+            -HeadVersion       '2.30.0' `
+            -BaseVersion       '2.30.0' `
+            -ChangelogContent  "## [2.30.0] — 2026-06-12`nRelease notes." `
+            -HeadCommitMessage "fix: no bump`n`nSkip-Release-Check: changelog-only"
+
+        $result.Pass | Should -Be $false
+        $result.FailedLegs | Should -Contain 'bump'
+        $result.ExitCode | Should -Be 1
+    }
+
+    It 'returns Pass=$true when both legs fail but all waiver is applied' {
+        $result = Invoke-ReleaseGateEvaluation `
+            -ChangedFiles      @('skills/foo/SKILL.md') `
+            -HeadVersion       '2.30.0' `
+            -BaseVersion       '2.30.0' `
+            -ChangelogContent  "## [2.29.0] — 2026-05-01`nOlder release." `
+            -HeadCommitMessage "fix: emergency hotfix`n`nSkip-Release-Check: all need to hotfix"
+
+        $result.Pass          | Should -Be $true
+        $result.WaiverApplied | Should -Be 'all'
+        $result.ExitCode      | Should -Be 0
+    }
+}

--- a/.github/scripts/Tests/release-gate.Tests.ps1
+++ b/.github/scripts/Tests/release-gate.Tests.ps1
@@ -77,28 +77,23 @@ Describe 'Get-PluginVersion' {
         }
     }
 
-    It 'throws or returns $null for a 2-segment version (2.30) — must reject before [System.Version] cast' {
+    It 'returns $null for a 2-segment version (2.30)' {
         $tmpFile = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.json'
         try {
             '{"name":"agent-orchestra","version":"2.30"}' | Set-Content -Path $tmpFile -Encoding utf8
             $result = Get-PluginVersion -Path $tmpFile
             $result | Should -BeNullOrEmpty
-        } catch {
-            # Throwing is also acceptable
-            $true | Should -Be $true
         } finally {
             Remove-Item -Path $tmpFile -ErrorAction SilentlyContinue
         }
     }
 
-    It 'throws or returns $null for a leading-zero version (2.030.0) — must assert format before [System.Version] cast' {
+    It 'returns $null for a leading-zero version (2.030.0) — no-leading-zeros rule' {
         $tmpFile = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.json'
         try {
             '{"name":"agent-orchestra","version":"2.030.0"}' | Set-Content -Path $tmpFile -Encoding utf8
             $result = Get-PluginVersion -Path $tmpFile
             $result | Should -BeNullOrEmpty
-        } catch {
-            $true | Should -Be $true
         } finally {
             Remove-Item -Path $tmpFile -ErrorAction SilentlyContinue
         }
@@ -201,6 +196,12 @@ Describe 'Get-ReleaseGateWaiver' {
         # The function only looks at the passed-in message; this simulates
         # a caller passing a non-HEAD commit message that lacks the trailer.
         $msg = ''
+        $result = Get-ReleaseGateWaiver -CommitMessage $msg
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'returns $null when commit message MENTIONS the trailer in prose (not a real trailer line)' {
+        $msg = "feat: add gate documentation`n`nThis commit discusses Skip-Release-Check: all and Skip-Release-Check: changelog-only syntax in prose."
         $result = Get-ReleaseGateWaiver -CommitMessage $msg
         $result | Should -BeNullOrEmpty
     }

--- a/.github/scripts/lib/release-gate-core.ps1
+++ b/.github/scripts/lib/release-gate-core.ps1
@@ -1,0 +1,103 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Side-effect-free library for the CI release gate. Dot-source this file.
+    All logic is in functions; no top-level executable statements.
+#>
+
+. (Join-Path $PSScriptRoot 'frame-predicate-core.ps1')
+
+function Test-ReleaseGateEntryPointTouched {
+    param([string[]]$ChangedFiles)
+    $patterns = Get-FVPluginEntryPointPatterns
+    foreach ($file in $ChangedFiles) {
+        foreach ($pattern in $patterns) {
+            if ($file -like $pattern) {
+                return $true
+            }
+        }
+    }
+    return $false
+}
+
+function Get-PluginVersion {
+    param([Parameter(Mandatory)][string]$Path)
+    try {
+        $content = Get-Content -Path $Path -Raw -ErrorAction Stop
+    } catch {
+        return $null
+    }
+    if ($content -match '"version":\s*"([\d.]+)"') {
+        $versionString = $matches[1]
+    } else {
+        return $null
+    }
+    if ($versionString -notmatch '^\d+\.\d+\.\d+$') {
+        return $null
+    }
+    return $versionString
+}
+
+function Compare-PluginVersionIsGreater {
+    param(
+        [Parameter(Mandatory)][string]$NewVersion,
+        [Parameter(Mandatory)][string]$BaseVersion
+    )
+    return ([System.Version]$NewVersion -gt [System.Version]$BaseVersion)
+}
+
+function Test-ChangelogSectionPresent {
+    param(
+        [Parameter(Mandatory)][string]$ChangelogContent,
+        [Parameter(Mandatory)][string]$Version
+    )
+    $escaped = [regex]::Escape($Version)
+    $pattern = "(?m)^##\s+\[$escaped\]"
+    return [bool]([regex]::IsMatch($ChangelogContent, $pattern))
+}
+
+function Get-ReleaseGateWaiver {
+    param([string]$CommitMessage)
+    if ($CommitMessage -match 'Skip-Release-Check: all') {
+        return 'all'
+    }
+    if ($CommitMessage -match 'Skip-Release-Check: changelog-only') {
+        return 'changelog-only'
+    }
+    return $null
+}
+
+function Invoke-ReleaseGateEvaluation {
+    param(
+        [Parameter(Mandatory)][string[]]$ChangedFiles,
+        [Parameter(Mandatory)][string]$HeadVersion,
+        [Parameter(Mandatory)][string]$BaseVersion,
+        [Parameter(Mandatory)][string]$ChangelogContent,
+        [string]$HeadCommitMessage = ''
+    )
+
+    $waiver = Get-ReleaseGateWaiver -CommitMessage $HeadCommitMessage
+
+    $bumpPass = Compare-PluginVersionIsGreater -NewVersion $HeadVersion -BaseVersion $BaseVersion
+    if ($waiver -eq 'all') {
+        $bumpPass = $true
+    }
+
+    $changelogPass = Test-ChangelogSectionPresent -ChangelogContent $ChangelogContent -Version $HeadVersion
+    if ($waiver -eq 'changelog-only' -or $waiver -eq 'all') {
+        $changelogPass = $true
+    }
+
+    $failedLegs = @()
+    if (-not $bumpPass) { $failedLegs += 'bump' }
+    if (-not $changelogPass) { $failedLegs += 'changelog' }
+
+    $pass = $failedLegs.Count -eq 0
+
+    return @{
+        Pass          = $pass
+        FailedLegs    = $failedLegs
+        WaiverApplied = $waiver
+        ExitCode      = if ($pass) { 0 } else { 1 }
+    }
+}

--- a/.github/scripts/lib/release-gate-core.ps1
+++ b/.github/scripts/lib/release-gate-core.ps1
@@ -32,7 +32,7 @@ function Get-PluginVersion {
     } else {
         return $null
     }
-    if ($versionString -notmatch '^\d+\.\d+\.\d+$') {
+    if ($versionString -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
         return $null
     }
     return $versionString
@@ -48,7 +48,7 @@ function Compare-PluginVersionIsGreater {
 
 function Test-ChangelogSectionPresent {
     param(
-        [Parameter(Mandatory)][string]$ChangelogContent,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$ChangelogContent,
         [Parameter(Mandatory)][string]$Version
     )
     $escaped = [regex]::Escape($Version)
@@ -58,12 +58,8 @@ function Test-ChangelogSectionPresent {
 
 function Get-ReleaseGateWaiver {
     param([string]$CommitMessage)
-    if ($CommitMessage -match 'Skip-Release-Check: all') {
-        return 'all'
-    }
-    if ($CommitMessage -match 'Skip-Release-Check: changelog-only') {
-        return 'changelog-only'
-    }
+    if ($CommitMessage -match '(?m)^Skip-Release-Check:\s*all\b') { return 'all' }
+    if ($CommitMessage -match '(?m)^Skip-Release-Check:\s*changelog-only\b') { return 'changelog-only' }
     return $null
 }
 
@@ -72,7 +68,7 @@ function Invoke-ReleaseGateEvaluation {
         [Parameter(Mandatory)][string[]]$ChangedFiles,
         [Parameter(Mandatory)][string]$HeadVersion,
         [Parameter(Mandatory)][string]$BaseVersion,
-        [Parameter(Mandatory)][string]$ChangelogContent,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$ChangelogContent,
         [string]$HeadCommitMessage = ''
     )
 

--- a/.github/scripts/lib/release-gate-core.ps1
+++ b/.github/scripts/lib/release-gate-core.ps1
@@ -20,14 +20,9 @@ function Test-ReleaseGateEntryPointTouched {
     return $false
 }
 
-function Get-PluginVersion {
-    param([Parameter(Mandatory)][string]$Path)
-    try {
-        $content = Get-Content -Path $Path -Raw -ErrorAction Stop
-    } catch {
-        return $null
-    }
-    if ($content -match '"version":\s*"([\d.]+)"') {
+function Get-PluginVersionFromString {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Content)
+    if ($Content -match '"version":\s*"([\d.]+)"') {
         $versionString = $matches[1]
     } else {
         return $null
@@ -36,6 +31,16 @@ function Get-PluginVersion {
         return $null
     }
     return $versionString
+}
+
+function Get-PluginVersion {
+    param([Parameter(Mandatory)][string]$Path)
+    try {
+        $content = Get-Content -Path $Path -Raw -ErrorAction Stop
+    } catch {
+        return $null
+    }
+    return Get-PluginVersionFromString -Content $content
 }
 
 function Compare-PluginVersionIsGreater {
@@ -65,7 +70,6 @@ function Get-ReleaseGateWaiver {
 
 function Invoke-ReleaseGateEvaluation {
     param(
-        [Parameter(Mandatory)][string[]]$ChangedFiles,
         [Parameter(Mandatory)][string]$HeadVersion,
         [Parameter(Mandatory)][string]$BaseVersion,
         [Parameter(Mandatory)][AllowEmptyString()][string]$ChangelogContent,

--- a/.github/scripts/release-gate.ps1
+++ b/.github/scripts/release-gate.ps1
@@ -39,12 +39,13 @@ if (-not $entryPointTouched) {
     exit 0
 }
 
-$baseJsonContent = git show "origin/$BaseRef:.claude-plugin/plugin.json" 2>&1
+$baseJsonRaw = @(git show "origin/$BaseRef:.claude-plugin/plugin.json")
 $baseJsonExitCode = $LASTEXITCODE
 if ($baseJsonExitCode -ne 0) {
     Write-Error "Failed to read base-branch plugin.json (exit $baseJsonExitCode) — failing closed"
     exit 1
 }
+$baseJsonContent = $baseJsonRaw -join "`n"
 
 $baseVersion = $null
 if ($baseJsonContent -match '"version":\s*"([\d.]+)"') {
@@ -63,13 +64,21 @@ if ($null -eq $headVersion) {
 
 $headMsg = git log -1 --format=%B HEAD
 
-$changelog = Get-Content -Path 'CHANGELOG.md' -Raw -ErrorAction SilentlyContinue
+$changelog = ''
+if (Test-Path 'CHANGELOG.md') {
+    $changelog = Get-Content -Path 'CHANGELOG.md' -Raw -ErrorAction SilentlyContinue
+    if ($null -eq $changelog) {
+        Write-Error "CHANGELOG.md exists but could not be read — failing closed"
+        exit 1
+    }
+}
+# $changelog is '' if the file is absent (will fail the changelog leg cleanly)
 
 $result = Invoke-ReleaseGateEvaluation `
     -ChangedFiles $changedFiles `
     -HeadVersion $headVersion `
     -BaseVersion $baseVersion `
-    -ChangelogContent ($changelog ?? '') `
+    -ChangelogContent $changelog `
     -HeadCommitMessage ($headMsg ?? '')
 
 if ($result.Pass) {

--- a/.github/scripts/release-gate.ps1
+++ b/.github/scripts/release-gate.ps1
@@ -39,7 +39,7 @@ if (-not $entryPointTouched) {
     exit 0
 }
 
-$baseJsonRaw = @(git show "origin/$BaseRef:.claude-plugin/plugin.json")
+$baseJsonRaw = @(git show "origin/${BaseRef}:.claude-plugin/plugin.json")
 $baseJsonExitCode = $LASTEXITCODE
 if ($baseJsonExitCode -ne 0) {
     Write-Error "Failed to read base-branch plugin.json (exit $baseJsonExitCode) — failing closed"

--- a/.github/scripts/release-gate.ps1
+++ b/.github/scripts/release-gate.ps1
@@ -1,0 +1,93 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    CI release gate: fail PRs that touch plugin entry points without a version bump + CHANGELOG entry.
+.DESCRIPTION
+    Reads changed files and versions from git, then invokes Invoke-ReleaseGateEvaluation.
+    Exits 0 on pass, exits 1 on failure with an actionable message.
+
+    Parameters:
+      -BaseRef   The base branch ref (e.g. 'main' or 'origin/main'). The caller (workflow)
+                 must have already run 'git fetch origin <base>' before invoking this script.
+      -HeadRef   Optional. Defaults to 'HEAD'.
+
+    Environment:
+      GITHUB_TOKEN  Optional. Not needed for local git operations.
+#>
+param(
+    [Parameter(Mandatory)][string]$BaseRef,
+    [string]$HeadRef = 'HEAD'
+)
+
+. (Join-Path $PSScriptRoot 'lib' 'release-gate-core.ps1')
+
+$changedFiles = @(git diff --name-only "origin/$BaseRef...$HeadRef")
+$gitExitCode = $LASTEXITCODE
+if ($gitExitCode -ne 0) {
+    Write-Error "Failed to get changed files (exit $gitExitCode) — failing closed"
+    exit 1
+}
+
+if ($changedFiles.Count -eq 0) {
+    Write-Host "No files changed — gate passes."
+    exit 0
+}
+
+$entryPointTouched = Test-ReleaseGateEntryPointTouched -ChangedFiles $changedFiles
+if (-not $entryPointTouched) {
+    Write-Host "No plugin entry points changed — gate passes."
+    exit 0
+}
+
+$baseJsonContent = git show "origin/$BaseRef:.claude-plugin/plugin.json" 2>&1
+$baseJsonExitCode = $LASTEXITCODE
+if ($baseJsonExitCode -ne 0) {
+    Write-Error "Failed to read base-branch plugin.json (exit $baseJsonExitCode) — failing closed"
+    exit 1
+}
+
+$baseVersion = $null
+if ($baseJsonContent -match '"version":\s*"([\d.]+)"') {
+    $baseVersion = $matches[1]
+}
+if (-not $baseVersion -or $baseVersion -notmatch '^\d+\.\d+\.\d+$') {
+    Write-Error "Base plugin.json has invalid or missing version '$baseVersion' — failing closed"
+    exit 1
+}
+
+$headVersion = Get-PluginVersion -Path '.claude-plugin/plugin.json'
+if ($null -eq $headVersion) {
+    Write-Error "Head plugin.json has invalid or missing version — failing closed"
+    exit 1
+}
+
+$headMsg = git log -1 --format=%B HEAD
+
+$changelog = Get-Content -Path 'CHANGELOG.md' -Raw -ErrorAction SilentlyContinue
+
+$result = Invoke-ReleaseGateEvaluation `
+    -ChangedFiles $changedFiles `
+    -HeadVersion $headVersion `
+    -BaseVersion $baseVersion `
+    -ChangelogContent ($changelog ?? '') `
+    -HeadCommitMessage ($headMsg ?? '')
+
+if ($result.Pass) {
+    if ($result.WaiverApplied) {
+        Write-Host "Release gate PASSED (waiver applied: $($result.WaiverApplied))."
+    } else {
+        Write-Host "Release gate PASSED."
+    }
+    exit 0
+} else {
+    Write-Error "Release gate FAILED. Failed legs: $($result.FailedLegs -join ', ')"
+    if ($result.FailedLegs -contains 'bump') {
+        Write-Host "  Version bump required: head version must be greater than base version."
+        Write-Host "  To waive the entire gate (use sparingly): Skip-Release-Check: all <reason>"
+    }
+    if ($result.FailedLegs -contains 'changelog') {
+        Write-Host "  CHANGELOG entry required: add a '## [$headVersion]' section."
+        Write-Host "  To waive the CHANGELOG leg only: Skip-Release-Check: changelog-only"
+    }
+    exit 1
+}

--- a/.github/scripts/release-gate.ps1
+++ b/.github/scripts/release-gate.ps1
@@ -7,8 +7,9 @@
     Exits 0 on pass, exits 1 on failure with an actionable message.
 
     Parameters:
-      -BaseRef   The base branch ref (e.g. 'main' or 'origin/main'). The caller (workflow)
-                 must have already run 'git fetch origin <base>' before invoking this script.
+      -BaseRef   The base branch ref as a bare branch name (e.g. 'main', not 'origin/main').
+                 Any leading 'origin/' is stripped automatically. The caller (workflow) must
+                 have already run 'git fetch origin <base>' before invoking this script.
       -HeadRef   Optional. Defaults to 'HEAD'.
 
     Environment:
@@ -20,6 +21,9 @@ param(
 )
 
 . (Join-Path $PSScriptRoot 'lib' 'release-gate-core.ps1')
+
+# Normalize: strip any leading 'origin/' so both 'main' and 'origin/main' are accepted.
+$BaseRef = $BaseRef -replace '^origin/', ''
 
 $changedFiles = @(git diff --name-only "origin/$BaseRef...$HeadRef")
 $gitExitCode = $LASTEXITCODE
@@ -47,12 +51,9 @@ if ($baseJsonExitCode -ne 0) {
 }
 $baseJsonContent = $baseJsonRaw -join "`n"
 
-$baseVersion = $null
-if ($baseJsonContent -match '"version":\s*"([\d.]+)"') {
-    $baseVersion = $matches[1]
-}
-if (-not $baseVersion -or $baseVersion -notmatch '^\d+\.\d+\.\d+$') {
-    Write-Error "Base plugin.json has invalid or missing version '$baseVersion' — failing closed"
+$baseVersion = Get-PluginVersionFromString -Content $baseJsonContent
+if ($null -eq $baseVersion) {
+    Write-Error "Base plugin.json has invalid or missing version — failing closed"
     exit 1
 }
 
@@ -62,7 +63,7 @@ if ($null -eq $headVersion) {
     exit 1
 }
 
-$headMsg = git log -1 --format=%B HEAD
+$headMsg = (@(git log -1 --format=%B HEAD) -join [Environment]::NewLine)
 
 $changelog = ''
 if (Test-Path 'CHANGELOG.md') {
@@ -75,11 +76,10 @@ if (Test-Path 'CHANGELOG.md') {
 # $changelog is '' if the file is absent (will fail the changelog leg cleanly)
 
 $result = Invoke-ReleaseGateEvaluation `
-    -ChangedFiles $changedFiles `
     -HeadVersion $headVersion `
     -BaseVersion $baseVersion `
     -ChangelogContent $changelog `
-    -HeadCommitMessage ($headMsg ?? '')
+    -HeadCommitMessage $headMsg
 
 if ($result.Pass) {
     if ($result.WaiverApplied) {

--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -42,7 +42,9 @@ jobs:
             # render-portfolio tests — registered per d-ci-gate-registration (#692 s3)
             '.github/scripts/Tests/render-portfolio.Tests.ps1',
             # release-gate tests — registered per d-ci-gate-registration (#703 s2)
-            '.github/scripts/Tests/release-gate.Tests.ps1'
+            '.github/scripts/Tests/release-gate.Tests.ps1',
+            # entry-point-scope-parity test — registered per s4 (#703)
+            '.github/scripts/Tests/entry-point-scope-parity.Tests.ps1'
           )
           $config.Run.Exit = $true
           $config.Output.Verbosity = 'Detailed'

--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -40,7 +40,9 @@ jobs:
             '.github/scripts/Tests/Ensure-ScratchGitignore.Tests.ps1',
             '.github/scripts/Tests/audit-docs-mechanical.Tests.ps1',
             # render-portfolio tests — registered per d-ci-gate-registration (#692 s3)
-            '.github/scripts/Tests/render-portfolio.Tests.ps1'
+            '.github/scripts/Tests/render-portfolio.Tests.ps1',
+            # release-gate tests — registered per d-ci-gate-registration (#703 s2)
+            '.github/scripts/Tests/release-gate.Tests.ps1'
           )
           $config.Run.Exit = $true
           $config.Output.Verbosity = 'Detailed'

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,32 @@
+# Fails PRs that touch plugin entry points without a version bump + CHANGELOG entry.
+# Triggered on pull request open, synchronize, and reopen events.
+name: Release gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: release-gate-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  release-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Run release gate
+        shell: pwsh
+        run: |
+          ./.github/scripts/release-gate.ps1 -BaseRef '${{ github.event.pull_request.base.ref }}'

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -24,9 +24,13 @@ jobs:
           persist-credentials: false
 
       - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch origin "$BASE_REF"
 
       - name: Run release gate
         shell: pwsh
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          ./.github/scripts/release-gate.ps1 -BaseRef '${{ github.event.pull_request.base.ref }}'
+          ./.github/scripts/release-gate.ps1 -BaseRef $env:BASE_REF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to agent-orchestra will be documented in this file.
 
+## [2.31.0] — 2026-06-21
+
+### Added
+
+- **CI release gate** (`.github/scripts/lib/release-gate-core.ps1`, `.github/scripts/release-gate.ps1`, `.github/workflows/release-gate.yml`): A required PR check that fails any PR touching plugin entry points (`agents/**`, `commands/**`, `skills/**`, `hooks/**`, `.claude-plugin/**`, `plugin.json`, `README.md`, `.github/copilot-instructions.md`) without a monotonic version bump **and** a matching `## [version]` CHANGELOG section. Leg-scoped `Skip-Release-Check:` commit-trailer waiver: `changelog-only` waives only the CHANGELOG leg; `all <reason>` waives both. Fail-closed on any base-ref/diff error (AC5). Entry-point membership delegated to `Get-FVPluginEntryPointPatterns`; parity enforced by `.github/scripts/Tests/entry-point-scope-parity.Tests.ps1` (#703).
+
 ## [2.30.0] — 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > ⚠️ **GitHub Copilot / VS Code support is frozen and retiring after 2026-08-31.**
 > Claude Code is the actively supported path. See [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md) for details and the reach-out channel if you depend on Copilot support.
 
-[![Version](https://img.shields.io/badge/version-v2.30.0-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v2.31.0-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development through specialized Claude Code agents. *(GitHub Copilot/VS Code: frozen and retiring after 2026-08-31 — see [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md))*
@@ -119,6 +119,8 @@ Claude Code includes the implementation specialists for Code-Conductor dispatch.
 Claude Code caches plugins by the `version` in `.claude-plugin/plugin.json`. If an entry-point file changes without a version bump, cached installs keep serving the previous snapshot even though the repo content changed.
 
 Agent-assisted maintainer flows now route entry-point edits through the shared `plugin-release-hygiene` skill. Claude uses a committed `PostToolUse` hook, Copilot uses an auto-attached instruction file, and both mechanisms converge on one conversation-scoped version-bump decision.
+
+PRs touching plugin entry points are also enforced by a required GitHub Actions check (`release-gate.yml`). The check fails if the PR lacks a monotonic version bump and a matching `## [version]` CHANGELOG section. To waive only the CHANGELOG leg, add `Skip-Release-Check: changelog-only` as a head-commit trailer. To waive the full gate, use `Skip-Release-Check: all <reason>`.
 
 Claude sessions also run an active-assist startup drift check. When the installed `agent-orchestra@agent-orchestra` version is behind the resolved marketplace version, startup runs `claude plugin update`, reports the old and new versions, and asks whether to restart now or continue under the old code until the next session.
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "author": {
     "name": "Grimblaz"
   },

--- a/skills/plugin-release-hygiene/SKILL.md
+++ b/skills/plugin-release-hygiene/SKILL.md
@@ -29,10 +29,13 @@ Treat these paths as cache-keyed plugin entry points:
 - `agents/**`
 - `commands/**`
 - `skills/**`
+- `hooks/**`
 - `.claude-plugin/**`
 - `plugin.json`
 - `README.md`
 - `.github/copilot-instructions.md`
+
+> **Authoritative source**: The canonical entry-point set is defined by `Get-FVPluginEntryPointPatterns` in `.github/scripts/lib/frame-predicate-core.ps1`. The list above mirrors it; `.github/scripts/Tests/entry-point-scope-parity.Tests.ps1` permanently prevents drift between this prose and the function.
 
 Any edit touching one of those paths requires a release-hygiene check before the turn ends.
 


### PR DESCRIPTION
## Summary

Implements the CI hard-gate specified in #703. A required GitHub Actions check (`release-gate.yml`) now fails any PR that touches plugin entry points (`agents/**`, `commands/**`, `skills/**`, `hooks/**`, `.claude-plugin/**`, `plugin.json`, `README.md`, `.github/copilot-instructions.md`) without **both** a monotonic version bump **and** a matching `## [version]` CHANGELOG section.

- **`release-gate-core.ps1`** — side-effect-free library (6 pure functions): entry-point detection via `Get-FVPluginEntryPointPatterns`, strict 3-segment version parse (no leading zeros), CHANGELOG section regex (line-anchored, dash-agnostic), anchored trailer-waiver detection (`(?m)^Skip-Release-Check:`)
- **`release-gate.ps1`** — thin wrapper: reads changed files from `git diff`, extracts base version from `git show`, reads head version from `.claude-plugin/plugin.json`, reads CHANGELOG, evaluates via core library; fail-closed on any git/read error; actionable error messages including waiver syntax
- **`release-gate.yml`** — PR workflow: SHA-pinned checkout, `persist-credentials: false`, `permissions: contents: read`, `concurrency` cancel-in-progress; pwsh step with `${BaseRef}` disambiguation
- **`release-gate.Tests.ps1`** — 31 Pester v5 tests covering all 6 functions including edge cases and the SF-3 prose-mention regression guard
- **`entry-point-scope-parity.Tests.ps1`** — 1 parity test that permanently prevents drift between `skills/plugin-release-hygiene/SKILL.md` Entry-Point Scope and `Get-FVPluginEntryPointPatterns`
- **`plugin-release-hygiene/SKILL.md`** — adds `hooks/**` to documented entry-point list, cites authoritative function, links parity test
- **`README.md`** — documents the gate + `Skip-Release-Check:` waiver syntax in the Releases section
- **Version bumped 2.30.0 to 2.31.0** (dogfood: this PR itself touches entry points)

## Adversarial review findings applied (5 of 5)

The prosecution x 3 / defense / judge pipeline surfaced 5 sustained defects; all fixed before this PR:

| Finding | Fix |
|---|---|
| SF-1 CRITICAL: `git show` array `-match` does not populate `$matches` | Join array to string with `-join` before matching |
| SF-2 CRITICAL: Mandatory `[string]` rejects empty CHANGELOG | Added `[AllowEmptyString()]` to ChangelogContent params |
| SF-3 HIGH: Unanchored waiver regex (prose bypass) | Anchored to `(?m)^Skip-Release-Check:\s*all\b` |
| SF-4 HIGH: Tautological catch masked leading-zero version defect | Removed catch; tightened regex to no-leading-zeros form |
| SF-5 HIGH: CHANGELOG read failure degraded silently | Fail-closed on I/O error; clean fail for absent file |

CE Gate also caught a `$BaseRef:` scope-variable parse error on line 42 (fixed: `${BaseRef}`).

## Leg-scoped waiver convention

```
# Waive only the CHANGELOG leg (version bump still required):
Skip-Release-Check: changelog-only

# Waive both legs (use sparingly, include reason):
Skip-Release-Check: all <reason>
```

## Test plan

- [x] 32 Pester tests GREEN (31 release-gate + 1 parity)
- [x] CE Gate probes AC1-AC9 all PASS
- [x] `release-gate.ps1` script parses cleanly (0 parser errors)
- [x] Fail-closed smoke test: bad BaseRef exits 1 with "failing closed" message
- [x] Prose waiver mention does NOT activate waiver (SF-3 regression test)
- [x] Version 2.31.0 lockstep verified across all 7 occurrences in 5 files
- [ ] Post-merge: register `release-gate` as a **required** status check in branch protection settings (manual step — requires GitHub repo admin access)

Closes #703

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a CI release gate that enforces version bump and CHANGELOG updates for plugin entry-point changes, with accompanying documentation and tests.

New Features:
- Add PowerShell-based release gate script and core library to validate version bumps and CHANGELOG entries when plugin entry points are modified.
- Add GitHub Actions workflow to run the release gate on pull requests as a required status check.

Enhancements:
- Document plugin entry-point scope in the release-hygiene skill as mirroring the canonical function and extend it to include hooks paths.
- Update project README and CHANGELOG with details of the release gate behavior and waiver conventions.
- Bump plugin version from 2.30.0 to 2.31.0 across marketplace and plugin manifests.

CI:
- Extend existing Pester CI workflow to run the new release gate and parity test suites.

Tests:
- Register new Pester suites in CI for the release gate core logic and entry-point scope parity.
- Add parity test ensuring SKILL.md entry-point list stays in sync with the canonical entry-point pattern function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a CI “release gate” that validates required version bumps and matching CHANGELOG entries for pull requests that modify plugin entry points.
  * Added leg-scoped waivers via `Skip-Release-Check` commit trailers to bypass changelog-only or the full gate when needed.

* **Documentation**
  * Updated the README, CHANGELOG, and entry-point scope documentation to reflect the new enforcement and supported waiver options.

* **Tests**
  * Added CI coverage to ensure entry-point scope parity and release-gate behavior correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->