### PR TITLE
feat(#439): frame enforce mode — required-check substrate + advisory ship

### DIFF
--- a/.github/scripts/Tests/credit-row-schema-conformance.Tests.ps1
+++ b/.github/scripts/Tests/credit-row-schema-conformance.Tests.ps1
@@ -60,8 +60,8 @@ BeforeAll {
                 return $script:AllowedStatusByPortPattern[$pattern]
             }
         }
-        # Default: all six values (for ports not in the table)
-        return @('passed', 'failed', 'skipped', 'not-applicable', 'inconclusive', 'not-persisted')
+        # Default: all seven values (for ports not in the table)
+        return @('passed', 'failed', 'skipped', 'not-applicable', 'inconclusive', 'not-persisted', 'overridden')
     }
 
     function script:Get-CreditBuilderFunctionAst {

--- a/.github/scripts/Tests/frame-credit-ledger-core.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-core.Tests.ps1
@@ -1346,6 +1346,82 @@ Describe 'Compose-Comment' {
         $out | Should -Not -Match '### ✅ Covered'
         $out | Should -Not -Match '### 🚫 Not covered'
     }
+
+    It 'renders OverriddenCredit as 🔓 overridden (not ❓ OverriddenCredit) — M3 fix' {
+        $reports = @(
+            [pscustomobject]@{
+                PortName          = 'review'
+                Status            = 'Covered'
+                SubReason         = 'OverriddenCredit'
+                AdapterName       = ''
+                SuggestedNextStep = $null
+                Evidence          = 'override: authorized self-override posted in PR 429 comment'
+            }
+        )
+
+        $out = Compose-Comment -MarkerToken $script:Marker -PortReports $reports
+
+        $out | Should -Match '🔓'
+        $out | Should -Match 'overridden'
+        $out | Should -Not -Match '❓'
+        $out | Should -Not -Match 'OverriddenCredit'
+    }
+
+    It 'renders warn-mode footer when Mode is warn (default) — M4' {
+        $reports = @(
+            [pscustomobject]@{
+                PortName          = 'review'
+                Status            = 'Covered'
+                SubReason         = 'PassedCredit'
+                AdapterName       = 'review-adapter'
+                SuggestedNextStep = $null
+                Evidence          = ''
+            }
+        )
+
+        $out = Compose-Comment -MarkerToken $script:Marker -PortReports $reports
+
+        $out | Should -Match 'warn'
+        $out | Should -Not -Match 'enforce mode'
+    }
+
+    It 'renders enforce-mode footer (not blocked) when Mode is enforce and HasBlock is false — M4' {
+        $reports = @(
+            [pscustomobject]@{
+                PortName          = 'review'
+                Status            = 'Covered'
+                SubReason         = 'PassedCredit'
+                AdapterName       = 'review-adapter'
+                SuggestedNextStep = $null
+                Evidence          = ''
+            }
+        )
+
+        $out = Compose-Comment -MarkerToken $script:Marker -PortReports $reports -Mode 'enforce' -HasBlock $false
+
+        $out | Should -Match 'enforce'
+        $out | Should -Match 'passed'
+        $out | Should -Not -Match 'PR creation was not blocked'
+    }
+
+    It 'renders enforce-mode footer (blocked) when Mode is enforce and HasBlock is true — M4' {
+        $reports = @(
+            [pscustomobject]@{
+                PortName          = 'review'
+                Status            = 'NotCovered'
+                SubReason         = 'MissingAdapter'
+                AdapterName       = ''
+                SuggestedNextStep = 'Run /review'
+                Evidence          = ''
+            }
+        )
+
+        $out = Compose-Comment -MarkerToken $script:Marker -PortReports $reports -Mode 'enforce' -HasBlock $true
+
+        $out | Should -Match 'enforce'
+        $out | Should -Match 'blocked'
+        $out | Should -Not -Match 'PR creation was not blocked'
+    }
 }
 
 Describe 'Compose-PreV4ShortCircuitComment' {

--- a/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
@@ -1415,8 +1415,9 @@ dispatch-cost-samples:
             $result = & $script:InvokeOrchestrator `
                 -Pr 429 -Mode 'enforce' `
                 -Env @{
-                FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'
-                FRAME_ENFORCE                     = '0'
+                FRAME_CREDIT_LEDGER_TEST_NO_SLEEP              = '1'
+                FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER = '1'
+                FRAME_ENFORCE                                  = '0'
             } `
                 -MockBootstrap $bootstrap
 

--- a/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
@@ -1532,7 +1532,7 @@ if (`$joined -match 'pr view \d+ --json body') {
             } `
                 -MockBootstrap $bootstrap
 
-            # PR is before the 9999-12-31 activation timestamp (caught by far-future guard first)
+            # PR_CREATED_AT (2026) < activation_timestamp (9999-12-31) → caught by PR_CREATED_AT guard
             # → coerced to warn → exit 0
             $result.ExitCode | Should -Be 0
         }

--- a/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
@@ -649,7 +649,7 @@ Describe 'frame-credit-ledger.ps1 orchestrator' {
 
             $result = & $script:InvokeOrchestrator `
                 -Pr 429 -Mode 'enforce' `
-                -Env @{ FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1' } `
+                -Env @{ FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'; FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER = '1' } `
                 -MockBootstrap $bootstrap
 
             $result.ExitCode | Should -Be 0
@@ -920,7 +920,7 @@ body
 
             $result = & $script:InvokeOrchestrator `
                 -Pr 429 -Mode 'enforce' `
-                -Env @{ FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1' } `
+                -Env @{ FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'; FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER = '1' } `
                 -MockBootstrap $bootstrap
 
             $result.ExitCode | Should -Be 3
@@ -932,7 +932,7 @@ body
 
             $result = & $script:InvokeOrchestrator `
                 -Pr 429 -Mode 'enforce' `
-                -Env @{ FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1' } `
+                -Env @{ FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'; FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER = '1' } `
                 -MockBootstrap $bootstrap
 
             $result.ExitCode | Should -Be 0

--- a/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
@@ -1364,6 +1364,180 @@ dispatch-cost-samples:
         }
     }
 
+    Context 'Issue #439 enforce mode — block-on-inconclusive, kill switch, exit codes' {
+
+        # AC3: inconclusive review port (block-on-inconclusive: true) blocks in enforce mode.
+        It 'AC3: inconclusive review credit blocks in enforce mode (block-on-inconclusive: true → exit 3)' {
+            # Start from the fully-covered fixture and swap review from passed → inconclusive.
+            # All other ports remain covered so the only blocking candidate is review.
+            $prBody = $script:V4AllCoveredBody -replace '(?m)(port: review\s*\n\s*status:)\s*passed', '$1 inconclusive'
+            $bodyJson = (@{ body = $prBody } | ConvertTo-Json -Compress)
+            $bootstrap = & $script:NewGhMockBootstrap -BodyJson $bodyJson
+
+            $result = & $script:InvokeOrchestrator `
+                -Pr 429 -Mode 'enforce' `
+                -Env @{
+                FRAME_CREDIT_LEDGER_TEST_NO_SLEEP              = '1'
+                FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER = '1'
+            } `
+                -MockBootstrap $bootstrap
+
+            # review has block-on-inconclusive: true → inconclusive review is blocking → exit 3
+            $result.ExitCode | Should -Be 3
+        }
+
+        # AC4: inconclusive ce-gate-cli port (block-on-inconclusive: false) is non-blocking in enforce mode.
+        It 'AC4: inconclusive ce-gate-cli credit does not block in enforce mode (block-on-inconclusive: false → exit 0)' {
+            # Start from the fully-covered fixture and swap ce-gate-cli from not-applicable → inconclusive.
+            # All other ports remain covered so the only questionable port is ce-gate-cli.
+            $prBody = $script:V4AllCoveredBody -replace '(?m)(port: ce-gate-cli\s*\n\s*status:)\s*not-applicable', '$1 inconclusive'
+            $bodyJson = (@{ body = $prBody } | ConvertTo-Json -Compress)
+            $bootstrap = & $script:NewGhMockBootstrap -BodyJson $bodyJson
+
+            $result = & $script:InvokeOrchestrator `
+                -Pr 429 -Mode 'enforce' `
+                -Env @{
+                FRAME_CREDIT_LEDGER_TEST_NO_SLEEP              = '1'
+                FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER = '1'
+            } `
+                -MockBootstrap $bootstrap
+
+            # ce-gate-cli has block-on-inconclusive: false → inconclusive ce-gate-cli is non-blocking → exit 0
+            $result.ExitCode | Should -Be 0
+        }
+
+        # AC7: FRAME_ENFORCE=0 kill switch coerces enforce → warn → exit 0 even when credits are missing.
+        It 'AC7: FRAME_ENFORCE=0 kill switch coerces enforce to warn and exits 0 even when credits are missing' {
+            # V4WithNotCoveredBody has review: failed → would exit 3 in real enforce mode.
+            $bodyJson = (@{ body = $script:V4WithNotCoveredBody } | ConvertTo-Json -Compress)
+            $bootstrap = & $script:NewGhMockBootstrap -BodyJson $bodyJson
+
+            $result = & $script:InvokeOrchestrator `
+                -Pr 429 -Mode 'enforce' `
+                -Env @{
+                FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'
+                FRAME_ENFORCE                     = '0'
+            } `
+                -MockBootstrap $bootstrap
+
+            # Kill switch coerces to warn → fail-open → exit 0
+            $result.ExitCode | Should -Be 0
+        }
+
+        # AC8: timeout in enforce mode → exit 4.
+        It 'AC8: timeout in enforce mode exits 4 (not 0 as in warn mode)' {
+            $bootstrap = & $script:NewGhMockBootstrap -HangOnBaseRef $true
+
+            $result = & $script:InvokeOrchestrator `
+                -Pr 429 -Mode 'enforce' `
+                -Env @{
+                FRAME_CREDIT_LEDGER_TEST_NO_SLEEP              = '1'
+                FRAME_CREDIT_LEDGER_TEST_BUDGET_SECONDS        = '3'
+                FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER = '1'
+            } `
+                -TimeoutSeconds 30 `
+                -MockBootstrap $bootstrap
+
+            # Enforce mode on timeout must exit 4 (not 0)
+            $result.TimedOut | Should -Be $false
+            $result.ExitCode | Should -Be 4
+        }
+
+        # AC9: internal exception in enforce mode → exit 5.
+        It 'AC9: internal exception in enforce mode exits 5 (not 0 as in warn mode)' {
+            # Same technique as the warn-mode exception test: patch the body-fetch branch to throw.
+            $extra = @'
+$global:ThrowOnBody = $true
+'@
+            $bootstrapBase = & $script:NewGhMockBootstrap -ExtraDeclarations $extra
+            $bootstrap = $bootstrapBase -replace [regex]::Escape("if (`$joined -match 'pr view \d+ --json body') {"), @"
+if (`$joined -match 'pr view \d+ --json body') {
+        throw 'simulated body-fetch failure'
+"@
+
+            $result = & $script:InvokeOrchestrator `
+                -Pr 429 -Mode 'enforce' `
+                -Env @{
+                FRAME_CREDIT_LEDGER_TEST_NO_SLEEP              = '1'
+                FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER = '1'
+            } `
+                -MockBootstrap $bootstrap
+
+            # Enforce mode on internal error must exit 5 (not 0)
+            $result.ExitCode | Should -Be 5
+        }
+
+        # s3 AC: frame-override marker removes a blocking port → exit 0 in enforce mode.
+        It 'frame-override-429 marker from OWNER overrides a blocking NotCovered port in enforce mode → exit 0' {
+            # Start from the fully-covered fixture and swap review from passed → failed (NotCovered → would block).
+            # Every other port remains covered so overriding review leaves no remaining blocking ports.
+            $prBodyWithFailedReview = $script:V4AllCoveredBody -replace '(?m)(port: review\s*\n\s*status:)\s*passed', '$1 failed'
+            $prComments = @(
+                [pscustomobject]@{
+                    body              = "<!-- frame-override-429`nports: review`nreason: emergency deploy`n-->"
+                    authorAssociation = "OWNER"
+                }
+            )
+            $bodyJson = (@{
+                    body     = $prBodyWithFailedReview
+                    comments = $prComments
+                } | ConvertTo-Json -Compress -Depth 10)
+            $bootstrap = & $script:NewGhMockBootstrap -BodyJson $bodyJson
+
+            $result = & $script:InvokeOrchestrator `
+                -Pr 429 -Mode 'enforce' `
+                -Env @{
+                FRAME_CREDIT_LEDGER_TEST_NO_SLEEP              = '1'
+                FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER = '1'
+            } `
+                -MockBootstrap $bootstrap
+
+            # Override applied → no blocking ports remain → exit 0
+            $result.ExitCode | Should -Be 0
+        }
+
+        # AC10(a): Far-future sentinel in enforce-activation.yaml → coerces to warn → exit 0.
+        It 'AC10a: far-future activation_timestamp sentinel coerces enforce to warn → exit 0 (advisory ship)' {
+            # Do NOT set SKIP_ACTIVATION_CUTOVER — this exercises the real cutover path.
+            # The repo's enforce-activation.yaml has activation_timestamp: 9999-12-31 which
+            # should trip the far-future guard and downgrade to warn mode.
+            $bodyJson = (@{ body = $script:V4WithNotCoveredBody } | ConvertTo-Json -Compress)
+            $bootstrap = & $script:NewGhMockBootstrap -BodyJson $bodyJson
+
+            $result = & $script:InvokeOrchestrator `
+                -Pr 429 -Mode 'enforce' `
+                -Env @{
+                FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'
+            } `
+                -MockBootstrap $bootstrap
+
+            # Far-future sentinel → coerced to warn → fail-open → exit 0 even with NotCovered port
+            $result.ExitCode | Should -Be 0
+            # Stderr should mention the advisory/far-future downgrade
+            $result.Stderr | Should -Match '(?i)(far.future|advisory|sentinel|warn)'
+        }
+
+        # AC10(b): PR created before activation timestamp → coerces to warn → exit 0.
+        It 'AC10b: PR_CREATED_AT before activation_timestamp coerces enforce to warn → exit 0' {
+            # The repo has activation_timestamp: 9999-12-31T00:00:00Z.
+            # Any PR_CREATED_AT in 2026 is before that timestamp → coerce to warn.
+            $bodyJson = (@{ body = $script:V4WithNotCoveredBody } | ConvertTo-Json -Compress)
+            $bootstrap = & $script:NewGhMockBootstrap -BodyJson $bodyJson
+
+            $result = & $script:InvokeOrchestrator `
+                -Pr 429 -Mode 'enforce' `
+                -Env @{
+                FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'
+                PR_CREATED_AT                     = '2026-01-01T00:00:00Z'
+            } `
+                -MockBootstrap $bootstrap
+
+            # PR is before the 9999-12-31 activation timestamp (caught by far-future guard first)
+            # → coerced to warn → exit 0
+            $result.ExitCode | Should -Be 0
+        }
+    }
+
     Context 'C-Risk-1 fix: predicate evaluator is wired into per-adapter applicability' {
 
         It 'Resolve-FrameCreditLedgerApplicableMap evaluates `applies-when` against the changeset and returns true/false (not "unknown") for supported identifiers' {

--- a/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
@@ -914,7 +914,7 @@ body
             (($result.Stdout, $result.Stderr) -join "`n") | Should -Match '(?i)pre-v4 metrics detected'
         }
 
-        It 'enforce mode exits 1 when at least one port is NotCovered' {
+        It 'enforce mode exits 3 when at least one port is NotCovered' {
             $bodyJson = (@{ body = $script:V4WithNotCoveredBody } | ConvertTo-Json -Compress)
             $bootstrap = & $script:NewGhMockBootstrap -BodyJson $bodyJson
 
@@ -923,7 +923,7 @@ body
                 -Env @{ FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1' } `
                 -MockBootstrap $bootstrap
 
-            $result.ExitCode | Should -Be 1
+            $result.ExitCode | Should -Be 3
         }
 
         It 'enforce mode exits 0 when no ports are NotCovered (only Covered or Inconclusive)' {

--- a/.github/scripts/Tests/frame-no-enforcement.Tests.ps1
+++ b/.github/scripts/Tests/frame-no-enforcement.Tests.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 7.0
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
-Describe 'frame audit-only boundary' {
+Describe 'frame enforcement boundary' {
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
@@ -26,13 +26,20 @@ Describe 'frame audit-only boundary' {
         }
     }
 
-    It 'adds the frame audit wrappers without introducing an enforcement entry point' {
+    It 'frame-enforce workflow file exists and audit wrappers are present' {
+        # Audit wrappers are still present.
         foreach ($wrapper in $script:FrameWrappers) {
             $wrapper | Should -Exist
         }
+        # Enforcement workflow file ships in s2/s3.
+        $enforceWorkflow = Join-Path $script:WorkflowDir 'frame-enforce.yml'
+        $enforceWorkflow | Should -Exist
     }
 
-    It 'does not wire frame-specific behavior into hooks or workflows' {
+    It 'does not wire frame-specific audit wrappers into hooks or workflows' {
+        # frame-back-derive and frame-audit-report are internal audit wrappers and
+        # should NOT appear in hooks or workflows. frame-credit-ledger IS intentionally
+        # wired into frame-enforce.yml (that is the whole point of enforcement).
         foreach ($hookFile in $script:HookFiles) {
             $content = Get-Content -Raw -Path $hookFile
             $content | Should -Not -Match 'frame-(back-derive|audit-report)'
@@ -44,6 +51,13 @@ Describe 'frame audit-only boundary' {
             )
             $workflowHits.Count | Should -Be 0
         }
+    }
+
+    It 'enforce-activation.yaml has far-future sentinel (advisory ship constraint)' {
+        $activationFile = Join-Path $script:RepoRoot 'frame/enforce-activation.yaml'
+        $activationFile | Should -Exist
+        $content = Get-Content -LiteralPath $activationFile -Raw
+        $content | Should -Match 'activation_timestamp.*9999'
     }
 
     It 'keeps frame wrapper wording audit-only when the scripts arrive' {

--- a/.github/scripts/Tests/frame-port-files.Tests.ps1
+++ b/.github/scripts/Tests/frame-port-files.Tests.ps1
@@ -101,8 +101,8 @@ Describe 'frame port manifest' {
         $content = (Get-Content -Raw -Path $portFile) -replace '\r', ''
         # Must have a top-level enforce: block
         $content | Should -Match '(?m)^enforce:\s*$'
-        # Must have block-on-inconclusive nested inside it (indented)
-        $content | Should -Match '(?m)^\s+block-on-inconclusive:\s*(true|false)\s*$'
+        # Must have block-on-inconclusive nested under enforce: specifically
+        $content | Should -Match '(?ms)^enforce:\s*\r?\n(?:(?:[ \t]+[^\r\n]*\r?\n)*?)[ \t]+block-on-inconclusive:\s*(true|false)\s*$'
     }
 
     It 'process-retrospective explicitly declares block-on-inconclusive: false' {
@@ -114,7 +114,7 @@ Describe 'frame port manifest' {
         $portFile | Should -Exist
 
         $content = (Get-Content -Raw -Path $portFile) -replace '\r', ''
-        $content | Should -Match '(?m)^\s+block-on-inconclusive:\s*false\s*$'
+        $content | Should -Match '(?ms)^enforce:\s*\r?\n(?:(?:[ \t]+[^\r\n]*\r?\n)*?)[ \t]+block-on-inconclusive:\s*false\s*$'
     }
 }
 

--- a/.github/scripts/Tests/frame-port-files.Tests.ps1
+++ b/.github/scripts/Tests/frame-port-files.Tests.ps1
@@ -87,4 +87,63 @@ Describe 'frame port manifest' {
         $content = (Get-Content -Raw -Path $portFile) -replace '\r', ''
         $content | Should -Match '(?m)^status:\s*(stable|tbd-decision-pending|formalized-skeleton-deferred-to-\S+)$'
     }
+
+    It 'declares enforce.block-on-inconclusive in <PortName>.yaml' -ForEach $script:ExpectedPortCases {
+        param($PortName)
+
+        if (-not (& $script:RequirePortsDir)) {
+            return
+        }
+
+        $portFile = Join-Path $script:PortsDir ($PortName + '.yaml')
+        $portFile | Should -Exist
+
+        $content = (Get-Content -Raw -Path $portFile) -replace '\r', ''
+        # Must have a top-level enforce: block
+        $content | Should -Match '(?m)^enforce:\s*$'
+        # Must have block-on-inconclusive nested inside it (indented)
+        $content | Should -Match '(?m)^\s+block-on-inconclusive:\s*(true|false)\s*$'
+    }
+
+    It 'process-retrospective explicitly declares block-on-inconclusive: false' {
+        if (-not (& $script:RequirePortsDir)) {
+            return
+        }
+
+        $portFile = Join-Path $script:PortsDir 'process-retrospective.yaml'
+        $portFile | Should -Exist
+
+        $content = (Get-Content -Raw -Path $portFile) -replace '\r', ''
+        $content | Should -Match '(?m)^\s+block-on-inconclusive:\s*false\s*$'
+    }
+}
+
+Describe 'Get-PortFiles BlockOnInconclusive' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:PortsDir = Join-Path $script:RepoRoot 'frame/ports'
+        $script:CoreScript = Join-Path $script:RepoRoot '.github/scripts/lib/frame-credit-ledger-core.ps1'
+        . $script:CoreScript
+    }
+
+    It 'review port has BlockOnInconclusive = true' {
+        $ports = Get-PortFiles -PortsDir $script:PortsDir
+        ($ports | Where-Object Name -eq 'review').BlockOnInconclusive | Should -Be $true
+    }
+
+    It 'ce-gate-cli port has BlockOnInconclusive = false' {
+        $ports = Get-PortFiles -PortsDir $script:PortsDir
+        ($ports | Where-Object Name -eq 'ce-gate-cli').BlockOnInconclusive | Should -Be $false
+    }
+
+    It 'process-retrospective port has BlockOnInconclusive = false' {
+        $ports = Get-PortFiles -PortsDir $script:PortsDir
+        ($ports | Where-Object Name -eq 'process-retrospective').BlockOnInconclusive | Should -Be $false
+    }
+
+    It 'implement-code port has BlockOnInconclusive = true' {
+        $ports = Get-PortFiles -PortsDir $script:PortsDir
+        ($ports | Where-Object Name -eq 'implement-code').BlockOnInconclusive | Should -Be $true
+    }
 }

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -1696,7 +1696,7 @@ function Invoke-FrameCreditLedger {
         $costStopwatch.Stop()
     }
 
-    $comment = Compose-CommentWithCostPattern -MarkerToken $marker -PortReports $reportsArray -CostSection $costSection
+    $comment = Compose-CommentWithCostPattern -MarkerToken $marker -PortReports $reportsArray -CostSection $costSection -Mode $Mode -HasBlock $hasBlock
     try {
         $null = Find-OrUpsertComment -Type 'pr' -Number $Pr -Marker $marker -Body $comment
     }
@@ -1760,7 +1760,7 @@ if (-not $isDotSourced) {
                     $activationRaw = Get-Content -LiteralPath $activationFile -Raw -ErrorAction Stop
                     $activationTsStr = script:Get-FCLScalar -Block $activationRaw -Name 'activation_timestamp'
                     if (-not [string]::IsNullOrWhiteSpace($activationTsStr)) {
-                        $activationTimestamp = [datetime]::Parse($activationTsStr, $null, [System.Globalization.DateTimeStyles]::RoundtripKind)
+                        $activationTimestamp = [DateTimeOffset]::Parse($activationTsStr, $null, [System.Globalization.DateTimeStyles]::RoundtripKind)
                     }
                 }
                 catch {
@@ -1777,7 +1777,7 @@ if (-not $isDotSourced) {
                 $prCreatedAtStr = $env:PR_CREATED_AT
                 if (-not [string]::IsNullOrWhiteSpace($prCreatedAtStr)) {
                     try {
-                        $prCreatedAt = [datetime]::Parse($prCreatedAtStr, $null, [System.Globalization.DateTimeStyles]::RoundtripKind)
+                        $prCreatedAt = [DateTimeOffset]::Parse($prCreatedAtStr, $null, [System.Globalization.DateTimeStyles]::RoundtripKind)
                         if ($prCreatedAt -lt $activationTimestamp) {
                             [Console]::Error.WriteLine("frame-credit-ledger: PR created at $prCreatedAtStr is before activation timestamp $activationTsStr — falling back to warn mode")
                             $Mode = 'warn'
@@ -1795,7 +1795,7 @@ if (-not $isDotSourced) {
 
             # Handle far-future activation timestamp (advisory ship default)
             if ($Mode -eq 'enforce' -and $null -ne $activationTimestamp) {
-                $farFuture = [datetime]::new(9999, 12, 31, 0, 0, 0, [System.DateTimeKind]::Utc)
+                $farFuture = [DateTimeOffset]::new(9999, 12, 31, 0, 0, 0, [TimeSpan]::Zero)
                 if ($activationTimestamp -ge $farFuture) {
                     [Console]::Error.WriteLine("frame-credit-ledger: activation timestamp is far-future sentinel — falling back to warn mode (advisory ship)")
                     $Mode = 'warn'

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -57,7 +57,7 @@ catch {
         # Warn-mode invariant: never block PR creation on a lib-load error.
         exit 0
     }
-    exit 1
+    exit 5
 }
 
 # Cost pattern lib dot-sources (warn-mode fail-open: cost composition failure never blocks PR creation)
@@ -1251,9 +1251,10 @@ function Invoke-FrameCreditLedger {
         }
 
         return @{
-            ExitCode      = 0
-            HasNotCovered = $false
-            Comment       = $comment
+            ExitCode        = 5
+            HasBlock        = $true
+            IsInternalError = $true
+            Comment         = $comment
         }
     }
 
@@ -1269,9 +1270,10 @@ function Invoke-FrameCreditLedger {
         }
 
         return @{
-            ExitCode      = 0
-            HasNotCovered = $false
-            Comment       = $comment
+            ExitCode        = 5
+            HasBlock        = $true
+            IsInternalError = $true
+            Comment         = $comment
         }
     }
 
@@ -1285,9 +1287,10 @@ function Invoke-FrameCreditLedger {
         }
 
         return @{
-            ExitCode      = 0
-            HasNotCovered = $false
-            Comment       = $comment
+            ExitCode        = 5
+            HasBlock        = $true
+            IsInternalError = $true
+            Comment         = $comment
         }
     }
 
@@ -1397,7 +1400,97 @@ function Invoke-FrameCreditLedger {
     }
 
     $reportsArray = $portReports.ToArray()
-    $hasNotCovered = @($reportsArray | Where-Object { [string]$_.Status -eq 'NotCovered' }).Count -gt 0
+
+    # Build a port-descriptor lookup for fast access to BlockOnInconclusive and TriggerStatus.
+    $portDescriptorMap = @{}
+    foreach ($pd in $ports) {
+        $portDescriptorMap[[string]$pd.Name] = $pd
+    }
+
+    # Determine which ports should block in enforce mode.
+    # A port blocks when:
+    #   1. Status = 'NotCovered' (port has a gap — always blocks)
+    #   2. Status = 'Inconclusive' AND it is a misconfiguration sub-reason (AdapterParseError,
+    #      AdapterDiscoveryFailed) — always blocks regardless of BlockOnInconclusive
+    #   3. Status = 'Inconclusive' AND the port's BlockOnInconclusive = true (per-port flag)
+    # Exception: ports with TriggerStatus = 'deferred' are NEVER included in the block set.
+    $blockingReports = @($reportsArray | Where-Object {
+        $r = $_
+        $portName = [string]$r.PortName
+        $status = [string]$r.Status
+        $subReason = [string]$r.SubReason
+
+        # Deferred ports: never block, render DEFERRED row separately.
+        $pd = $portDescriptorMap[$portName]
+        if ($null -ne $pd -and [string]$pd.TriggerStatus -eq 'deferred') {
+            return $false
+        }
+
+        if ($status -eq 'NotCovered') {
+            return $true
+        }
+
+        if ($status -eq 'Inconclusive') {
+            # Misconfiguration classes always block.
+            if ($subReason -in @('AdapterParseError', 'AdapterDiscoveryFailed')) {
+                return $true
+            }
+            # Per-port flag.
+            if ($null -ne $pd) {
+                $boi = $pd.PSObject.Properties['BlockOnInconclusive']
+                if ($null -ne $boi) { return [bool]$boi.Value }
+            }
+            return $true  # fail-safe default
+        }
+
+        return $false
+    })
+    $hasBlock = $blockingReports.Count -gt 0
+
+    # Fill recovery commands for blocking reports that have no SuggestedNextStep.
+    $reportsArray = @($reportsArray | ForEach-Object {
+        $r = $_
+        if ($null -eq $r.SuggestedNextStep -or [string]::IsNullOrWhiteSpace([string]$r.SuggestedNextStep)) {
+            $status = [string]$r.Status
+            $subReason = [string]$r.SubReason
+            # Only fill for statuses that are presented as actionable in the report
+            if ($status -in @('NotCovered', 'Inconclusive')) {
+                $recovery = Resolve-FCLRecoveryCommand -PortName ([string]$r.PortName) -SubReason $subReason
+                $r = [pscustomobject]@{
+                    PortName          = $r.PortName
+                    Status            = $r.Status
+                    SubReason         = $r.SubReason
+                    AdapterName       = $r.AdapterName
+                    SuggestedNextStep = $recovery
+                    Evidence          = $r.Evidence
+                }
+            }
+        }
+        $r
+    })
+
+    # Ensure deferred ports render a visible DEFERRED(#NNN): row.
+    # These ports are excluded from the block check (above) but must appear in the render table.
+    foreach ($pd in $ports) {
+        if ([string]$pd.TriggerStatus -ne 'deferred') { continue }
+        $portName = [string]$pd.Name
+        $deferredTo = if ($null -ne $pd.TriggerDeferredTo) { [string]$pd.TriggerDeferredTo } else { 'unknown' }
+
+        # Check if this port already has a report (it might have a credit with DEFERRED evidence)
+        $existing = @($reportsArray | Where-Object { [string]$_.PortName -eq $portName })
+        if ($existing.Count -eq 0) {
+            # Add a synthetic DEFERRED row — status Covered/DeferredPort, never auto-filtered
+            $deferredRow = [pscustomobject]@{
+                PortName          = $portName
+                Status            = 'Covered'
+                SubReason         = 'DeferredPort'
+                AdapterName       = ''
+                SuggestedNextStep = "Deferred to issue $deferredTo"
+                Evidence          = "DEFERRED($deferredTo): port excluded until producing issue lands"
+            }
+            $reportsArray = @($reportsArray) + $deferredRow
+        }
+    }
 
     # ---------------------------------------------------------------------------
     # Step 5b: 90-day deferred-port tripwire (issue #443, Step 11)
@@ -1587,8 +1680,8 @@ function Invoke-FrameCreditLedger {
     }
 
     return @{
-        ExitCode      = if ($Mode -eq 'enforce' -and $hasNotCovered) { 1 } else { 0 }
-        HasNotCovered = $hasNotCovered
+        ExitCode      = if ($Mode -eq 'enforce' -and $hasBlock) { 3 } else { 0 }
+        HasBlock      = $hasBlock
         Comment       = $comment
         adversarial_pipeline_atomic_marker_present = $atomicMarkerStatusValue
     }
@@ -1624,6 +1717,11 @@ if (-not $isDotSourced) {
         # PowerShell instance (which interrupts a hanging Start-Sleep
         # inside the gh mock) and emit a fail-open stderr note.
 
+        # Kill switch: FRAME_ENFORCE=0 coerces warn mode regardless of -Mode parameter.
+        if ($env:FRAME_ENFORCE -eq '0') {
+            $Mode = 'warn'
+        }
+
         $iss = script:New-FCLInitialSessionStateClone
 
         $rs = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace($iss)
@@ -1656,7 +1754,7 @@ if (-not $isDotSourced) {
             }
             catch {
                 [Console]::Error.WriteLine("frame-credit-ledger: $($_.Exception.Message)")
-                if ($Mode -eq 'enforce') { $exitCode = 1 }
+                if ($Mode -eq 'enforce') { $exitCode = 5 }
             }
             # Mirror stderr from the worker.
             foreach ($errRecord in $worker.Streams.Error) {
@@ -1664,14 +1762,14 @@ if (-not $isDotSourced) {
             }
         }
         else {
-            # Budget exceeded — abort the worker and fail open.
+            # Budget exceeded: timeout-deferred conclusion in enforce mode.
             try { $worker.Stop() } catch { $null = $_ }
-            [Console]::Error.WriteLine("frame-credit-ledger: ${budgetSeconds}s budget exceeded; warn-mode fail-open (no comment posted)")
-            # Warn-mode invariant: never block PR creation on timeout. In
-            # enforce mode the test still expects exit 0 on timeout (warn
-            # invariant takes precedence over enforcement when no decision
-            # could be made).
-            $exitCode = 0
+            [Console]::Error.WriteLine("frame-credit-ledger: ${budgetSeconds}s budget exceeded; timeout-deferred (exit 4 in enforce mode, exit 0 in warn mode)")
+            if ($Mode -eq 'enforce') {
+                $exitCode = 4
+            } else {
+                $exitCode = 0
+            }
         }
 
         try { $worker.Dispose() } catch { $null = $_ }
@@ -1687,10 +1785,15 @@ if (-not $isDotSourced) {
             }
 
             if ($null -ne $resultHash) {
-                $hasNotCovered = $false
-                if ($null -ne $resultHash['HasNotCovered']) { $hasNotCovered = [bool]$resultHash['HasNotCovered'] }
-                if ($Mode -eq 'enforce' -and $hasNotCovered) {
-                    $exitCode = 1
+                $hasBlock = $false
+                $isInternalError = $false
+                if ($null -ne $resultHash['IsInternalError']) { $isInternalError = [bool]$resultHash['IsInternalError'] }
+                if ($null -ne $resultHash['HasBlock']) { $hasBlock = [bool]$resultHash['HasBlock'] }
+                # Also support legacy HasNotCovered key for backward compat
+                elseif ($null -ne $resultHash['HasNotCovered']) { $hasBlock = [bool]$resultHash['HasNotCovered'] }
+                if ($Mode -eq 'enforce') {
+                    if ($isInternalError) { $exitCode = 5 }
+                    elseif ($hasBlock) { $exitCode = 3 }
                 }
                 if ($null -ne $resultHash['Comment'] -and -not [string]::IsNullOrEmpty([string]$resultHash['Comment'])) {
                     Write-Output ([string]$resultHash['Comment'])
@@ -1700,9 +1803,8 @@ if (-not $isDotSourced) {
     }
     catch {
         [Console]::Error.WriteLine("frame-credit-ledger: $($_.Exception.Message)")
-        # Warn-mode invariant: never block PR creation; exit 0 even on caught exception.
         if ($Mode -eq 'enforce') {
-            $exitCode = 1
+            $exitCode = 5
         }
         else {
             $exitCode = 0

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -12,8 +12,9 @@
       5. Composes a markdown ledger comment and posts it via Find-OrUpsertComment.
 
     Honours two test-only env-var hooks (see TEST HOOK CONTRACT):
-      - FRAME_CREDIT_LEDGER_TEST_NO_SLEEP=1     skip Start-Sleep on retry
-      - FRAME_CREDIT_LEDGER_TEST_BUDGET_SECONDS override the 30s outer budget
+      - FRAME_CREDIT_LEDGER_TEST_NO_SLEEP=1                 skip Start-Sleep on retry
+      - FRAME_CREDIT_LEDGER_TEST_BUDGET_SECONDS             override the 30s outer budget
+      - FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER=1  bypass enforce-activation.yaml check
 
     `gh` is resolved via PATH/Get-Command so test mocks installed as
     `function global:gh { ... }` are reachable.
@@ -1744,6 +1745,62 @@ if (-not $isDotSourced) {
         # Kill switch: FRAME_ENFORCE=0 coerces warn mode regardless of -Mode parameter.
         if ($env:FRAME_ENFORCE -eq '0') {
             $Mode = 'warn'
+        }
+
+        # Activation cutover: only enforce for PRs created after the activation timestamp.
+        # Reads enforce-activation.yaml from the repo (which is the base-ref checkout in CI).
+        # If the file is absent, timestamp is unset, or PR_CREATED_AT is not passed,
+        # fall back to warn mode (advisory ship behavior).
+        # Test hook: FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER=1 bypasses this check.
+        if ($Mode -eq 'enforce' -and $env:FRAME_CREDIT_LEDGER_TEST_SKIP_ACTIVATION_CUTOVER -ne '1') {
+            $activationFile = Join-Path (script:Resolve-FCLRepoRoot -ScriptPath $PSCommandPath) 'frame/enforce-activation.yaml'
+            $activationTimestamp = $null
+            if (Test-Path -LiteralPath $activationFile -PathType Leaf) {
+                try {
+                    $activationRaw = Get-Content -LiteralPath $activationFile -Raw -ErrorAction Stop
+                    $activationTsStr = script:Get-FCLScalar -Block $activationRaw -Name 'activation_timestamp'
+                    if (-not [string]::IsNullOrWhiteSpace($activationTsStr)) {
+                        $activationTimestamp = [datetime]::Parse($activationTsStr, $null, [System.Globalization.DateTimeStyles]::RoundtripKind)
+                    }
+                }
+                catch {
+                    [Console]::Error.WriteLine("frame-credit-ledger: failed to read activation timestamp — falling back to warn mode: $($_.Exception.Message)")
+                    $Mode = 'warn'
+                }
+            } else {
+                [Console]::Error.WriteLine("frame-credit-ledger: enforce-activation.yaml not found — falling back to warn mode (advisory ship)")
+                $Mode = 'warn'
+            }
+
+            # Check PR created-at against the activation timestamp.
+            if ($Mode -eq 'enforce' -and $null -ne $activationTimestamp) {
+                $prCreatedAtStr = $env:PR_CREATED_AT
+                if (-not [string]::IsNullOrWhiteSpace($prCreatedAtStr)) {
+                    try {
+                        $prCreatedAt = [datetime]::Parse($prCreatedAtStr, $null, [System.Globalization.DateTimeStyles]::RoundtripKind)
+                        if ($prCreatedAt -lt $activationTimestamp) {
+                            [Console]::Error.WriteLine("frame-credit-ledger: PR created at $prCreatedAtStr is before activation timestamp $activationTsStr — falling back to warn mode")
+                            $Mode = 'warn'
+                        }
+                    }
+                    catch {
+                        [Console]::Error.WriteLine("frame-credit-ledger: failed to parse PR_CREATED_AT '$prCreatedAtStr' — falling back to warn mode: $($_.Exception.Message)")
+                        $Mode = 'warn'
+                    }
+                } else {
+                    # PR_CREATED_AT not set (e.g., local invocation) — skip the cutover check; enforce as-is
+                    [Console]::Error.WriteLine("frame-credit-ledger: PR_CREATED_AT not set — skipping activation cutover check")
+                }
+            }
+
+            # Handle far-future activation timestamp (advisory ship default)
+            if ($Mode -eq 'enforce' -and $null -ne $activationTimestamp) {
+                $farFuture = [datetime]::new(9999, 12, 31, 0, 0, 0, [System.DateTimeKind]::Utc)
+                if ($activationTimestamp -ge $farFuture) {
+                    [Console]::Error.WriteLine("frame-credit-ledger: activation timestamp is far-future sentinel — falling back to warn mode (advisory ship)")
+                    $Mode = 'warn'
+                }
+            }
         }
 
         $iss = script:New-FCLInitialSessionStateClone

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -1401,6 +1401,30 @@ function Invoke-FrameCreditLedger {
 
     $reportsArray = $portReports.ToArray()
 
+    # Apply authorized self-override: find and validate the frame-override-{PR} marker.
+    # Override misconfiguration classes (AdapterParseError, AdapterDiscoveryFailed) are NOT
+    # eligible — these indicate system configuration problems, not missing credits.
+    $overriddenPorts = @(Resolve-FCLOverrideMarker -Pr $Pr -Comments $script:PrComments)
+    if ($overriddenPorts.Count -gt 0) {
+        $nonOverridableSubs = @('AdapterParseError', 'AdapterDiscoveryFailed')
+        $reportsArray = @($reportsArray | ForEach-Object {
+            $r = $_
+            $portName = [string]$r.PortName
+            if ($portName -in $overriddenPorts -and [string]$r.SubReason -notin $nonOverridableSubs) {
+                [pscustomobject]@{
+                    PortName          = $portName
+                    Status            = 'Covered'
+                    SubReason         = 'OverriddenCredit'
+                    AdapterName       = $r.AdapterName
+                    SuggestedNextStep = $null
+                    Evidence          = "override: authorized self-override posted in PR $Pr comment"
+                }
+            } else {
+                $r
+            }
+        })
+    }
+
     # Build a port-descriptor lookup for fast access to BlockOnInconclusive and TriggerStatus.
     $portDescriptorMap = @{}
     foreach ($pd in $ports) {

--- a/.github/scripts/lib/frame-credit-ledger-core.ps1
+++ b/.github/scripts/lib/frame-credit-ledger-core.ps1
@@ -59,11 +59,12 @@ function script:Get-FCLNestedScalar {
     $insideParent = $false
 
     foreach ($line in $lines) {
-        # Skip blank lines
+        # Skip blank lines and comment lines
         if ($line -match '^\s*$') { continue }
+        $trimmed = $line.TrimStart()
+        if ($trimmed.StartsWith('#')) { continue }
 
         # Determine current line indentation
-        $trimmed = $line.TrimStart()
         $currentIndent = $line.Length - $trimmed.Length
 
         if (-not $insideParent) {
@@ -91,6 +92,15 @@ function script:Get-FCLNestedScalar {
             # Child must be strictly deeper than parent
             if ($childIndent -gt $parentIndent) {
                 $value = $line -replace ('^(\s+)' + [regex]::Escape($ChildKey) + '\s*:\s*'), ''
+                $value = ($value).Trim()
+                if ($value.Length -ge 2) {
+                    $first = $value[0]
+                    $last  = $value[$value.Length - 1]
+                    if (($first -eq '"'  -and $last -eq '"') -or
+                        ($first -eq "'" -and $last -eq "'")) {
+                        $value = $value.Substring(1, $value.Length - 2)
+                    }
+                }
                 return $value.Trim()
             }
         }
@@ -1563,7 +1573,16 @@ function Get-PortFiles {
             # Default is $true (fail-safe) when the enforce: block or child key is absent.
             # DO NOT use Get-FCLScalar here — the flat regex matches at any depth, defeating enforce: namespacing (M21/R2-8).
             $rawBOI = script:Get-FCLNestedScalar -Block $raw -ParentKey 'enforce' -ChildKey 'block-on-inconclusive'
-            $blockOnInconclusive = if ($null -eq $rawBOI) { $true } else { $rawBOI -eq 'true' }
+            $blockOnInconclusive = switch ($rawBOI) {
+                $null   { $true  }   # absent → fail-safe default
+                'true'  { $true  }
+                'false' { $false }
+                default {
+                    [Console]::Error.WriteLine(
+                        "frame-credit-ledger: invalid enforce.block-on-inconclusive value '$rawBOI' in '$($file.FullName)'; defaulting to true (fail-safe).")
+                    $true
+                }
+            }
 
             $triggerStatus = script:Get-FCLScalar -Block $raw -Name 'trigger-status'
             $triggerDeferredTo = script:Get-FCLScalar -Block $raw -Name 'trigger-deferred-to'
@@ -2741,7 +2760,7 @@ function Resolve-FCLOverrideMarker {
         # Check for the frame-override-{PR} marker (anchored: must appear as an HTML
         # comment at the start of a line, not inside a fenced block or blockquote).
         # Grammar: <!-- frame-override-{PR}\nports: {csv}\nreason: {text}\n-->
-        $markerPattern = "(?ms)<!--\s*frame-override-$Pr\s*\n\s*ports:\s*(?<ports>[^\n]+)\n\s*reason:\s*(?<reason>[^\n]+?)\s*\n\s*-->"
+        $markerPattern = "(?ms)^\s*<!--\s*frame-override-$Pr\s*\n\s*ports:\s*(?<ports>[^\n]+)\n\s*reason:\s*(?<reason>[^\n]+?)\s*\n\s*-->"
         $markerMatch = [regex]::Match($body, $markerPattern)
         if (-not $markerMatch.Success) { continue }
 
@@ -2772,7 +2791,7 @@ function Resolve-FCLOverrideMarker {
             continue
         }
         if ($authorAssociation.ToUpperInvariant() -notin $authorizedAssociations) {
-            $login = if ($comment.PSObject.Properties['author'] -and $comment.author.PSObject.Properties['login']) { [string]$comment.author.login } else { '(unknown)' }
+            $login = if ($comment.PSObject.Properties['author'] -and $null -ne $comment.author -and $comment.author.PSObject.Properties['login']) { [string]$comment.author.login } else { '(unknown)' }
             [Console]::Error.WriteLine("frame-credit-ledger: override marker on PR $Pr from unauthorized author '$login' (association: $authorAssociation) — override rejected")
             continue
         }
@@ -2785,7 +2804,7 @@ function Resolve-FCLOverrideMarker {
             continue
         }
 
-        $login = if ($comment.PSObject.Properties['author'] -and $comment.author.PSObject.Properties['login']) { [string]$comment.author.login } else { '(authorized)' }
+        $login = if ($comment.PSObject.Properties['author'] -and $null -ne $comment.author -and $comment.author.PSObject.Properties['login']) { [string]$comment.author.login } else { '(authorized)' }
         [Console]::Error.WriteLine("frame-credit-ledger: override applied on PR $Pr by '$login' (association: $authorAssociation) for ports: $($overriddenPorts -join ', '). Reason: $reason")
         return $overriddenPorts
     }

--- a/.github/scripts/lib/frame-credit-ledger-core.ps1
+++ b/.github/scripts/lib/frame-credit-ledger-core.ps1
@@ -1564,12 +1564,17 @@ function Get-PortFiles {
             $rawBOI = script:Get-FCLNestedScalar -Block $raw -ParentKey 'enforce' -ChildKey 'block-on-inconclusive'
             $blockOnInconclusive = if ($null -eq $rawBOI) { $true } else { $rawBOI -eq 'true' }
 
+            $triggerStatus = script:Get-FCLScalar -Block $raw -Name 'trigger-status'
+            $triggerDeferredTo = script:Get-FCLScalar -Block $raw -Name 'trigger-deferred-to'
+
             $results.Add([pscustomobject]@{
                     Name                = $name
                     Description         = $description
                     Applies             = $applies
                     Status              = $status
                     BlockOnInconclusive = [bool]$blockOnInconclusive
+                    TriggerStatus       = if ([string]::IsNullOrWhiteSpace($triggerStatus)) { $null } else { $triggerStatus }
+                    TriggerDeferredTo   = if ([string]::IsNullOrWhiteSpace($triggerDeferredTo)) { $null } else { $triggerDeferredTo }
                 }) | Out-Null
         }
         catch {
@@ -1579,6 +1584,54 @@ function Get-PortFiles {
     }
 
     return $results.ToArray()
+}
+
+function Resolve-FCLRecoveryCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$PortName,
+        [Parameter(Mandatory)][string]$SubReason
+    )
+
+    # Port-specific registry (checked first)
+    $portRegistry = @{
+        'review'             = 'Run /orchestra:review to complete the adversarial review pipeline'
+        'post-fix-review'    = 'Run /orchestra:review (post-fix) after Code-Smith applies fixes'
+        'ce-gate-cli'        = 'Run /experience {N} CE Gate to capture CE Gate evidence for the CLI surface'
+        'ce-gate-browser'    = 'Run /experience {N} CE Gate to capture CE Gate evidence for the browser surface'
+        'ce-gate-canvas'     = 'Run /experience {N} CE Gate to capture CE Gate evidence for the canvas surface'
+        'ce-gate-api'        = 'Run /experience {N} CE Gate to capture CE Gate evidence for the API surface'
+        'plan'               = 'Run /plan {N} to produce an implementation plan'
+        'design'             = 'Run /design {N} to produce a technical design'
+        'experience'         = 'Run /experience {N} to produce customer framing'
+        'release-hygiene'    = 'Ensure a version bump and CHANGELOG entry are present in this PR'
+        'post-pr'            = 'Run post-PR archival steps via /orchestrate after the PR merges'
+        'implement-code'     = 'Ensure the implement-code credit row is present in the PR pipeline-metrics block'
+        'implement-test'     = 'Ensure the implement-test credit row is present in the PR pipeline-metrics block'
+        'implement-refactor' = 'Ensure the implement-refactor credit row is present in the PR pipeline-metrics block'
+        'implement-docs'     = 'Ensure the implement-docs credit row is present in the PR pipeline-metrics block'
+        'process-review'     = 'Run Process-Review agent to complete systemic analysis'
+    }
+
+    # Sub-reason fallback registry (when no port-specific entry or as supplement)
+    $subReasonRegistry = @{
+        'NoEvidence'             = "No adapters or credits found for port '$PortName'. Check that the frame spine declares this port and that credits were emitted."
+        'MissingNextStepField'   = "Adapter for port '$PortName' has no SuggestedNextStep field. Update the adapter YAML to include a suggested-next-step value."
+        'AdapterParseError'      = "Adapter YAML for port '$PortName' failed to parse. Fix the adapter file syntax and re-run the hook."
+        'AdapterDiscoveryFailed' = "All adapters for port '$PortName' returned unknown applicability. Check that the adapter's applies-when predicate is correctly wired."
+        'UnknownCreditStatus'    = "Credit for port '$PortName' has an unrecognized status. Valid statuses: passed, failed, skipped, not-applicable, inconclusive, not-persisted, overridden."
+    }
+
+    if ($portRegistry.ContainsKey($PortName)) {
+        return $portRegistry[$PortName]
+    }
+
+    if ($subReasonRegistry.ContainsKey($SubReason)) {
+        return $subReasonRegistry[$SubReason]
+    }
+
+    # Absolute fallback — always non-empty
+    return "Check port '$PortName' (sub-reason: $SubReason): verify that the frame spine declares this port and that the producing adapter emitted a valid credit."
 }
 
 function Resolve-PortStatus {
@@ -1797,6 +1850,7 @@ function Compose-Comment {
                     'InconclusiveCredit'  { 'inconclusive' }
                     'NotPersistedCredit'  { 'not-persisted' }
                     'MissingAdapter'      { 'missing' }
+                    'DeferredPort'        { 'deferred' }
                     default               { [string]$r.SubReason }
                 }
             }
@@ -1808,6 +1862,7 @@ function Compose-Comment {
                 'failed'        { '❌' }
                 'inconclusive'  { '⚠️' }
                 'not-persisted' { '🔇' }
+                'deferred'      { '⏸️' }
                 default         { '❓' }
             }
 

--- a/.github/scripts/lib/frame-credit-ledger-core.ps1
+++ b/.github/scripts/lib/frame-credit-ledger-core.ps1
@@ -38,6 +38,67 @@ function script:ConvertTo-FCLNormalizedLines {
     return $normalized -split "`n"
 }
 
+function script:Get-FCLNestedScalar {
+    # Reads a child key from a parent block in YAML text.
+    # Returns the value only when the child key appears at exactly one indent level deeper than the parent key.
+    # Returns $null when the parent block is absent, or the child key is absent inside it, or is at the wrong depth.
+    # DO NOT replace with Get-FCLScalar — the flat regex in that function matches at any depth, defeating nesting constraints.
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Block,
+        [Parameter(Mandatory)][string]$ParentKey,
+        [Parameter(Mandatory)][string]$ChildKey
+    )
+
+    if ([string]::IsNullOrEmpty($Block)) {
+        return $null
+    }
+
+    $lines = script:ConvertTo-FCLNormalizedLines -Text $Block
+
+    $parentIndent = -1
+    $insideParent = $false
+
+    foreach ($line in $lines) {
+        # Skip blank lines
+        if ($line -match '^\s*$') { continue }
+
+        # Determine current line indentation
+        $trimmed = $line.TrimStart()
+        $currentIndent = $line.Length - $trimmed.Length
+
+        if (-not $insideParent) {
+            # Look for the parent key at any column (top-level is column 0)
+            $parentPattern = '^(\s*)' + [regex]::Escape($ParentKey) + '\s*:\s*$'
+            if ($line -match $parentPattern) {
+                $parentIndent = $Matches[1].Length
+                $insideParent = $true
+            }
+            continue
+        }
+
+        # We are inside the parent block
+        # If we see a line at same or lesser indent as parent, the block has ended
+        if ($currentIndent -le $parentIndent) {
+            return $null
+        }
+
+        # The child must be at exactly parentIndent + some positive indent (any depth > parent qualifies,
+        # but we require the child key to appear before any sub-block ends).
+        # Look for the child key at this indent level (must be deeper than parent)
+        $childPattern = '^(\s+)' + [regex]::Escape($ChildKey) + '\s*:\s*(?<value>.+?)\s*$'
+        if ($line -match $childPattern) {
+            $childIndent = $Matches[1].Length
+            # Child must be strictly deeper than parent
+            if ($childIndent -gt $parentIndent) {
+                $value = $line -replace ('^(\s+)' + [regex]::Escape($ChildKey) + '\s*:\s*'), ''
+                return $value.Trim()
+            }
+        }
+    }
+
+    return $null
+}
+
 function script:Get-FCLScalar {
     param(
         [Parameter(Mandatory)][AllowEmptyString()][string]$Block,
@@ -1497,11 +1558,18 @@ function Get-PortFiles {
                 continue
             }
 
+            # Read block-on-inconclusive from the nested enforce: block.
+            # Default is $true (fail-safe) when the enforce: block or child key is absent.
+            # DO NOT use Get-FCLScalar here — the flat regex matches at any depth, defeating enforce: namespacing (M21/R2-8).
+            $rawBOI = script:Get-FCLNestedScalar -Block $raw -ParentKey 'enforce' -ChildKey 'block-on-inconclusive'
+            $blockOnInconclusive = if ($null -eq $rawBOI) { $true } else { $rawBOI -eq 'true' }
+
             $results.Add([pscustomobject]@{
-                    Name        = $name
-                    Description = $description
-                    Applies     = $applies
-                    Status      = $status
+                    Name                = $name
+                    Description         = $description
+                    Applies             = $applies
+                    Status              = $status
+                    BlockOnInconclusive = [bool]$blockOnInconclusive
                 }) | Out-Null
         }
         catch {

--- a/.github/scripts/lib/frame-credit-ledger-core.ps1
+++ b/.github/scripts/lib/frame-credit-ledger-core.ps1
@@ -1477,13 +1477,14 @@ function script:Get-FCLCreditStatusPrecedence {
 
     $status = if ($null -eq $LedgerRow) { '' } else { [string]$LedgerRow.Status }
     switch ($status) {
-        'failed' { return 60 }
-        'inconclusive' { return 50 }
-        'not-persisted' { return 40 }
-        'skipped' { return 30 }
+        'overridden'     { return 70 }   # override beats failed — must come first
+        'failed'         { return 60 }
+        'inconclusive'   { return 50 }
+        'not-persisted'  { return 40 }
+        'skipped'        { return 30 }
         'not-applicable' { return 20 }
-        'passed' { return 10 }
-        default { return 0 }
+        'passed'         { return 10 }
+        default          { return 0 }
     }
 }
 
@@ -1745,6 +1746,7 @@ function Resolve-PortStatus {
             'skipped'        = @{ Status = 'Covered'; SubReason = 'SkippedCredit'; IncludeNextStep = $false }
             'failed'         = @{ Status = 'NotCovered'; SubReason = 'AdapterFailed'; IncludeNextStep = $true }
             'inconclusive'   = @{ Status = 'Inconclusive'; SubReason = 'InconclusiveCredit'; IncludeNextStep = $true }
+            'overridden'     = @{ Status = 'Covered'; SubReason = 'OverriddenCredit'; IncludeNextStep = $false }
         }
 
         $entry = $creditMap[$creditStatus]
@@ -2689,4 +2691,90 @@ function Invoke-CreditInputHarvest {
     }
 
     return $results
+}
+
+function Resolve-FCLOverrideMarker {
+    <#
+    .SYNOPSIS
+        Finds an authorized <!-- frame-override-{PR} --> marker in PR comments.
+    .DESCRIPTION
+        Scans top-level PR comments (not PR body, not issue comments) for a
+        <!-- frame-override-{PR} --> block. Returns the list of port names to
+        override when a valid marker is found from an authorized author.
+        Fail-closed: empty/missing author lookup -> no override granted.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$Pr,
+        [AllowNull()][AllowEmptyCollection()][object[]]$Comments
+    )
+
+    if ($null -eq $Comments -or @($Comments).Count -eq 0) {
+        return @()
+    }
+
+    # Authorized author associations (case-insensitive match)
+    $authorizedAssociations = @('OWNER', 'MEMBER', 'COLLABORATOR')
+
+    foreach ($comment in @($Comments)) {
+        # Extract body
+        $body = ''
+        if ($comment.PSObject.Properties['body']) {
+            $body = [string]$comment.body
+        }
+        if ([string]::IsNullOrWhiteSpace($body)) { continue }
+
+        # Check for the frame-override-{PR} marker (anchored: must appear as an HTML
+        # comment at the start of a line, not inside a fenced block or blockquote).
+        # Grammar: <!-- frame-override-{PR}\nports: {csv}\nreason: {text}\n-->
+        $markerPattern = "(?ms)<!--\s*frame-override-$Pr\s*\n\s*ports:\s*(?<ports>[^\n]+)\n\s*reason:\s*(?<reason>[^\n]+?)\s*\n\s*-->"
+        $markerMatch = [regex]::Match($body, $markerPattern)
+        if (-not $markerMatch.Success) { continue }
+
+        # Reject if the marker appears inside a fenced code block (```...```)
+        # Simple heuristic: count ``` before the match position; odd count = inside a block
+        $beforeMarker = $body.Substring(0, $markerMatch.Index)
+        $fenceCount = ([regex]::Matches($beforeMarker, '```') | Measure-Object).Count
+        if ($fenceCount % 2 -ne 0) { continue }
+
+        # Reject if inside a blockquote (line starts with >)
+        $markerLine = ($body.Substring(0, $markerMatch.Index) -split '\n' | Select-Object -Last 1)
+        if ($markerLine -match '^\s*>') { continue }
+
+        # Validate reason is non-empty
+        $reason = $markerMatch.Groups['reason'].Value.Trim()
+        if ([string]::IsNullOrWhiteSpace($reason)) {
+            [Console]::Error.WriteLine("frame-credit-ledger: override marker found on PR $Pr but reason is empty — override rejected")
+            continue
+        }
+
+        # Validate author association (fail-closed: missing/empty -> reject)
+        $authorAssociation = ''
+        if ($comment.PSObject.Properties['authorAssociation']) {
+            $authorAssociation = [string]$comment.authorAssociation
+        }
+        if ([string]::IsNullOrWhiteSpace($authorAssociation)) {
+            [Console]::Error.WriteLine("frame-credit-ledger: override marker on PR $Pr from unknown author association — override rejected (fail-closed)")
+            continue
+        }
+        if ($authorAssociation.ToUpperInvariant() -notin $authorizedAssociations) {
+            $login = if ($comment.PSObject.Properties['author'] -and $comment.author.PSObject.Properties['login']) { [string]$comment.author.login } else { '(unknown)' }
+            [Console]::Error.WriteLine("frame-credit-ledger: override marker on PR $Pr from unauthorized author '$login' (association: $authorAssociation) — override rejected")
+            continue
+        }
+
+        # Parse port list (comma-separated)
+        $portsRaw = $markerMatch.Groups['ports'].Value
+        $overriddenPorts = @($portsRaw -split ',' | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if ($overriddenPorts.Count -eq 0) {
+            [Console]::Error.WriteLine("frame-credit-ledger: override marker on PR $Pr has empty ports list — override rejected")
+            continue
+        }
+
+        $login = if ($comment.PSObject.Properties['author'] -and $comment.author.PSObject.Properties['login']) { [string]$comment.author.login } else { '(authorized)' }
+        [Console]::Error.WriteLine("frame-credit-ledger: override applied on PR $Pr by '$login' (association: $authorAssociation) for ports: $($overriddenPorts -join ', '). Reason: $reason")
+        return $overriddenPorts
+    }
+
+    return @()
 }

--- a/.github/scripts/lib/frame-credit-ledger-core.ps1
+++ b/.github/scripts/lib/frame-credit-ledger-core.ps1
@@ -1808,7 +1808,9 @@ function Compose-Comment {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$MarkerToken,
-        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$PortReports
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$PortReports,
+        [string]$Mode = 'warn',
+        [bool]$HasBlock = $false
     )
 
     $reports = @($PortReports | Where-Object { $_ -ne $null })
@@ -1853,6 +1855,7 @@ function Compose-Comment {
                     'NotPersistedCredit'  { 'not-persisted' }
                     'MissingAdapter'      { 'missing' }
                     'DeferredPort'        { 'deferred' }
+                    'OverriddenCredit'    { 'overridden' }
                     default               { [string]$r.SubReason }
                 }
             }
@@ -1865,6 +1868,7 @@ function Compose-Comment {
                 'inconclusive'  { '⚠️' }
                 'not-persisted' { '🔇' }
                 'deferred'      { '⏸️' }
+                'overridden'    { '🔓' }
                 default         { '❓' }
             }
 
@@ -1895,7 +1899,15 @@ function Compose-Comment {
         [void]$sb.AppendLine('')
     }
 
-    [void]$sb.AppendLine('(Hook ran in `warn` mode; PR creation was not blocked.)')
+    if ($Mode -eq 'enforce') {
+        if ($HasBlock) {
+            [void]$sb.AppendLine('(Hook ran in `enforce` mode; blocked ports above prevent merge.)')
+        } else {
+            [void]$sb.AppendLine('(Hook ran in `enforce` mode; all covered ports passed.)')
+        }
+    } else {
+        [void]$sb.AppendLine('(Hook ran in `warn` mode; PR creation was not blocked.)')
+    }
 
     return $sb.ToString()
 }
@@ -1906,10 +1918,12 @@ function Compose-CommentWithCostPattern {
     param(
         [Parameter(Mandatory)][string]$MarkerToken,
         [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$PortReports,
-        [AllowEmptyString()][string]$CostSection = ''
+        [AllowEmptyString()][string]$CostSection = '',
+        [string]$Mode = 'warn',
+        [bool]$HasBlock = $false
     )
     # 1. Call Compose-Comment to get the port-coverage section
-    $portCoverageBody = Compose-Comment -MarkerToken $MarkerToken -PortReports $PortReports
+    $portCoverageBody = Compose-Comment -MarkerToken $MarkerToken -PortReports $PortReports -Mode $Mode -HasBlock $HasBlock
     # 2. Append cost section if non-empty
     if ([string]::IsNullOrWhiteSpace($CostSection)) {
         return $portCoverageBody

--- a/.github/workflows/frame-enforce.yml
+++ b/.github/workflows/frame-enforce.yml
@@ -1,0 +1,48 @@
+# Enforces frame credit coverage as a required check (gates merge).
+# Ships in advisory mode — not marked required until the Pre-Activation Gate is met.
+# Activation: set enforce-activation.yaml on the base branch, then mark this check required
+# in branch protection. See frame/enforce-activation.yaml and Documents/Design/frame-architecture.md.
+name: Frame credit enforce
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: frame-enforce-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  frame-enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch origin "$BASE_REF"
+
+      - name: Checkout base-ref config files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # Read frame/ports/*.yaml and frame/enforce-activation.yaml from the base ref,
+          # not the merge commit. This ensures gate config cannot be changed by the PR.
+          git checkout "$BASE_SHA" -- frame/ports/ frame/enforce-activation.yaml || true
+
+      - name: Run frame credit enforce
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
+        run: |
+          ./.github/scripts/frame-credit-ledger.ps1 -Pr $env:PR_NUMBER -Mode enforce

--- a/.github/workflows/frame-enforce.yml
+++ b/.github/workflows/frame-enforce.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: write  # needed: Find-OrUpsertComment posts/updates the frame-credit-ledger PR comment
 
 concurrency:
   group: frame-enforce-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/frame-enforce.yml
+++ b/.github/workflows/frame-enforce.yml
@@ -30,13 +30,20 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: git fetch origin "$BASE_REF"
 
-      - name: Checkout base-ref config files
+      - name: Checkout base-ref port config
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          # Read frame/ports/*.yaml and frame/enforce-activation.yaml from the base ref,
-          # not the merge commit. This ensures gate config cannot be changed by the PR.
-          git checkout "$BASE_SHA" -- frame/ports/ frame/enforce-activation.yaml || true
+          # Read frame/ports/*.yaml from the base ref so gate config cannot be changed by the PR.
+          git checkout "$BASE_SHA" -- frame/ports/
+
+      - name: Checkout base-ref activation config
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # enforce-activation.yaml is a new file and may be absent on the base ref.
+          # Fail-open (|| true) so the PS script's missing-file guard fires and coerces warn.
+          git checkout "$BASE_SHA" -- frame/enforce-activation.yaml || true
 
       - name: Run frame credit enforce
         shell: pwsh

--- a/Documents/Design/frame-architecture.md
+++ b/Documents/Design/frame-architecture.md
@@ -12,7 +12,7 @@ Agent Orchestra delivers customer-visible work through a pipeline of phases (exp
 
 This design introduces a **frame** — a hexagonal-architecture-style contract that declares the required phases as **ports**, allows multiple **adapters** (skills/sub-skills) to fill each port, captures completion as **credits** in a structured PR ledger, and **enforces** completion via a pre-PR hook that blocks PR creation if any port lacks a credit. The frame separates **what must happen** (deterministic, declared in port files) from **how it happens this time** (judgment, contextual selection of an adapter), removing the prose-trust spine while preserving agent flexibility.
 
-The first deliverable is **audit-only**: build the credit ledger format, back-derive credits from existing markers across recent PRs, and report the actual gap rate per port. Enforcement comes after the audit shapes priorities.
+The first deliverable was **audit-only**: build the credit ledger format, back-derive credits from existing markers across recent PRs, and report the actual gap rate per port. Enforcement comes after the audit shapes priorities. As of #439, the frame is in **advisory enforce mode**: the `frame-enforce.yml` GitHub Actions workflow runs on every PR and emits a blocking signal for ports missing credits, but is not yet a required branch-protection check. See [Activation runbook](#activation-runbook) for the gate that must be met before an administrator marks it as required.
 
 ---
 
@@ -507,23 +507,22 @@ This closes the only failure mode the terminal-step rule alone doesn't address: 
 
 ## Pre-PR Hook Contract
 
-> **Shipped status (sub-issue #429, branch `feature/issue-429-pre-pr-warn-hook`):** the warn-only slice has landed.
+> **Shipped status:** two enforcement slices have landed.
 >
 > - **Schema**: `metrics_version: 4` — frame credits sit on top of the inherited v3 base. See `frame/pipeline-metrics-v4-schema.md` for the additive fields.
-> - **Orchestrator**: `.github/scripts/frame-credit-ledger.ps1 -Pr <N> [-Mode warn|enforce]`. Default `-Mode warn`; `enforce` is reserved for sub-issue #13 and is not active in this slice.
+> - **Orchestrator**: `.github/scripts/frame-credit-ledger.ps1 -Pr <N> [-Mode warn|enforce]`. Default `-Mode warn`; `enforce` mode ships as part of #439 and is active in the `frame-enforce.yml` GitHub Actions workflow (advisory only — not yet a required branch-protection check).
 > - **Methodology skill**: `skills/frame-credit-ledger/SKILL.md`, referenced from `agents/Code-Conductor.agent.md` Step 4 as the post-`gh pr create` observation step.
-> - **Status**: warn-only. The hook posts an idempotent `<!-- frame-credit-ledger-{PR} -->` comment listing gaps; it does **not** block PR creation. Blocking-mode activation is deferred to sub-issue #13.
+> - **Advisory enforce mode** (#439): the `frame-enforce.yml` workflow runs on every PR and exits with a non-zero code when ports are missing credits. It is **not** a required check — making it required is gated on the Pre-Activation Gate. See [Activation runbook](#activation-runbook).
+> - **Override mechanism** (#439): authorized actors (`OWNER`, `MEMBER`, or `COLLABORATOR`) may post a `<!-- frame-override-{PR} -->` comment to grant per-port clearance. The `overridden` credit status records this. Kill switch: set `FRAME_ENFORCE=0` in the Actions workflow run to coerce enforce → warn for that run.
 > - **Three-state taxonomy** for port coverage in the rendered ledger: `Covered | Inconclusive | NotCovered` — bare-string canonical at the data layer, with emoji applied at format-time only.
 > - **Auto-N/A semantics**: D7 logical-AND. A port is N/A iff *every* declared work-adapter for that port has an `applies-when` predicate that evaluates `false` against the changeset. If any work-adapter applies, the port is live and absence of a credit becomes a gap.
 >
-> The pseudocode below remains the design target; some semantics (notably blocking on `missing` / `failed`) describe the eventual enforce-mode behavior tracked in sub-issue #13. The shipped warn-only orchestrator surfaces the same conditions as ledger entries rather than as PR-create blocks.
+> The pseudocode below remains the design target. **As of #439**, the advisory enforce workflow (`frame-enforce.yml`) runs enforce mode on every PR and surfaces blocking conditions as a non-zero exit code; it is not yet a required branch-protection check. See [Activation runbook](#activation-runbook) for the gate that governs making it required.
 >
-> **Known limitation (sub-issue #13 will need more than a default-flag flip):** the original AC-8 / D6 promise framed sub-issue #13 as "change one parameter, not refactor the script." That promise is no longer fully truthful for two reasons surfaced during the warn-only slice:
+> **Resolved limitations from the warn-only slice** (tracked in #439):
 >
-> 1. **Budget-exceeded enforce policy is undefined.** When the 30s outer budget elapses, the orchestrator currently returns exit 0 *unconditionally* (warn-mode invariant takes precedence over enforcement when no decision could be made). Sub-issue #13 will need to pick an explicit policy: (a) keep the current warn-invariant precedence, (b) treat budget-exceeded as a hard fail in enforce mode, or (c) emit a separate "enforce-deferred" exit code. None of these are a flag flip.
-> 2. **AdapterDiscoveryFailed → Inconclusive routing.** When all adapters for a port resolve to `'unknown'` and no credit is present, the orchestrator currently routes to `Inconclusive`, not `NotCovered`. Sub-issue #13 will need to decide whether enforce mode treats `Inconclusive` as a block (strictest), as a pass (most permissive), or as a third "operator-must-acknowledge" path.
->
-> Both decisions touch the orchestrator's main flow, not just its default `-Mode` value. The audit-update for sub-issue #13 should rescope from "flip the flag" to "flip the flag + adopt explicit enforce-mode policies for the two ambiguity cases above."
+> 1. **Budget-exceeded enforce policy**: when the 30s outer budget elapses in enforce mode, the orchestrator exits with code 4 (budget-exceeded enforce block). This is the explicit policy chosen in #439 — budget-exceeded is treated as a soft-block requiring operator acknowledgment, not a silent pass.
+> 2. **AdapterDiscoveryFailed → Inconclusive routing**: in enforce mode, `Inconclusive` ports exit with code 3 (inconclusive-block), separate from code 4 (missing/failed). The `enforce: block-on-inconclusive:` field in each port YAML controls whether an inconclusive credit blocks or passes. This allows per-port tuning without changing the orchestrator's main flow.
 
 ```text
 on `gh pr create` (or push to PR branch with auto-PR):
@@ -553,6 +552,52 @@ Every BLOCK message names:
 - The recovery command (e.g., `/orchestra:review-judge`)
 
 Operators should never see a generic "frame check failed" — always actionable.
+
+---
+
+## Activation runbook
+
+The `frame-enforce.yml` GitHub Actions workflow ships as **advisory** — it runs on every PR but is not yet a required branch-protection check. The following gate must be met before an administrator marks the workflow as required.
+
+### Pre-Activation Gate
+
+All four conditions must hold before flipping to required:
+
+1. **Credit provenance resolved** — issue #724 (corroborate `credits[]` against a non-PR-mutable source) is closed. This ensures the enforcement signal cannot be trivially spoofed.
+2. **Audit completeness** — ≥ 95% credit coverage over the most recent 30-PR retrospective audit (run `/audit-docs` to generate the report).
+3. **Operator notice** — ≥ 1-week advance notice posted to the relevant channel or issue before enforcement becomes mandatory.
+4. **Kill switch tested** — set `FRAME_ENFORCE=0` on a test PR run and confirm the workflow exits 0 before activating enforcement.
+
+### Activation steps (administrator)
+
+Once the gate is met:
+
+1. Set the activation timestamp in `frame/enforce-activation.yaml` on the `main` branch:
+   ```yaml
+   activation_timestamp: "<ISO-8601 UTC timestamp of now>"
+   ```
+   For example: `activation_timestamp: "2026-09-01T00:00:00Z"`
+
+2. In the GitHub repository settings → Branch protection → `main` branch rule, add **`Frame credit enforce`** as a required status check.
+
+3. Announce activation in the relevant channel or issue.
+
+PRs created **before** the `activation_timestamp` are not subject to enforcement (they degrade to warn mode automatically). Only PRs created after the timestamp are enforced.
+
+### Emergency opt-out
+
+Two escape hatches are available:
+
+- **Per-PR override**: an `OWNER`, `MEMBER`, or `COLLABORATOR` posts a top-level PR comment containing:
+  ```
+  <!-- frame-override-{PR_NUMBER}
+  ports: port1, port2
+  reason: <mandatory explanation>
+  -->
+  ```
+  This marks the listed ports as `overridden` (precedence 70, beats `failed`). The comment is the durable record; no additional tracking is added.
+
+- **Kill switch**: set the `FRAME_ENFORCE=0` environment variable in the Actions workflow run. This coerces enforce → warn for that run. Use only in genuine emergencies.
 
 ---
 
@@ -649,7 +694,7 @@ Order is intentional but flexible — actual priority will shift based on audit-
 | 10 | #435 (closed) | Reify `post-pr` and `post-fix-review` ports | Trigger-conditional logic for post-fix-review; explicit credit for post-pr cleanup. | row 5 |
 | 11 | #436 (closed) | Decision: `process-retrospective` port or retire | Audit usage feeds the ADR-0004 D14 deferred-skeleton pattern until the practice is formalized as a port, folded into `post-pr`, or retired. | row 1 |
 | 12 | #438 (closed) | Reify `process-review` port | Trigger-conditional on CE Gate defects. | row 7 |
-| 13 | #439 | Pre-PR hook switches to **blocking mode** | After all 17 ports have adapters and audit shows acceptable credit-rate, hook upgrades from warn → block. **The actual rails turn on.** Per D17 (#442), blocking-mode activation requires ≥30-PR recalibration data, all post-spine. | all preceding |
+| 13 | #439 | Pre-PR hook: **advisory enforce mode** (shipped); required-check activation gated on Pre-Activation Gate | `enforce: block-on-inconclusive:` field added to all 17 port files; block aggregator (`FRAME_ENFORCE=0` kill switch, exit codes {0,3,4,5}); `overridden` credit status and `Resolve-FCLOverrideMarker`; `frame-enforce.yml` advisory workflow and `frame/enforce-activation.yaml` sentinel; activation-cutover logic in orchestrator. The hook runs on every PR but is **not** a required branch-protection check. See [Activation runbook](#activation-runbook) for the Pre-Activation Gate. Per D17 (#442), requiring ≥30-PR recalibration data (all post-spine) and issue #724 closure are among the gate conditions. | all preceding |
 
 Active aggregation issues: #441 (sub-A, closed 2026-05) covers rows 5, 6, and 10; **#442** (sub-B, active) covers rows 7, 8, and 9.
 
@@ -740,9 +785,9 @@ Reserved. Same policy as D14.
 
 Reserved. Same policy as D14.
 
-### D17 — Blocking-mode activation precondition
+### D17 — Activation precondition (updated by #439)
 
-Blocking-mode activation for sub-issue #13 requires ≥30-PR recalibration data, all post-spine. The first PR with spine semantics merging restarts the counter for #439. The warn-only hook must accumulate that dataset before the gate switches from `warn` to `enforce` mode. Sub-issue #13 owns the enforcement switch; this decision prevents premature enforcement before the credit-rate baseline is established.
+Advisory enforce mode (`frame-enforce.yml` running on every PR with a non-zero exit code for missing/failed/inconclusive ports) shipped in #439. Making the workflow a **required** branch-protection check is the remaining activation step. Required-check activation requires all four Pre-Activation Gate conditions to hold (see [Activation runbook](#activation-runbook)): credit provenance resolved (issue #724 closed), ≥95% credit coverage over the most recent 30-PR retrospective audit (all post-spine), ≥1-week operator notice, and kill switch tested. The first PR with spine semantics merging restarts the 30-PR audit counter. This decision prevents premature enforcement before the credit-rate baseline is established and before the spoofing surface is closed.
 
 ### D18 — Skill-first methodology
 

--- a/Documents/Design/frame-architecture.md
+++ b/Documents/Design/frame-architecture.md
@@ -522,7 +522,7 @@ This closes the only failure mode the terminal-step rule alone doesn't address: 
 > **Resolved limitations from the warn-only slice** (tracked in #439):
 >
 > 1. **Budget-exceeded enforce policy**: when the 30s outer budget elapses in enforce mode, the orchestrator exits with code 4 (budget-exceeded enforce block). This is the explicit policy chosen in #439 — budget-exceeded is treated as a soft-block requiring operator acknowledgment, not a silent pass.
-> 2. **AdapterDiscoveryFailed → Inconclusive routing**: in enforce mode, `Inconclusive` ports exit with code 3 (inconclusive-block), separate from code 4 (missing/failed). The `enforce: block-on-inconclusive:` field in each port YAML controls whether an inconclusive credit blocks or passes. This allows per-port tuning without changing the orchestrator's main flow.
+> 2. **AdapterDiscoveryFailed → Inconclusive routing**: in enforce mode, blocking ports (missing/failed and configured-blocking inconclusive) exit with code 3. Code 4 is reserved for budget timeout. The `enforce: block-on-inconclusive:` field in each port YAML controls whether an inconclusive credit blocks or passes. This allows per-port tuning without changing the orchestrator's main flow.
 
 ```text
 on `gh pr create` (or push to PR branch with auto-PR):
@@ -573,9 +573,11 @@ All four conditions must hold before flipping to required:
 Once the gate is met:
 
 1. Set the activation timestamp in `frame/enforce-activation.yaml` on the `main` branch:
+
    ```yaml
    activation_timestamp: "<ISO-8601 UTC timestamp of now>"
    ```
+
    For example: `activation_timestamp: "2026-09-01T00:00:00Z"`
 
 2. In the GitHub repository settings → Branch protection → `main` branch rule, add **`Frame credit enforce`** as a required status check.
@@ -589,12 +591,14 @@ PRs created **before** the `activation_timestamp` are not subject to enforcement
 Two escape hatches are available:
 
 - **Per-PR override**: an `OWNER`, `MEMBER`, or `COLLABORATOR` posts a top-level PR comment containing:
-  ```
+
+  ```text
   <!-- frame-override-{PR_NUMBER}
   ports: port1, port2
   reason: <mandatory explanation>
   -->
   ```
+
   This marks the listed ports as `overridden` (precedence 70, beats `failed`). The comment is the durable record; no additional tracking is added.
 
 - **Kill switch**: set the `FRAME_ENFORCE=0` environment variable in the Actions workflow run. This coerces enforce → warn for that run. Use only in genuine emergencies.

--- a/frame/enforce-activation.yaml
+++ b/frame/enforce-activation.yaml
@@ -1,0 +1,10 @@
+# Frame enforce activation timestamp.
+# PRs created BEFORE this timestamp are not subject to enforcement (warn mode only).
+# Set this to a past timestamp only after the Pre-Activation Gate is met:
+#   1. >= 95% credit completeness over 30-PR retrospective audit
+#   2. >= 1-week operator notice posted
+#   3. Opt-out mechanism (FRAME_ENFORCE=0) built, documented, and tested
+#   4. Credit provenance (#724) resolved
+# See Documents/Design/frame-architecture.md for the activation runbook.
+schema_version: 1
+activation_timestamp: "9999-12-31T00:00:00Z"

--- a/frame/pipeline-metrics-v4-schema.md
+++ b/frame/pipeline-metrics-v4-schema.md
@@ -8,7 +8,7 @@ Frame ledger data starts at `metrics_version: 4` because v3 was already claimed 
 
 This document owns only the frame-specific audit additions introduced with v4. The inherited pipeline-metrics fields, including the existing `findings:` array and all v1-v3 semantics, remain authoritative in `skills/calibration-pipeline/references/metrics-schema.md`.
 
-The v4 surface is audit-only. It records synthetic frame credits and integrity metadata for historical analysis without introducing adapter duplication, enforcement behavior, or a runtime trigger grammar.
+The v4 surface was designed as audit-only. It records synthetic frame credits and integrity metadata for historical analysis without introducing adapter duplication or a runtime trigger grammar. (Note: the no-enforcement constraint was superseded by #439, which adds advisory `enforce` mode via `frame-enforce.yml`. The schema remains audit-data — enforcement is in the required check that reads from it, not in the schema fields themselves.)
 
 ## v4 Additions
 

--- a/frame/pipeline-metrics-v4-schema.md
+++ b/frame/pipeline-metrics-v4-schema.md
@@ -109,8 +109,9 @@ Field notes:
   - `stale-spine[]` records each user-approved stale-spine fallback to legacy-shape dispatch. Each event carries `step` (the implementation step identifier or index) and `reason` (`generated_at-mismatch` or `missing-step-id`). Additive updates append newly observed stale fallback events and preserve existing entries.
 - `spine-stale-fallback-count` is optional and absent when no stale-spine fallback event occurred. When present, it is a non-negative integer equal to the number of observed `dispatch-fallback-events.stale-spine[]` entries, except additive updates must never decrement an already-written higher value; use `max(existing count, observed stale-spine event count)`. The field gives report consumers a cheap count without requiring nested event parsing.
 - `credits[]` is the audit ledger. Each entry records a `port`, a frame credit `status`, and brief audit evidence.
-- `credits[].status` uses the explicit enum `passed | failed | skipped | not-applicable | inconclusive | not-persisted`.
+- `credits[].status` uses the explicit enum `passed | failed | skipped | not-applicable | inconclusive | not-persisted | overridden`.
   - `not-persisted` is synthesized by the warn-only hook when the sentinel `<!-- review-judge-produced-{PR} -->` is present but no credit row was written. It is never emitted directly as an inline credit.
+  - `overridden` is applied by `Resolve-FCLOverrideMarker` when an authorized actor (`OWNER`, `MEMBER`, or `COLLABORATOR`) posts a `<!-- frame-override-{PR} -->` marker comment on the PR granting explicit per-port clearance. The marker comment is the durable record. Enum-widening policy: adding `overridden` is a forward-compat enum-widening with no schema version bump. Unknown status values produce `inconclusive/❓` (never a parse error).
 - `credits[].adapter` (optional on non-review ports) names the specific adapter that produced this credit row.
 - `credits[].run_index` is a monotonically increasing integer per `(port, adapter)` pair. Multiple entries for the same port and adapter are appended; the latest by `run_index` is the authoritative summary value. There is no `timestamp` field on credit rows — `run_index` provides re-run ordering without violating the audit-only framing.
 - `credits[].terminal-step-id` (optional) records the positive terminal implementation step that emitted a spine-backed credit. Omitted or `0` preserves the legacy/spine-omitted identity for plans without a terminal slice.
@@ -144,6 +145,6 @@ Readers that understand v4 consume the inherited v3 metrics plus the frame addit
 ## Out Of Scope
 
 - Re-documenting inherited v1-v3 field semantics from `skills/calibration-pipeline/references/metrics-schema.md`
-- Any enforcement, warning, or blocking behavior
+- Any enforcement, warning, or blocking behavior (Note: this constraint was superseded by #439 which adds `enforce` mode. The schema remains audit-data — the enforcement is in the required check that reads from it.)
 - A runtime-evaluable trigger-condition DSL
 - Adapter declarations or frontmatter changes outside the audit artifacts

--- a/frame/ports/ce-gate-api.yaml
+++ b/frame/ports/ce-gate-api.yaml
@@ -2,3 +2,5 @@ name: ce-gate-api
 description: "Was the customer-experience gate evaluated for an API surface?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: false

--- a/frame/ports/ce-gate-browser.yaml
+++ b/frame/ports/ce-gate-browser.yaml
@@ -2,3 +2,5 @@ name: ce-gate-browser
 description: "Was the customer-experience gate evaluated for a browser surface?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: false

--- a/frame/ports/ce-gate-canvas.yaml
+++ b/frame/ports/ce-gate-canvas.yaml
@@ -2,3 +2,5 @@ name: ce-gate-canvas
 description: "Was the customer-experience gate evaluated for a canvas surface?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: false

--- a/frame/ports/ce-gate-cli.yaml
+++ b/frame/ports/ce-gate-cli.yaml
@@ -2,3 +2,5 @@ name: ce-gate-cli
 description: "Was the customer-experience gate evaluated for a CLI-oriented surface?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: false

--- a/frame/ports/design.yaml
+++ b/frame/ports/design.yaml
@@ -2,3 +2,5 @@ name: design
 description: "Was the technical design explored before implementation?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/experience.yaml
+++ b/frame/ports/experience.yaml
@@ -2,3 +2,5 @@ name: experience
 description: "Was the customer problem framed before implementation?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/implement-code.yaml
+++ b/frame/ports/implement-code.yaml
@@ -2,3 +2,5 @@ name: implement-code
 description: "Was the core implementation lane executed for this change?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/implement-docs.yaml
+++ b/frame/ports/implement-docs.yaml
@@ -2,3 +2,5 @@ name: implement-docs
 description: "Was implementation-facing documentation work executed for this change?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/implement-refactor.yaml
+++ b/frame/ports/implement-refactor.yaml
@@ -2,3 +2,5 @@ name: implement-refactor
 description: "Was structural improvement or cleanup work executed for this change?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/implement-test.yaml
+++ b/frame/ports/implement-test.yaml
@@ -2,3 +2,5 @@ name: implement-test
 description: "Was behavior or regression test work executed for this change?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/plan.yaml
+++ b/frame/ports/plan.yaml
@@ -2,3 +2,5 @@ name: plan
 description: "Was an implementation plan approved before coding began?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/post-fix-review.yaml
+++ b/frame/ports/post-fix-review.yaml
@@ -5,3 +5,5 @@ trigger:
   source-port: review
   condition-description: "Main review accepted findings that required a follow-up fix and targeted re-review."
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/post-pr.yaml
+++ b/frame/ports/post-pr.yaml
@@ -2,3 +2,5 @@ name: post-pr
 description: "Was the post-merge cleanup and archival path completed for this change?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/process-retrospective.yaml
+++ b/frame/ports/process-retrospective.yaml
@@ -2,6 +2,8 @@ name: process-retrospective
 description: "Should this change contribute to a broader process retrospective signal?"
 applies: trigger-conditional
 status: formalized-skeleton-deferred-to-348
+enforce:
+  block-on-inconclusive: false
 trigger-status: deferred
 trigger-deferred-to: '#348'
 trigger-deferred-since: '2026-05-03'

--- a/frame/ports/process-review.yaml
+++ b/frame/ports/process-review.yaml
@@ -5,3 +5,5 @@ trigger:
   source-port: review
   condition-description: "Review or CE evidence identified a systemic process gap that warranted retrospective analysis."
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/release-hygiene.yaml
+++ b/frame/ports/release-hygiene.yaml
@@ -5,3 +5,5 @@ trigger:
   source-port: implement-code
   condition-description: "Entry-point or distributed plugin files changed in a way that would require release-hygiene review."
 status: stable
+enforce:
+  block-on-inconclusive: true

--- a/frame/ports/review.yaml
+++ b/frame/ports/review.yaml
@@ -2,3 +2,5 @@ name: review
 description: "Was the change adversarially reviewed and judged?"
 applies: always
 status: stable
+enforce:
+  block-on-inconclusive: true


### PR DESCRIPTION
Closes #439

## Summary

Ships the frame's `enforce` mode behind a GitHub Actions required check (`frame-enforce.yml`) that gates **merge**. Ships **advisory** — the check runs on every PR but is NOT marked required in branch protection until the Pre-Activation Gate is met (issue #724 resolved, ≥95% audit, ≥1-week notice). The far-future sentinel in `frame/enforce-activation.yaml` ensures the cutover never fires until an admin explicitly sets a real timestamp.

- **Port schema** (s1): `enforce.block-on-inconclusive` boolean added to all 17 port files with defined defaults (review=true, post-fix-review=true, ce-gate-*=false, process-retrospective=false, remainder=true)
- **Verdict core** (s2): block aggregator folds NotCovered + Inconclusive×block-on-inconclusive + misconfig classes; exit-code space {0=allow, 3=gap, 4=timeout, 5=error}; recovery resolver; FRAME_ENFORCE=0 kill switch; activation cutover with DateTimeOffset-aware comparison
- **Author-bound override** (s3): `<!-- frame-override-{PR} -->` marker recognized only from OWNER|MEMBER|COLLABORATOR in top-level PR comments; fail-closed; `overridden` credit renders as 🔓; beats `failed` in precedence
- **Workflow** (s4): `frame-enforce.yml` with split base-ref checkout (port config and activation config isolated so frame/ports/ resets even when enforce-activation.yaml is absent on base)
- **Tests** (s5): enforce suite (42 orchestrator tests green); boundary rescope for frame-no-enforcement
- **Docs** (s6): false "audit-only" premise removed; activation runbook added (Pre-Activation Gate + admin steps + emergency opt-out)
- **Review fixes** (post-judge): C1 split checkout, H1 DateTimeOffset, M3 OverriddenCredit renderer, M4 mode-aware footer

## CE Gate evidence

| Scenario | Test | Result |
|----------|------|--------|
| S1: missing credit → exit 3 + recovery named | `AC3: inconclusive review credit blocks in enforce mode` | ✅ 42/42 green |
| S2: full credits → exit 0 | existing "all ports covered" suite | ✅ green |
| S3: deferred port → DEFERRED(#348): row | `build-deferred-port-credit-row.Tests.ps1` + process-retrospective=false config | ✅ green |
| S4: recovery command documented effect → green | OWNER override → exit 0 (effect-contract) | ✅ green |
| S5: authorized self-override → overridden record | `frame-override-429 marker from OWNER → exit 0` | ✅ green |

## Adversarial review

5-pass standard panel (2 generalist + 3 specialist) → defense → judge.
Judge verdict: **CONDITIONAL_PASS**. Fix-before-merge set (C1, H1, M3, M4) applied and green.

## Activation

The check is advisory until an admin:
1. Closes issue #724 (credit provenance)
2. Achieves ≥95% frame audit coverage
3. Posts 1-week advance notice in issue #439
4. Sets `activation_timestamp` in `frame/enforce-activation.yaml` on `main`
5. Marks `frame-enforce / frame-enforce` required in branch protection

See `Documents/Design/frame-architecture.md § Activation runbook` for the full procedure.

<!-- frame-pipeline-metrics
schema_version: 4
issue: 439
branch: feature/issue-439-rails-on-blocking-mode
credits:
  - port: implement-code
    adapter: implement-code-adapter
    status: passed
    slices: [s1, s2, s3, s4]
  - port: implement-test
    adapter: implement-test-adapter
    status: passed
    slices: [s5]
  - port: implement-docs
    adapter: implement-docs-adapter
    status: passed
    slices: [s6]
  - port: review
    adapter: standard
    status: passed
    evidence: "5-pass prosecution + defense + judge; CONDITIONAL_PASS; fix-before-merge set applied"
  - port: ce-gate-cli
    adapter: ce-gate-cli-adapter
    status: passed
    evidence: "42/42 orchestrator tests green; 85/85 core tests green; CE Gate S1-S5 verified"
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an advisory frame-enforce GitHub Action that runs enforcement logic for frame credit coverage on every PR, with activation gated by a timestamp file and kill switch, and extend the frame orchestrator to support enforce mode semantics including exit codes, overrides, and recovery guidance.

New Features:
- Add per-port enforce.block-on-inconclusive settings in all frame port manifests to control whether inconclusive credits block in enforce mode.
- Introduce an authorized frame-override PR comment mechanism that records overridden credits and allows per-port clearance without changing the ledger schema version.
- Add a FRAME_ENFORCE=0 kill switch and activation timestamp cutover logic so enforce mode can be globally disabled or gated by PR creation time.
- Extend the frame credit ledger comment rendering to show enforce vs warn mode status, deferred ports, and overridden credits with dedicated icons.
- Add a frame-enforce.yml GitHub Actions workflow wired to the frame credit ledger orchestrator in enforce mode, plus an enforce-activation.yaml sentinel to keep enforcement advisory until explicitly activated.

Enhancements:
- Refine port aggregation to treat deferred and inconclusive ports with per-port blocking rules and to synthesize recovery commands for blocking ports lacking next steps.
- Teach the orchestrator to distinguish internal errors, timeouts, and blocking gaps via dedicated exit codes and to honor an activation cutover based on enforce-activation.yaml and PR metadata.
- Update documentation to describe advisory enforce mode, the activation runbook, override and kill-switch mechanisms, and to clarify that v4 schema remains audit data with a widened credits status enum.

Documentation:
- Document the advisory enforce mode, Pre-Activation Gate, activation steps, override mechanism, kill switch, and updated activation preconditions in the frame architecture design doc, and clarify the audit-only intent of the v4 schema despite the new enforce workflow.

Tests:
- Add orchestrator tests covering enforce mode exit codes, block-on-inconclusive behavior, kill switch semantics, activation cutover behavior, timeouts, internal errors, and override markers.
- Add tests ensuring port manifests declare enforce.block-on-inconclusive, verifying specific port defaults, and validating enforce activation sentinel configuration.
- Extend comment-rendering tests to cover overridden credit rendering and enforce-mode footer variants, and widen credit-row schema conformance tests to accept the overridden status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advisory credit enforcement mode on every pull request, with per-port `block-on-inconclusive` control and clearer enforcement outcomes.
  * Implemented an authorized PR comment override to mark credits as “overridden”.
  * Added an activation gate so enforcement only becomes required after an admin cutover.
  * Added a kill switch to force enforcement into non-blocking warning mode.
* **Documentation**
  * Updated architecture and v4 schema docs to cover advisory enforcement, override status, and activation behavior.
* **Tests**
  * Expanded/adjusted enforcement and schema conformance test coverage, including new exit-code scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->