### PR TITLE
fix(#656): exclude live persistent tracking files from session-cleanup detection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/scripts/Tests/post-merge-cleanup.Tests.ps1
+++ b/.github/scripts/Tests/post-merge-cleanup.Tests.ps1
@@ -1356,3 +1356,110 @@ title: "Issue 42 back-compat test"
         }
     }
 }
+
+Describe 'post-merge-cleanup.ps1 — persistent root-level file exclusion (#656)' {
+
+    # $script:InvokeScript and $script:ScriptFile are set in the outer BeforeAll
+    # (script-scoped) and available to this sibling Describe.
+
+    It 'AC4-UntaggedRoute: registry-protected file in -UntaggedTrackingFiles is skipped, not archived' {
+        $workDir = Join-Path $TestDrive 'persistent-untagged-skip'
+        New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+
+        # Create a registry-named file at tracking root
+        $trackingDir = Join-Path $workDir '.copilot-tracking'
+        New-Item -ItemType Directory -Path $trackingDir -Force | Out-Null
+        $registryFile = Join-Path $trackingDir 'gate-events.jsonl'
+        Set-Content -Path $registryFile -Value '{"window_position":"pre-ask"}' -Encoding UTF8
+
+        $relPath = '.copilot-tracking\gate-events.jsonl'
+
+        $result = & $script:InvokeScript -WorkDir $workDir -GitConfig @{
+            'symbolic-ref-origin-HEAD'          = 'refs/remotes/origin/main'
+            'show-ref-refs/remotes/origin/main' = 0
+        } -ScriptParams @{
+            UntaggedTrackingFiles = [string[]]@($relPath)
+            SkipGitUpdate         = $true
+            SkipRemoteDelete      = $true
+        }
+
+        $result.ExitCode | Should -Be 0 -Because 'script must succeed even when only registry files are passed'
+        $result.Output   | Should -Match 'registry-protected' -Because 'a warning about the skipped registry file must appear'
+        # File must still exist (not moved to archive)
+        Test-Path $registryFile | Should -Be $true -Because 'persistent tracking file must not be archived'
+        # No archive directory must have been created for it
+        $archiveDir = Join-Path $workDir '.copilot-tracking-archive'
+        $archivedCopies = @(Get-ChildItem -Path $archiveDir -Recurse -Filter 'gate-events*' -ErrorAction SilentlyContinue)
+        $archivedCopies.Count | Should -Be 0 -Because 'gate-events.jsonl must not be archived'
+    }
+
+    It 'AC4-IssueNumberRoute: registry-protected file with issue_id frontmatter is skipped on -IssueNumber route' {
+        $workDir = Join-Path $TestDrive 'persistent-issueroute-skip'
+        New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+
+        $trackingDir = Join-Path $workDir '.copilot-tracking'
+        New-Item -ItemType Directory -Path $trackingDir -Force | Out-Null
+
+        # Registry-named file that also happens to carry issue_id frontmatter (hypothetical future scenario)
+        # The registry guard must fire BEFORE the issue_id filter
+        $registryFile = Join-Path $trackingDir 'gate-events.jsonl'
+        Set-Content -Path $registryFile -Value "issue_id: '999'`n{`"window_position`":`"pre-ask`"}" -Encoding UTF8
+
+        # Legitimate issue-scoped file that should still be archived normally
+        $issueFile = Join-Path $trackingDir 'issue-999-research.md'
+        Set-Content -Path $issueFile -Value "---`nissue_id: '999'`ntitle: test`n---`n# research" -Encoding UTF8
+
+        $result = & $script:InvokeScript -WorkDir $workDir -GitConfig @{
+            'symbolic-ref-origin-HEAD'          = 'refs/remotes/origin/main'
+            'show-ref-refs/remotes/origin/main' = 0
+        } -ScriptParams @{
+            IssueNumber      = 999
+            SkipGitUpdate    = $true
+            SkipRemoteDelete = $true
+            SkipLocalDelete  = $true
+        }
+
+        $result.ExitCode  | Should -Be 0 -Because 'script must succeed'
+        $result.Output    | Should -Match 'registry-protected' -Because 'skip warning must appear for gate-events.jsonl'
+        # Registry file must still exist at its original location
+        Test-Path $registryFile | Should -Be $true -Because 'gate-events.jsonl must not be archived even with matching issue_id'
+        # The legitimate issue file must have been archived
+        $archiveDir = Join-Path $workDir '.copilot-tracking-archive'
+        $archivedIssueFiles = @(Get-ChildItem -Path $archiveDir -Recurse -Filter 'issue-999-research*' -ErrorAction SilentlyContinue)
+        $archivedIssueFiles.Count | Should -BeGreaterThan 0 -Because 'the legitimate issue-scoped file must still be archived'
+    }
+
+    It 'AC6-Executor: undefined accessor causes executor to halt with exit 1 before any archival' {
+        $workDir = Join-Path $TestDrive 'persistent-executor-failsafe'
+        New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+
+        # Create a registry file that would be archived if the guard did not fire
+        $trackingDir = Join-Path $workDir '.copilot-tracking'
+        New-Item -ItemType Directory -Path $trackingDir -Force | Out-Null
+        $registryFile = Join-Path $trackingDir 'gate-events.jsonl'
+        Set-Content -Path $registryFile -Value '{"window_position":"pre-ask"}' -Encoding UTF8
+
+        # Strategy: produce a helpers stub that loads cleanly but does NOT define
+        # Get-SCDPersistentTrackingExclusions. The script's failsafe guard fires because
+        # the function is absent even though the dot-source itself succeeded.
+        $helpersStubPath = Join-Path $TestDrive 'helpers-stub-no-accessor.ps1'
+        Set-Content -Path $helpersStubPath -Value '# stub — accessor intentionally omitted to trigger failsafe' -Encoding UTF8
+
+        $scriptContent = Get-Content -Path $script:ScriptFile -Raw -ErrorAction Stop
+        $stubScriptPath = $helpersStubPath -replace '\\', '/'
+        $patchedScript = $scriptContent -replace [regex]::Escape('. "$PSScriptRoot/session-startup-git-helpers.ps1"'), ('. "' + $stubScriptPath + '"')
+        $patchedScriptPath = Join-Path $TestDrive 'patched-post-merge-cleanup.ps1'
+        Set-Content -Path $patchedScriptPath -Value $patchedScript -Encoding UTF8
+
+        $output = & pwsh -NoProfile -NonInteractive -File $patchedScriptPath `
+            -UntaggedTrackingFiles @('.copilot-tracking\gate-events.jsonl') `
+            -SkipGitUpdate `
+            -SkipRemoteDelete 2>&1
+        $exitCode = $LASTEXITCODE
+
+        $exitCode  | Should -Be 1 -Because 'undefined accessor must cause exit 1'
+        ($output -join "`n") | Should -Match 'HALT' -Because 'a loud HALT message must appear in stderr/output'
+        # File must NOT be archived — no archival must occur when the accessor fails to load
+        Test-Path $registryFile | Should -Be $true -Because 'no archival must occur when the accessor fails to load'
+    }
+}

--- a/.github/scripts/Tests/post-merge-cleanup.Tests.ps1
+++ b/.github/scripts/Tests/post-merge-cleanup.Tests.ps1
@@ -1359,8 +1359,21 @@ title: "Issue 42 back-compat test"
 
 Describe 'post-merge-cleanup.ps1 — persistent root-level file exclusion (#656)' {
 
-    # $script:InvokeScript and $script:ScriptFile are set in the outer BeforeAll
-    # (script-scoped) and available to this sibling Describe.
+    BeforeAll {
+        # Initialize the variables this Describe needs so it can run in isolation
+        # (e.g. if extracted to a separate file). In normal full-file runs these are
+        # also set by the first Describe's BeforeAll (Describe-scoped, not script-scoped).
+        # NOTE: $script:InvokeScript and its mock-factory dependencies ($script:NewMockGitDir,
+        # $script:AddMockGh, $script:SavedPath) are NOT reproduced here — the AC4 tests
+        # (AC4-UntaggedRoute, AC4-IssueNumberRoute) require the full mock infrastructure
+        # from the first Describe's BeforeAll to run. AC6-Executor is fully self-contained.
+        if (-not $script:RepoRoot) {
+            $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        }
+        if (-not $script:ScriptFile) {
+            $script:ScriptFile = Join-Path $script:RepoRoot 'skills/session-startup/scripts/post-merge-cleanup.ps1'
+        }
+    }
 
     It 'AC4-UntaggedRoute: registry-protected file in -UntaggedTrackingFiles is skipped, not archived' {
         $workDir = Join-Path $TestDrive 'persistent-untagged-skip'

--- a/.github/scripts/Tests/script-safety-contract.Tests.ps1
+++ b/.github/scripts/Tests/script-safety-contract.Tests.ps1
@@ -79,6 +79,7 @@ Describe 'script safety contract' {
                 'audit-hub-artifact-paths.Tests.ps1',      # CLI integration tests: exercises script argument-parsing entry point; dot-source pattern cannot cover CLI flag paths
                 'branch-authority-gate.Tests.ps1',
                 'hub-artifact-paths-coverage.Tests.ps1',   # CLI integration tests: exercises -Diff mode against live repo; requires sub-process invocation
+                'post-merge-cleanup.Tests.ps1',            # executor integration tests: post-merge-cleanup.ps1 is a top-level executable (no -core.ps1 library); the #656 AC6 failsafe test must spawn a subprocess to exercise the load-time exit 1, which dot-sourcing cannot test without terminating the Pester host
                 'script-safety-contract.Tests.ps1',        # self-excluded: this file contains the literal '& pwsh' in its own scan pattern, which would cause a false-positive match
                 'session-cleanup-detector.Tests.ps1'
             )

--- a/.github/scripts/Tests/session-cleanup-detector.Tests.ps1
+++ b/.github/scripts/Tests/session-cleanup-detector.Tests.ps1
@@ -1517,3 +1517,183 @@ Describe 'Get-OrphanBranchLines — per-line suffix and composite invocation' {
             -Because 'the composite invocation must include -OrphanBranches'
     }
 }
+
+Describe 'session-cleanup-detector.ps1 — persistent root-level tracking file exclusion (#656)' {
+
+    BeforeAll {
+        # Load the core library so Invoke-SessionCleanupDetector and
+        # Get-SCDPersistentTrackingExclusions are defined in this Describe scope.
+        # The $script: helpers (InvokeDetectorInWorkDir, WriteFixtureFile, etc.) were
+        # set during the calibration-exclusion Describe's BeforeAll and are reused here.
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        . (Join-Path $script:RepoRoot 'skills/session-startup/scripts/session-cleanup-detector-core.ps1')
+    }
+
+    It 'AC1: gate-events.jsonl at tracking root is excluded from cleanup detection' {
+        $workDir = Join-Path $TestDrive 'persistent-gate-events'
+        New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+        & $script:WriteFixtureFile -WorkDir $workDir -RelativePath '.copilot-tracking\gate-events.jsonl' -Content '{"window_position":"pre-ask"}' | Out-Null
+
+        $result = & $script:InvokeDetectorInWorkDir -WorkDir $workDir -GitConfig @{
+            'branch--show-current'     = 'main'
+            'symbolic-ref-origin-HEAD' = 'refs/remotes/origin/main'
+        }
+
+        $result.ExitCode | Should -Be 0
+        $result.Output   | Should -Match '^\{\s*\}$' -Because 'gate-events.jsonl is a live persistent file and must not trigger cleanup'
+    }
+
+    It 'AC1: references-state.yml at tracking root is excluded from cleanup detection' {
+        $workDir = Join-Path $TestDrive 'persistent-references-state'
+        New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+        & $script:WriteFixtureFile -WorkDir $workDir -RelativePath '.copilot-tracking\references-state.yml' -Content 'version: 1' | Out-Null
+
+        $result = & $script:InvokeDetectorInWorkDir -WorkDir $workDir -GitConfig @{
+            'branch--show-current'     = 'main'
+            'symbolic-ref-origin-HEAD' = 'refs/remotes/origin/main'
+        }
+
+        $result.ExitCode | Should -Be 0
+        $result.Output   | Should -Match '^\{\s*\}$' -Because 'references-state.yml is a live persistent file and must not trigger cleanup'
+    }
+
+    It 'AC1: references-init.manifest at tracking root is excluded from cleanup detection' {
+        $workDir = Join-Path $TestDrive 'persistent-references-init-manifest'
+        New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+        & $script:WriteFixtureFile -WorkDir $workDir -RelativePath '.copilot-tracking\references-init.manifest' -Content '{}' | Out-Null
+
+        $result = & $script:InvokeDetectorInWorkDir -WorkDir $workDir -GitConfig @{
+            'branch--show-current'     = 'main'
+            'symbolic-ref-origin-HEAD' = 'refs/remotes/origin/main'
+        }
+
+        $result.ExitCode | Should -Be 0
+        $result.Output   | Should -Match '^\{\s*\}$' -Because 'references-init.manifest is a live persistent file and must not trigger cleanup'
+    }
+
+    It 'AC3: non-registry untagged root file is still flagged (positive companion)' {
+        $workDir = Join-Path $TestDrive 'persistent-positive-companion'
+        New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+        & $script:WriteFixtureFile -WorkDir $workDir -RelativePath '.copilot-tracking\stale-notes.md' -Content '# no issue_id here' | Out-Null
+
+        $result = & $script:InvokeDetectorInWorkDir -WorkDir $workDir -GitConfig @{
+            'branch--show-current'     = 'main'
+            'symbolic-ref-origin-HEAD' = 'refs/remotes/origin/main'
+        }
+        $context = & $script:GetAdditionalContext -Output $result.Output
+        $insideFence = (& $script:GetFencedPowerShellBlocks -Context $context) -join "`n"
+
+        $result.ExitCode | Should -Be 0
+        $insideFence     | Should -Match 'stale-notes' -Because 'untagged non-registry root file must still appear in cleanup recommendations'
+    }
+
+    It 'AC5: registry-named file at depth >= 1 is NOT excluded (over-exclusion guard)' {
+        $workDir = Join-Path $TestDrive 'persistent-depth-check'
+        New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+        & $script:WriteFixtureFile -WorkDir $workDir -RelativePath '.copilot-tracking\sub\gate-events.jsonl' -Content '{}' | Out-Null
+
+        $result = & $script:InvokeDetectorInWorkDir -WorkDir $workDir -GitConfig @{
+            'branch--show-current'     = 'main'
+            'symbolic-ref-origin-HEAD' = 'refs/remotes/origin/main'
+        }
+        $context = & $script:GetAdditionalContext -Output $result.Output
+        $insideFence = (& $script:GetFencedPowerShellBlocks -Context $context) -join "`n"
+
+        $result.ExitCode | Should -Be 0
+        $insideFence     | Should -Match 'gate-events' -Because 'a registry-named file in a subdirectory must NOT be excluded'
+    }
+
+    It 'AC6: undefined accessor causes detector to halt loudly instead of silently proceeding' {
+        # Strategy: run the detector wrapper script in a fresh subprocess where the helpers file
+        # has been temporarily replaced with an empty stub so Get-SCDPersistentTrackingExclusions
+        # is never defined. Using a subprocess avoids mutating the in-process function provider.
+        $workDir = Join-Path $TestDrive 'persistent-accessor-missing'
+        New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+
+        # Write an empty helpers stub so the dot-source succeeds but the accessor is absent
+        $helpersStubPath = Join-Path $TestDrive 'session-startup-git-helpers-stub.ps1'
+        Set-Content -Path $helpersStubPath -Value '# stub — accessor intentionally omitted' -Encoding UTF8
+
+        # Build a patched copy of the detector core that loads the stub instead of the real helpers
+        $coreContent = Get-Content -Path (Join-Path $script:RepoRoot 'skills/session-startup/scripts/session-cleanup-detector-core.ps1') -Raw
+        $patchedCore = $coreContent -replace [regex]::Escape('. "$PSScriptRoot/session-startup-git-helpers.ps1"'), ('. "' + ($helpersStubPath -replace '\\', '/') + '"')
+        $patchedCorePath = Join-Path $TestDrive 'patched-detector-core.ps1'
+        Set-Content -Path $patchedCorePath -Value $patchedCore -Encoding UTF8
+
+        # Run a subprocess that dot-sources the patched core and calls Invoke-SessionCleanupDetector
+        $escapedWorkDir = $workDir -replace "'", "''"
+        $escapedCorePath = $patchedCorePath -replace "'", "''"
+        $output = pwsh -NoProfile -NonInteractive -Command @"
+. '$escapedCorePath'
+`$r = Invoke-SessionCleanupDetector -RepoRoot '$escapedWorkDir'
+Write-Output "EXIT:`$(`$r.ExitCode)"
+Write-Output "OUT:`$(`$r.Output)"
+"@ 2>&1
+        $outputStr = ($output -join "`n")
+        $exitCodeLine = $output | Where-Object { $_ -match '^EXIT:' } | Select-Object -First 1
+        $detectorExitCode = if ($exitCodeLine -match '^EXIT:(\d+)') { [int]$Matches[1] } else { -1 }
+
+        $detectorExitCode | Should -Be 1 -Because 'undefined accessor must cause a hard halt'
+        $outputStr        | Should -Match 'HALT' -Because 'a loud HALT message must be emitted'
+    }
+
+    It 'AC7: writer-oracle — registry contains all known root-level persistent tracking writers' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+
+        # Get the registered filenames from the accessor
+        $exclusions = Get-SCDPersistentTrackingExclusions
+        $registeredFilenames = @($exclusions.Filenames | ForEach-Object { $_.ToLowerInvariant() })
+
+        # Writer oracle: scan all .ps1 files for patterns that write root-level files under .copilot-tracking/
+        $psFiles = Get-ChildItem -Path $repoRoot -Filter '*.ps1' -Recurse |
+            Where-Object {
+                $_.FullName -notmatch '\.Tests\.' -and
+                $_.Name -ne 'session-cleanup-detector-core.ps1' -and
+                $_.Name -ne 'post-merge-cleanup.ps1' -and
+                $_.Name -ne 'session-cleanup-detector.ps1' -and
+                $_.Name -notmatch 'gate-reconciliation' -and
+                $_.Name -notmatch 'Resolve-PersistDecision'
+            }
+
+        $writtenBasenames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+        foreach ($file in $psFiles) {
+            $content = Get-Content -Path $file.FullName -Raw -ErrorAction SilentlyContinue
+            if (-not $content) { continue }
+
+            # Pattern 1: Join-Path $trackingDir 'filename.ext' (depth-0 file only — no slash in filename)
+            $matches1 = [regex]::Matches($content, "Join-Path\s+\`$\w*[Tt]racking\w*\s+['\`"]([^/\\'\`"]+\.[a-zA-Z0-9]+)['\`"]")
+            foreach ($m in $matches1) { $null = $writtenBasenames.Add($m.Groups[1].Value) }
+
+            # Pattern 2: Join-Path ... '.copilot-tracking' 'filename.ext'
+            $matches2 = [regex]::Matches($content, "Join-Path\s+\S+\s+'?\.copilot-tracking'?\s+['\`"]([^/\\'\`"]+\.[a-zA-Z0-9]+)['\`"]")
+            foreach ($m in $matches2) { $null = $writtenBasenames.Add($m.Groups[2].Value) }
+        }
+
+        # Every oracle-found basename must be in the registry
+        $unregistered = @($writtenBasenames | Where-Object { $registeredFilenames -notcontains $_.ToLowerInvariant() })
+        $unregistered | Should -BeNullOrEmpty `
+            -Because "oracle-found root-level tracking writers must all be enrolled in Get-SCDPersistentTrackingExclusions: missing: $($unregistered -join ', ')"
+    }
+
+    It 'AC7: no persistent-filename literal exists outside Get-SCDPersistentTrackingExclusions' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+
+        $exclusions = Get-SCDPersistentTrackingExclusions
+
+        foreach ($fname in $exclusions.Filenames) {
+            $matches = @(
+                Get-ChildItem -Path (Join-Path $repoRoot 'skills/session-startup/scripts') -Filter '*.ps1' |
+                Where-Object { $_.Name -ne 'session-startup-git-helpers.ps1' } |
+                ForEach-Object {
+                    $content = Get-Content $_.FullName -Raw -ErrorAction SilentlyContinue
+                    if ($content -match [regex]::Escape($fname)) {
+                        $_.Name
+                    }
+                }
+            )
+            $matches | Should -BeNullOrEmpty `
+                -Because "'$fname' must only appear in the accessor, not as a literal in other session-startup scripts"
+        }
+    }
+}

--- a/.github/scripts/Tests/session-cleanup-detector.Tests.ps1
+++ b/.github/scripts/Tests/session-cleanup-detector.Tests.ps1
@@ -1667,11 +1667,11 @@ Write-Output "OUT:`$(`$r.Output)"
 
             # Pattern 2: Join-Path ... '.copilot-tracking' 'filename.ext'
             $matches2 = [regex]::Matches($content, "Join-Path\s+\S+\s+'?\.copilot-tracking'?\s+['\`"]([^/\\'\`"]+\.[a-zA-Z0-9]+)['\`"]")
-            foreach ($m in $matches2) { $null = $writtenBasenames.Add($m.Groups[2].Value) }
+            foreach ($m in $matches2) { $null = $writtenBasenames.Add($m.Groups[1].Value) }
         }
 
-        # Every oracle-found basename must be in the registry
-        $unregistered = @($writtenBasenames | Where-Object { $registeredFilenames -notcontains $_.ToLowerInvariant() })
+        # Every oracle-found basename must be in the registry (filter empties to prevent silent BeNullOrEmpty pass)
+        $unregistered = @($writtenBasenames | Where-Object { $_ } | Where-Object { $registeredFilenames -notcontains $_.ToLowerInvariant() })
         $unregistered | Should -BeNullOrEmpty `
             -Because "oracle-found root-level tracking writers must all be enrolled in Get-SCDPersistentTrackingExclusions: missing: $($unregistered -join ', ')"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to agent-orchestra will be documented in this file.
 
+## [2.33.1] — 2026-06-23
+
+### Fixed
+
+- **Session-cleanup false-positive on live persistent tracking files** (`skills/session-startup/scripts/session-startup-git-helpers.ps1`, `skills/session-startup/scripts/session-cleanup-detector-core.ps1`, `skills/session-startup/scripts/post-merge-cleanup.ps1`): root-level `.copilot-tracking/` artifacts with no `issue_id` frontmatter — `gate-events.jsonl`, `references-state.yml`, `references-init.manifest` — were flagged as stale untagged tracking files and archived by the cleanup executor. A new dual-axis exclusion registry (`Get-SCDPersistentTrackingExclusions` returning `Subtrees` + `Filenames`) is the single source of truth consumed by both detector and executor. The detector excludes registered filenames matched root-anchored at depth 0 (a registry-named file at depth ≥ 1 is still flagged); both executor archival routes skip registered files with a warning. Both consumers fail loudly (HALT + exit 1) before any `Move-Item` when the accessor is undefined or returns `$null`/missing `Filenames` — never fail-open toward deletion (#656).
+
+### Tests
+
+- 11 new Pester `It` blocks across two harnesses covering AC1–AC7: per-seed-file exclusion, positive companion (non-registry untagged file still flagged), over-exclusion depth guard, undefined-accessor hard-halt for both detector and executor, writer-oracle parity, and both executor-route skips (#656).
+
 ## [2.33.0] — 2026-06-22
 
 ### Added

--- a/Documents/Design/session-cleanup-persistent-exclusion-registry.md
+++ b/Documents/Design/session-cleanup-persistent-exclusion-registry.md
@@ -1,0 +1,49 @@
+# Session-Cleanup Persistent-File Exclusion Registry
+
+> Issue: [#656](https://github.com/Grimblaz/agent-orchestra/issues/656)
+
+## Problem
+
+The session-cleanup detector and executor treated `.copilot-tracking/` root-level files with no `issue_id` frontmatter as stale untagged artifacts eligible for archival. Three files are permanently live at root depth and must never be archived:
+
+| File | Writer |
+|---|---|
+| `gate-events.jsonl` | `skills/solution-authoring/scripts/gate-event-logger-hook.ps1:63` |
+| `references-state.yml` | `skills/project-references/scripts/init-references.ps1:12` |
+| `references-init.manifest` | `skills/project-references/scripts/init-references.ps1:11` |
+
+## Design: Dual-Axis Exclusion Registry
+
+A single accessor `Get-SCDPersistentTrackingExclusions` in `session-startup-git-helpers.ps1` returns two exclusion axes:
+
+```powershell
+@{
+    Subtrees  = @('calibration')   # directory prefixes — entire subtree protected
+    Filenames = @('gate-events.jsonl', 'references-state.yml', 'references-init.manifest')
+}
+```
+
+Both the detector (`session-cleanup-detector-core.ps1`) and executor (`post-merge-cleanup.ps1`) dot-source the helpers file and consume the registry from this single function — no literals scattered across files.
+
+### Axis semantics
+
+- **Subtrees**: any file whose path relative to `.copilot-tracking/` starts with a subtree prefix is excluded. Used for the `calibration/` directory, which was protected before this issue.
+- **Filenames**: a file at **root depth only** (no `/` in its relative path) that matches a registered basename is excluded. Registry-named files in subdirectories are NOT excluded (AC5).
+
+### Fail-safe contracts
+
+Both consumers must fail loudly toward preservation, never silently toward deletion:
+
+1. **Accessor undefined**: if `Get-SCDPersistentTrackingExclusions` is not defined after the helpers file loads, abort immediately with a HALT diagnostic before any `Move-Item`. Exit code 1.
+2. **Accessor returns null/missing key**: if the accessor is defined but returns `$null` or a hashtable without a `Filenames` key, also abort with a HALT diagnostic. Exit code 1.
+3. **Executor scope**: the executor consumes only the `Filenames` axis (root-level files). The `Subtrees` axis is honored only by the detector, which excludes subtree-protected files before writing its `-UntaggedTrackingFiles` output.
+
+### Writer-oracle parity (AC7)
+
+A Pester test in `session-cleanup-detector.Tests.ps1` scans all non-test, non-cleanup `.ps1` files for `Join-Path` patterns that write to `.copilot-tracking/` root and asserts every discovered writer is enrolled in the registry. This catches new persistent writers at CI time.
+
+## Extension guide
+
+To protect a new root-level persistent file, add its basename to the `Filenames` array in `Get-SCDPersistentTrackingExclusions`. The writer-oracle AC7 test will fail CI until the entry is added, prompting the change.
+
+To protect a new persistent subtree, add the directory name to the `Subtrees` array. Note: the executor does not currently enforce subtree protection (by design, because the detector already excludes subtree files before emitting untagged-file lists). If subtree protection at the executor level is ever needed, add a Subtrees guard to the two registry-guard blocks in `post-merge-cleanup.ps1` (search for `mf6-executor-failsafe`).

--- a/skills/session-startup/scripts/post-merge-cleanup.ps1
+++ b/skills/session-startup/scripts/post-merge-cleanup.ps1
@@ -428,6 +428,12 @@ if ($UntaggedTrackingFiles.Count -gt 0) {
             continue
         }
         $fileInfo = Get-Item $absPath
+        # CR-5 defensive guard: skip directories (caller should only pass files via -File,
+        # but guard against API misuse that could move an entire tracking subtree)
+        if ($fileInfo.PSIsContainer) {
+            Write-Warning "Untagged tracking path is not a file: '$relPath' — skipping"
+            continue
+        }
         $ext = $fileInfo.Extension
         $nameNoExt = $fileInfo.BaseName
         $mtime = $fileInfo.LastWriteTime.ToString('yyyyMMddHHmmss')
@@ -459,11 +465,13 @@ if ($null -ne $IssueNumber) {
     New-Item -ItemType Directory -Path $archivePath -Force | Out-Null
 
     $trackingRoot = '.copilot-tracking'
+    # S-C1: hoist loop-invariant path resolution out of the per-file Where-Object and foreach
+    $trackingRootResolved = (Resolve-Path $trackingRoot).Path
     $allTrackingFiles = Get-ChildItem -Path $trackingRoot -Recurse -File -ErrorAction SilentlyContinue
     # Exclude .gitkeep placeholder files, then filter to only files belonging to this issue
     $trackingFiles = @($allTrackingFiles | Where-Object { $_.Name -ne '.gitkeep' } | Where-Object {
             # Registry guard: skip persistent root-level files (AC4)
-            $relFromRoot = $_.FullName.Substring((Resolve-Path $trackingRoot).Path.Length).TrimStart('\', '/')
+            $relFromRoot = $_.FullName.Substring($trackingRootResolved.Length).TrimStart('\', '/')
             if ($script:PersistentTrackingFilenames.Count -gt 0 -and
                 -not $relFromRoot.Contains('\') -and
                 -not $relFromRoot.Contains('/') -and
@@ -483,7 +491,7 @@ if ($null -ne $IssueNumber) {
 
     $archivedCount = 0
     foreach ($file in $trackingFiles) {
-        $relativePath = $file.FullName.Substring((Resolve-Path $trackingRoot).Path.Length).TrimStart('\', '/')
+        $relativePath = $file.FullName.Substring($trackingRootResolved.Length).TrimStart('\', '/')
         $destDir = Join-Path $archivePath (Split-Path $relativePath -Parent)
         New-Item -Force -ItemType Directory -Path $destDir | Out-Null
         Move-Item -LiteralPath $file.FullName -Destination (Join-Path $destDir $file.Name)

--- a/skills/session-startup/scripts/post-merge-cleanup.ps1
+++ b/skills/session-startup/scripts/post-merge-cleanup.ps1
@@ -62,7 +62,11 @@ if (-not (Get-Command Get-SCDPersistentTrackingExclusions -ErrorAction SilentlyC
     exit 1
 }
 $persistentExclusions = Get-SCDPersistentTrackingExclusions
-$script:PersistentTrackingFilenames = if ($null -ne $persistentExclusions.Filenames) { [string[]]$persistentExclusions.Filenames } else { [string[]]@() }
+if ($null -eq $persistentExclusions -or $null -eq $persistentExclusions.Filenames) {
+    Write-Error "HALT: Get-SCDPersistentTrackingExclusions returned null or missing Filenames — registry integrity failure. Aborting executor to prevent destruction of persistent tracking files. (mf6-executor-failsafe)"
+    exit 1
+}
+$script:PersistentTrackingFilenames = [string[]]$persistentExclusions.Filenames
 
 # Guard: require IssueNumber, FeatureBranch, OR at least one of the new category parameters
 # (C6/C1: -FeatureBranch alone is sufficient — used by detector for no-issue-id stale branches

--- a/skills/session-startup/scripts/post-merge-cleanup.ps1
+++ b/skills/session-startup/scripts/post-merge-cleanup.ps1
@@ -57,6 +57,12 @@ param(
 $ErrorActionPreference = 'Stop'
 
 . "$PSScriptRoot/session-startup-git-helpers.ps1"
+if (-not (Get-Command Get-SCDPersistentTrackingExclusions -ErrorAction SilentlyContinue)) {
+    Write-Error "HALT: Get-SCDPersistentTrackingExclusions is not defined after loading session-startup-git-helpers.ps1. Aborting executor to prevent destruction of persistent tracking files. (mf6-executor-failsafe)"
+    exit 1
+}
+$persistentExclusions = Get-SCDPersistentTrackingExclusions
+$script:PersistentTrackingFilenames = if ($null -ne $persistentExclusions.Filenames) { [string[]]$persistentExclusions.Filenames } else { [string[]]@() }
 
 # Guard: require IssueNumber, FeatureBranch, OR at least one of the new category parameters
 # (C6/C1: -FeatureBranch alone is sufficient — used by detector for no-issue-id stale branches
@@ -408,6 +414,15 @@ if ($UntaggedTrackingFiles.Count -gt 0) {
             Write-Warning "Path traversal blocked: '$relPath' resolves outside .copilot-tracking/ — skipping"
             continue
         }
+        # Registry guard: skip persistent root-level files (mf6-executor-failsafe, AC4)
+        $relFromTrackingRoot = $resolvedAbs.Substring($trackingRootCanonical.Length).TrimStart([System.IO.Path]::DirectorySeparatorChar, '/')
+        if ($script:PersistentTrackingFilenames.Count -gt 0 -and
+            -not $relFromTrackingRoot.Contains([System.IO.Path]::DirectorySeparatorChar) -and
+            -not $relFromTrackingRoot.Contains('/') -and
+            $script:PersistentTrackingFilenames -icontains $relFromTrackingRoot) {
+            Write-Warning "Persistent tracking file skipped — registry-protected, will not be archived: '$relPath'"
+            continue
+        }
         $fileInfo = Get-Item $absPath
         $ext = $fileInfo.Extension
         $nameNoExt = $fileInfo.BaseName
@@ -443,6 +458,15 @@ if ($null -ne $IssueNumber) {
     $allTrackingFiles = Get-ChildItem -Path $trackingRoot -Recurse -File -ErrorAction SilentlyContinue
     # Exclude .gitkeep placeholder files, then filter to only files belonging to this issue
     $trackingFiles = @($allTrackingFiles | Where-Object { $_.Name -ne '.gitkeep' } | Where-Object {
+            # Registry guard: skip persistent root-level files (AC4)
+            $relFromRoot = $_.FullName.Substring((Resolve-Path $trackingRoot).Path.Length).TrimStart('\', '/')
+            if ($script:PersistentTrackingFilenames.Count -gt 0 -and
+                -not $relFromRoot.Contains('\') -and
+                -not $relFromRoot.Contains('/') -and
+                $script:PersistentTrackingFilenames -icontains $relFromRoot) {
+                Write-Warning "Persistent tracking file skipped — registry-protected, will not be archived: '$($_.Name)'"
+                return $false
+            }
             $content = Get-Content -Path $_.FullName -Raw -ErrorAction SilentlyContinue
             if ($content -match '(?m)^issue_id:\s*["\x27]?(\d+)["\x27]?') {
                 [int]$Matches[1] -eq $IssueNumber

--- a/skills/session-startup/scripts/session-cleanup-detector-core.ps1
+++ b/skills/session-startup/scripts/session-cleanup-detector-core.ps1
@@ -25,11 +25,22 @@ function Test-SCDPersistentTrackingFile {
         [System.IO.FileInfo]$File,
 
         [Parameter(Mandatory)]
-        [string[]]$PersistentSubtrees
+        [string[]]$PersistentSubtrees,
+
+        [string[]]$PersistentFilenames = @()
     )
 
     $filePath = [System.IO.Path]::GetFullPath($File.FullName)
     $relativePath = [System.IO.Path]::GetRelativePath($TrackingRootPath, $filePath).Replace('\', '/')
+
+    # Root-anchored filename check: file must be at tracking root depth 0 (no path separator)
+    if ($PersistentFilenames.Count -gt 0 -and -not $relativePath.Contains('/')) {
+        foreach ($fname in $PersistentFilenames) {
+            if ($relativePath.Equals($fname, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return $true
+            }
+        }
+    }
 
     foreach ($subtree in $PersistentSubtrees) {
         $normalizedSubtree = $subtree.Trim('/').Replace('\', '/')
@@ -803,9 +814,18 @@ function Invoke-SessionCleanupDetector {
         return @{ ExitCode = 1; Output = $output; Error = '' }
     }
 
-    $persistentTrackingSubtrees = @(
-        'calibration'
-    )
+    if (-not (Get-Command Get-SCDPersistentTrackingExclusions -ErrorAction SilentlyContinue)) {
+        $errorJson = [pscustomobject]@{
+            hookSpecificOutput = [pscustomobject]@{
+                hookEventName     = 'SessionStart'
+                additionalContext = 'HALT: Get-SCDPersistentTrackingExclusions is not defined — session-startup-git-helpers.ps1 failed to load. Aborting detector to prevent false-positive cleanup recommendations.'
+            }
+        } | ConvertTo-Json -Depth 3 -Compress
+        return @{ ExitCode = 1; Output = $errorJson; Error = 'Accessor undefined: Get-SCDPersistentTrackingExclusions' }
+    }
+    $exclusions = Get-SCDPersistentTrackingExclusions
+    $persistentTrackingSubtrees = if ($null -ne $exclusions.Subtrees) { [string[]]$exclusions.Subtrees } else { [string[]]@() }
+    $persistentTrackingFilenames = if ($null -ne $exclusions.Filenames) { [string[]]$exclusions.Filenames } else { [string[]]@() }
     $noUpstreamBranchPrefixes = @('claude/')
     $upstreamDeletedBranchPrefixes = @('feature/issue-')
     $fetchLookup = New-SCDStringLookup
@@ -894,7 +914,7 @@ function Invoke-SessionCleanupDetector {
             $issueIds = @()
             $unknownFiles = @()
             foreach ($file in $trackingFiles) {
-                if (Test-SCDPersistentTrackingFile -TrackingRootPath $trackingRootPath -File $file -PersistentSubtrees $persistentTrackingSubtrees) {
+                if (Test-SCDPersistentTrackingFile -TrackingRootPath $trackingRootPath -File $file -PersistentSubtrees $persistentTrackingSubtrees -PersistentFilenames $persistentTrackingFilenames) {
                     continue
                 }
 

--- a/skills/session-startup/scripts/session-cleanup-detector-core.ps1
+++ b/skills/session-startup/scripts/session-cleanup-detector-core.ps1
@@ -25,9 +25,12 @@ function Test-SCDPersistentTrackingFile {
         [System.IO.FileInfo]$File,
 
         [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
         [string[]]$PersistentSubtrees,
 
-        [string[]]$PersistentFilenames = @()
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [string[]]$PersistentFilenames
     )
 
     $filePath = [System.IO.Path]::GetFullPath($File.FullName)
@@ -824,8 +827,17 @@ function Invoke-SessionCleanupDetector {
         return @{ ExitCode = 1; Output = $errorJson; Error = 'Accessor undefined: Get-SCDPersistentTrackingExclusions' }
     }
     $exclusions = Get-SCDPersistentTrackingExclusions
+    if ($null -eq $exclusions -or $null -eq $exclusions.Filenames) {
+        $haltJson = [pscustomobject]@{
+            hookSpecificOutput = [pscustomobject]@{
+                hookEventName     = 'SessionStart'
+                additionalContext = 'HALT: Get-SCDPersistentTrackingExclusions returned $null or missing Filenames — registry integrity failure. Aborting detector to prevent false-positive cleanup recommendations.'
+            }
+        } | ConvertTo-Json -Depth 3 -Compress
+        return @{ ExitCode = 1; Output = $haltJson; Error = 'Accessor returned null or missing Filenames' }
+    }
     $persistentTrackingSubtrees = if ($null -ne $exclusions.Subtrees) { [string[]]$exclusions.Subtrees } else { [string[]]@() }
-    $persistentTrackingFilenames = if ($null -ne $exclusions.Filenames) { [string[]]$exclusions.Filenames } else { [string[]]@() }
+    $persistentTrackingFilenames = [string[]]$exclusions.Filenames
     $noUpstreamBranchPrefixes = @('claude/')
     $upstreamDeletedBranchPrefixes = @('feature/issue-')
     $fetchLookup = New-SCDStringLookup

--- a/skills/session-startup/scripts/session-startup-git-helpers.ps1
+++ b/skills/session-startup/scripts/session-startup-git-helpers.ps1
@@ -8,9 +8,28 @@
     used by session-cleanup-detector-core.ps1. Cleanup-only decision helpers
     feed deletion authorization in post-merge-cleanup.ps1; keep those
     conservative and fail-open when their evidence is unavailable.
+    Fail-safe static-persistence-registry: Get-SCDPersistentTrackingExclusions
+    returns the set of .copilot-tracking/ artifacts that must never be deleted.
+    Registry unavailability must halt loudly before any deletion; it must NOT
+    fail-open toward deletion.
 #>
 
 $script:OrphanIssueRegex = '^feature/issue-(\d+)-'
+
+function Get-SCDPersistentTrackingExclusions {
+    <#
+    .SYNOPSIS
+        Returns the dual-axis persistent-exclusion registry for .copilot-tracking/ artifacts.
+        Subtrees: directory prefixes whose entire subtree is persistent (e.g. 'calibration').
+        Filenames: root-level basenames that must never be deleted/archived.
+        Callers: session-cleanup-detector-core.ps1, post-merge-cleanup.ps1.
+        Registry unavailability must halt loudly before any Move-Item — do NOT fail-open.
+    #>
+    return @{
+        Subtrees  = @('calibration')
+        Filenames = @('gate-events.jsonl', 'references-state.yml', 'references-init.manifest')
+    }
+}
 
 function Invoke-SCDNativeCommand {
     [CmdletBinding()]


### PR DESCRIPTION
## Summary

- Adds `Get-SCDPersistentTrackingExclusions` to `session-startup-git-helpers.ps1` as the single dual-axis registry (Subtrees + Filenames) for `.copilot-tracking/` artifacts that must never be deleted
- Extends `Test-SCDPersistentTrackingFile` with root-anchored depth-0 filename matching so `gate-events.jsonl`, `references-state.yml`, and `references-init.manifest` are excluded from cleanup detection
- Guards both executor archival routes (`-UntaggedTrackingFiles` and `-IssueNumber`) with registry skip + warn
- Fail-safes: undefined accessor → loud HALT + exit 1 before any `Move-Item`; null/missing-Filenames return → same HALT (accessor return-value validation, post-review fix)

## CE Gate evidence

S1, S2, S3 all pass — see [CE Gate comment](https://github.com/Grimblaz/agent-orchestra/issues/656#issuecomment-4775496858) on issue #656.

## Test plan

- [x] 49/49 detector tests pass (`session-cleanup-detector.Tests.ps1`)
- [x] 33/33 executor tests pass (`post-merge-cleanup.Tests.ps1`)
- [x] 11 new `It` blocks: AC1×3 (each seed file excluded), AC3 (positive companion), AC5 (depth≥1 not excluded), AC6×2 (undefined accessor → halt, for both detector and executor), AC7×2 (writer-oracle parity + literal guard), AC4×2 (both executor routes skip registry files)
- [x] AC7 writer-oracle now correctly reads `Groups[1]` (was `Groups[2]` — post-review fix MRG-01)
- [x] Fail-safe validates accessor return value, not just existence (post-review fix MRG-04)
- [x] Design doc added: `Documents/Design/session-cleanup-persistent-exclusion-registry.md`

## Pipeline metrics

```yaml
<!-- pipeline-metrics
issue: 656
scope_tier: full
phases_completed:
  - experience-owner
  - solution-designer
  - issue-planner
  - implementation
  - adversarial-review
  - ce-gate
implementation_slices:
  - id: s1
    description: "Get-SCDPersistentTrackingExclusions accessor in git-helpers"
    executor: senior-engineer
  - id: s2
    description: "detector extension (Test-SCDPersistentTrackingFile + Invoke-SessionCleanupDetector)"
    executor: senior-engineer
  - id: s3
    description: "executor both-routes guard + fail-safe"
    executor: senior-engineer
  - id: s4
    description: "AC1-AC7 Pester test suite (11 new tests, 2 harnesses)"
    executor: test-writer
  - id: s5
    description: "standard adversarial review — 5-pass prosecution, defense, judge; 2 blocking fixes applied"
    adapter: standard
  - id: s6
    description: "CE Gate — S1/S2/S3 all pass"
    executor: experience-owner
credits:
  - port: implementation
    adapter: senior-engineer
  - port: test
    adapter: test-writer
  - port: review
    adapter: standard
  - port: ce-gate
    adapter: experience-owner
-->
```

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a central persistent tracking exclusion registry and wire detector and executor to honor it while failing safely if unavailable.

New Features:
- Add Get-SCDPersistentTrackingExclusions accessor as the single registry for persistent .copilot-tracking subtrees and root-level filenames that must never be deleted.

Bug Fixes:
- Ensure gate-events.jsonl, references-state.yml, and references-init.manifest at the .copilot-tracking root are excluded from session cleanup detection and archival.
- Prevent cleanup from proceeding when the persistent exclusion registry is undefined or returns invalid data, halting loudly instead of failing open toward deletion.

Enhancements:
- Extend the session cleanup detector to support root-level persistent filename exclusions in addition to subtree exclusions.
- Guard both post-merge cleanup execution routes so registry-protected files are skipped with warnings rather than archived.
- Enforce writer-oracle parity and literal centralization via new tests that ensure all root-level tracking writers are enrolled in the registry and filenames are not duplicated across scripts.

Documentation:
- Add a design document describing the persistent-file exclusion registry, its axes, fail-safe behavior, and extension guidelines.

Tests:
- Add Pester tests for root-level persistent file exclusion behavior in the detector and executor, including positive/negative cases, fail-safe behavior when the registry is unavailable, and writer-oracle/literal-guard invariants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation for persistent tracking file protection registry.

* **Tests**
  * Added comprehensive test coverage for persistent tracking file exclusion during cleanup operations.
  * Added regression tests to ensure all protected files are registered.

* **Chores**
  * Implemented persistent file exclusion registry to protect critical tracking files from deletion during cleanup.
  * Added safety checks to prevent accidental removal of important session files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->