### PR TITLE
docs(#425): reconcile enforce-activation runbook — required-mode descoped

### DIFF
--- a/Documents/Design/frame-architecture.md
+++ b/Documents/Design/frame-architecture.md
@@ -557,13 +557,15 @@ Operators should never see a generic "frame check failed" — always actionable.
 
 ## Activation runbook
 
-The `frame-enforce.yml` GitHub Actions workflow ships as **advisory** — it runs on every PR but is not yet a required branch-protection check. The following gate must be met before an administrator marks the workflow as required.
+> **Status (2026-06-23): activation descoped — frame stays advisory.** Required-check activation is not being pursued. Its precondition, credit provenance (#724), was closed **won't-do** after a value-vs-cost review (a solo + own-agents repo gains little from an un-bypassable merge gate against real build + maintenance + false-block cost), and the frame-enforcement umbrella (#425) closed **completed-advisory**. The runbook below is retained for reference; re-scoping activation requires re-opening #724 first.
+
+The `frame-enforce.yml` GitHub Actions workflow ships as **advisory** — it runs on every PR but is not a required branch-protection check. The gate below would need to be met before an administrator marked the workflow as required.
 
 ### Pre-Activation Gate
 
 All four conditions must hold before flipping to required:
 
-1. **Credit provenance resolved** — issue #724 (corroborate `credits[]` against a non-PR-mutable source) is closed. This ensures the enforcement signal cannot be trivially spoofed.
+1. **Credit provenance resolved** — issue #724 (corroborate `credits[]` against a non-PR-mutable source). **Closed won't-do (2026-06-23)** — this gate item is not satisfiable without re-opening #724, which is why activation is descoped.
 2. **Audit completeness** — ≥ 95% credit coverage over the most recent 30-PR retrospective audit (run `/audit-docs` to generate the report).
 3. **Operator notice** — ≥ 1-week advance notice posted to the relevant channel or issue before enforcement becomes mandatory.
 4. **Kill switch tested** — set `FRAME_ENFORCE=0` on a test PR run and confirm the workflow exits 0 before activating enforcement.
@@ -789,9 +791,11 @@ Reserved. Same policy as D14.
 
 Reserved. Same policy as D14.
 
-### D17 — Activation precondition (updated by #439)
+### D17 — Activation precondition (updated by #439; descoped 2026-06-23)
 
-Advisory enforce mode (`frame-enforce.yml` running on every PR with a non-zero exit code for missing/failed/inconclusive ports) shipped in #439. Making the workflow a **required** branch-protection check is the remaining activation step. Required-check activation requires all four Pre-Activation Gate conditions to hold (see [Activation runbook](#activation-runbook)): credit provenance resolved (issue #724 closed), ≥95% credit coverage over the most recent 30-PR retrospective audit (all post-spine), ≥1-week operator notice, and kill switch tested. The first PR with spine semantics merging restarts the 30-PR audit counter. This decision prevents premature enforcement before the credit-rate baseline is established and before the spoofing surface is closed.
+Advisory enforce mode (`frame-enforce.yml` running on every PR with a non-zero exit code for missing/failed/inconclusive ports) shipped in #439. Making the workflow a **required** branch-protection check would have required all four Pre-Activation Gate conditions to hold (see [Activation runbook](#activation-runbook)): credit provenance resolved (issue #724 closed), ≥95% credit coverage over the most recent 30-PR retrospective audit (all post-spine), ≥1-week operator notice, and kill switch tested. The first PR with spine semantics merging restarts the 30-PR audit counter. This decision prevented premature enforcement before the credit-rate baseline was established and before the spoofing surface was closed.
+
+**Update (2026-06-23): required-check activation is descoped.** Credit provenance (#724) closed **won't-do** and the umbrella (#425) closed **completed-advisory** — so the frame remains in **advisory mode indefinitely** by choice, not by incomplete work. See the [Activation runbook](#activation-runbook) status note. Re-scoping activation requires re-opening #724 first.
 
 ### D18 — Skill-first methodology
 

--- a/frame/enforce-activation.yaml
+++ b/frame/enforce-activation.yaml
@@ -1,10 +1,17 @@
 # Frame enforce activation timestamp.
 # PRs created BEFORE this timestamp are not subject to enforcement (warn mode only).
-# Set this to a past timestamp only after the Pre-Activation Gate is met:
+#
+# STATUS (2026-06-23): required-check activation is DESCOPED — the frame ships
+# advisory and stays advisory. Credit provenance (#724), a Pre-Activation Gate
+# precondition, was closed won't-do, and the frame-enforcement umbrella (#425)
+# closed completed-advisory. The activation_timestamp is intentionally left at the
+# never-date below; re-scoping activation means re-opening #724 first.
+#
+# Pre-Activation Gate (retained for reference; not currently pursued):
 #   1. >= 95% credit completeness over 30-PR retrospective audit
 #   2. >= 1-week operator notice posted
 #   3. Opt-out mechanism (FRAME_ENFORCE=0) built, documented, and tested
-#   4. Credit provenance (#724) resolved
+#   4. Credit provenance (#724) resolved — CLOSED WON'T-DO (2026-06-23)
 # See Documents/Design/frame-architecture.md for the activation runbook.
 schema_version: 1
 activation_timestamp: "9999-12-31T00:00:00Z"


### PR DESCRIPTION
## What

Reconciles the frame-enforce activation docs after **#724 (credit provenance) closed won't-do** and the **frame-enforcement umbrella #425 closed completed-advisory**. Required-check activation is descoped — the frame ships and stays **advisory** by choice.

## Why

Marking the `frame-enforce` check `required` was gated on #724 (Pre-Activation Gate item 4). After a value-vs-cost review, #724 was closed won't-do: for a solo + own-agents repo, an un-bypassable merge gate has little near-term payoff against real build + permanent maintenance + false-block-friction cost. That leaves the activation runbook citing an abandoned precondition.

## Changes

- `frame/enforce-activation.yaml` — annotate the Pre-Activation Gate comment (item 4 → CLOSED WON'T-DO) + a STATUS banner that activation is descoped. Executable config (`schema_version`, `activation_timestamp`) **unchanged**.
- `Documents/Design/frame-architecture.md` — STATUS banner on the Activation runbook, gate item 1 annotated, and D17 updated to record the descope.

## Scope / safety

- Doc + comment only; no behavior change. The frame still runs advisory exactly as before.
- Neither file is a plugin entry point (`agents/`, `skills/`, `commands/`, `hooks/`, `.claude-plugin/`, `plugin.json`, `README.md`, `.github/copilot-instructions.md`), so **no version bump / CHANGELOG entry required**.

Refs #425, #724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update documentation and configuration comments to record that frame-enforce required-check activation has been descoped and the workflow will remain advisory.

Documentation:
- Annotate the frame-enforce activation runbook with a status note that required-check activation is descoped, and clarify that the workflow remains advisory with its gate conditions retained for reference.
- Update design decision D17 to document the descoping of required-check activation and the rationale tied to issues #724 and #425.

Chores:
- Clarify enforce-activation configuration comments to mark required-check activation as descoped, note the unsatisfied credit provenance precondition, and retain the previous gate checklist as historical context.