### PR TITLE
fix(#736): replace hard-coded scan cap with issueScanLimit param on Invoke-PortfolioRender

### DIFF
--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -1242,12 +1242,9 @@ rounds:
 '@ | Set-Content -Path $tempSpecCeil1 -Encoding UTF8
 
         try {
-            try {
-                Invoke-PortfolioRender -specPath $tempSpecCeil1 -issueScanLimit 3
-            }
-            catch {
-                # Expected: ceiling guard throws; swallow so we can assert below.
-            }
+            { Invoke-PortfolioRender -specPath $tempSpecCeil1 -issueScanLimit 3 } |
+                Should -Throw -ExpectedMessage '*refusing to render*' `
+                -Because 'ceiling guard must throw with the truncated-board message before gh issue edit is reached'
 
             $script:ScanReached | Should -BeTrue `
                 -Because 'gh stub must have been called before the ceiling guard fired — if false, function failed with ParameterBindingException instead'
@@ -1312,12 +1309,9 @@ rounds:
 '@ | Set-Content -Path $tempSpecCeil2 -Encoding UTF8
 
         try {
-            try {
-                Invoke-PortfolioRender -specPath $tempSpecCeil2 -issueScanLimit 3
-            }
-            catch {
-                # Expected: ceiling guard throws; swallow so we can assert below.
-            }
+            { Invoke-PortfolioRender -specPath $tempSpecCeil2 -issueScanLimit 3 } |
+                Should -Throw -ExpectedMessage '*truncated RecentlyClosed*' `
+                -Because 'ceiling guard must throw with the truncated-RecentlyClosed message before gh issue edit is reached'
 
             $script:ScanReached | Should -BeTrue `
                 -Because 'gh stub must have been called before the ceiling guard fired — if false, function failed with ParameterBindingException instead'
@@ -1393,7 +1387,9 @@ rounds:
             $script:GhEditCallCount | Should -Be 0 `
                 -Because 'gh issue edit must not be reached when the closed ceiling fires at [Math]::Min(1500,1000)=1000'
 
-            { Invoke-PortfolioRender -specPath $tempSpecCeil4 -issueScanLimit 1500 } | Should -Throw
+            { Invoke-PortfolioRender -specPath $tempSpecCeil4 -issueScanLimit 1500 } |
+                Should -Throw -ExpectedMessage '*GitHub Search API hard cap*' `
+                -Because 'api-cap path must throw the GitHub Search API hard cap message specifically'
         }
         finally {
             if (Test-Path $tempSpecCeil4) { Remove-Item $tempSpecCeil4 -Force -ErrorAction SilentlyContinue }
@@ -1478,8 +1474,8 @@ rounds:
             $warnings[0].Message | Should -Match 'returned 3 results' `
                 -Because 'the captured warning must be the triage ceiling warning (count/limit included), not a parse or exit-code warning'
 
-            $script:GhEditCallCount | Should -BeGreaterThan 0 `
-                -Because 'render must complete (warn-and-continue, not abort) and write the control tower body'
+            $script:GhEditCallCount | Should -Be 1 `
+                -Because 'render must complete with exactly one control-tower write (warn-and-continue, not abort)'
         }
         finally {
             if (Test-Path $tempSpecCeil3) { Remove-Item $tempSpecCeil3 -Force -ErrorAction SilentlyContinue }

--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -1190,4 +1190,226 @@ rounds:
             if (Test-Path $tempSpec2) { Remove-Item $tempSpec2 -Force -ErrorAction SilentlyContinue }
         }
     }
+
+    It 'open-ceiling-throws: open scan at limit fires fail-loud guard before gh issue edit is reached' {
+        # RED driver for s2 fix: -issueScanLimit param does not exist yet, so
+        # calling it throws ParameterBindingException.  $script:ScanReached stays
+        # $false and the ScanReached assertion fails — correct RED failure.
+        #
+        # GREEN (after s2): open scan stub sets ScanReached=$true, ceiling guard
+        # fires Write-Error -ErrorAction Stop, edit never reached, both assertions pass.
+
+        $script:ScanReached    = $false
+        $script:GhEditCallCount = 0
+
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+
+            if ($ghArgs -contains 'edit') {
+                $script:GhEditCallCount++
+                $global:LASTEXITCODE = 0
+                return
+            }
+
+            if ($ghArgs -contains 'list') {
+                if ($ghArgs -contains 'closed') {
+                    # 1 item — below limit, closed guard won't fire
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":10,"title":"c1","closedAt":"2026-01-01T00:00:00Z","labels":[]}]'
+                }
+                if ($ghArgs -contains 'triage') {
+                    $global:LASTEXITCODE = 0
+                    return '[]'
+                }
+                # open scan fallthrough — return exactly 3 items (= limit) and mark reached
+                $script:ScanReached = $true
+                $global:LASTEXITCODE = 0
+                return '[{"number":1,"title":"t1","labels":[],"createdAt":"2026-01-01T00:00:00Z"},{"number":2,"title":"t2","labels":[],"createdAt":"2026-01-01T00:00:00Z"},{"number":3,"title":"t3","labels":[],"createdAt":"2026-01-01T00:00:00Z"}]'
+            }
+
+            $global:LASTEXITCODE = 0
+        }
+
+        $tempSpecCeil1 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [425, 571]
+'@ | Set-Content -Path $tempSpecCeil1 -Encoding UTF8
+
+        try {
+            try {
+                Invoke-PortfolioRender -specPath $tempSpecCeil1 -issueScanLimit 3
+            }
+            catch {
+                # Expected: ceiling guard throws; swallow so we can assert below.
+            }
+
+            $script:ScanReached | Should -BeTrue `
+                -Because 'gh stub must have been called before the ceiling guard fired — if false, function failed with ParameterBindingException instead'
+
+            $script:GhEditCallCount | Should -Be 0 `
+                -Because 'gh issue edit must never be reached when the open ceiling guard fires'
+        }
+        finally {
+            if (Test-Path $tempSpecCeil1) { Remove-Item $tempSpecCeil1 -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'closed-ceiling-throws: closed scan at limit fires fail-loud guard before gh issue edit is reached' {
+        # RED driver for s2 fix: -issueScanLimit param does not exist yet, so
+        # calling it throws ParameterBindingException.  $script:ScanReached stays
+        # $false and the ScanReached assertion fails — correct RED failure.
+        #
+        # GREEN (after s2): open scan (2 items) passes, closed scan stub sets
+        # ScanReached=$true, closed ceiling guard fires Write-Error -ErrorAction Stop,
+        # edit never reached, both assertions pass.
+
+        $script:ScanReached    = $false
+        $script:GhEditCallCount = 0
+
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+
+            if ($ghArgs -contains 'edit') {
+                $script:GhEditCallCount++
+                $global:LASTEXITCODE = 0
+                return
+            }
+
+            if ($ghArgs -contains 'list') {
+                if ($ghArgs -contains 'closed') {
+                    # 3 items — exactly at limit, closed ceiling guard fires; mark reached
+                    $script:ScanReached = $true
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":10,"title":"c1","closedAt":"2026-01-01T00:00:00Z","labels":[]},{"number":11,"title":"c2","closedAt":"2026-01-01T00:00:00Z","labels":[]},{"number":12,"title":"c3","closedAt":"2026-01-01T00:00:00Z","labels":[]}]'
+                }
+                if ($ghArgs -contains 'triage') {
+                    $global:LASTEXITCODE = 0
+                    return '[]'
+                }
+                # open scan fallthrough — 2 items, below limit, open guard won't fire
+                $global:LASTEXITCODE = 0
+                return '[{"number":1,"title":"t1","labels":[],"createdAt":"2026-01-01T00:00:00Z"},{"number":2,"title":"t2","labels":[],"createdAt":"2026-01-01T00:00:00Z"}]'
+            }
+
+            $global:LASTEXITCODE = 0
+        }
+
+        $tempSpecCeil2 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [425, 571]
+'@ | Set-Content -Path $tempSpecCeil2 -Encoding UTF8
+
+        try {
+            try {
+                Invoke-PortfolioRender -specPath $tempSpecCeil2 -issueScanLimit 3
+            }
+            catch {
+                # Expected: ceiling guard throws; swallow so we can assert below.
+            }
+
+            $script:ScanReached | Should -BeTrue `
+                -Because 'gh stub must have been called before the ceiling guard fired — if false, function failed with ParameterBindingException instead'
+
+            $script:GhEditCallCount | Should -Be 0 `
+                -Because 'gh issue edit must never be reached when the closed ceiling guard fires'
+        }
+        finally {
+            if (Test-Path $tempSpecCeil2) { Remove-Item $tempSpecCeil2 -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'triage-ceiling-warns: triage scan at limit emits Write-Warning and render completes (warn-and-continue)' {
+        # RED driver for s2 fix: -issueScanLimit param does not exist yet, so
+        # calling it throws ParameterBindingException (unhandled, no try/catch) —
+        # Pester marks the test FAILED with ParameterBindingException.  Correct RED.
+        #
+        # GREEN (after s2): open/closed scans below limit, triage scan at limit fires
+        # Write-Warning (warn-and-continue, never throw), render completes, gh issue edit
+        # is called exactly once, and the captured warning stream contains at least one
+        # WarningRecord for the triage ceiling.
+
+        $script:GhEditCallCount = 0
+
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+
+            if ($ghArgs -contains 'edit') {
+                $script:GhEditCallCount++
+                $global:LASTEXITCODE = 0
+                return
+            }
+
+            if ($ghArgs -contains 'view') {
+                $global:LASTEXITCODE = 0
+                return '{"body":"# Control Tower\n\nNo portfolio block yet."}'
+            }
+
+            if ($ghArgs -contains 'list') {
+                if ($ghArgs -contains 'closed') {
+                    # 1 item — below limit, closed guard won't fire
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":10,"title":"c1","closedAt":"2026-01-01T00:00:00Z","labels":[]}]'
+                }
+                if ($ghArgs -contains 'triage') {
+                    # 3 items — exactly at limit, triage ceiling fires Write-Warning
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":1},{"number":2},{"number":3}]'
+                }
+                # open scan fallthrough — 1 item, below limit, open guard won't fire
+                $global:LASTEXITCODE = 0
+                return '[{"number":425,"title":"Umbrella 425","labels":[],"createdAt":"2025-06-01T00:00:00Z"}]'
+            }
+
+            if ($ghArgs -contains 'api') {
+                $queryStr = $ghArgs | Where-Object { $_ -like 'query=*' } | Select-Object -Last 1
+                $issueNum = 0
+                if ($queryStr -match 'issue\(number:\s*(\d+)') { $issueNum = [int]$Matches[1] }
+                $global:LASTEXITCODE = 0
+                return "{`"data`":{`"repository`":{`"issue`":{`"number`":$issueNum,`"title`":`"t$issueNum`",`"state`":`"OPEN`",`"closedAt`":null,`"createdAt`":`"2026-01-01T00:00:00Z`",`"labels`":{`"totalCount`":0,`"nodes`":[]},`"blockedBy`":{`"totalCount`":0,`"nodes`":[]},`"subIssues`":{`"nodes`":[]}}}}}"
+            }
+
+            $global:LASTEXITCODE = 0
+        }
+
+        $tempSpecCeil3 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [425, 571]
+'@ | Set-Content -Path $tempSpecCeil3 -Encoding UTF8
+
+        try {
+            # NO try/catch: in RED state ParameterBindingException is unhandled
+            # and Pester marks the test FAILED — correct RED failure mode.
+            # In GREEN state the function completes (warn-and-continue) and
+            # warnings are captured via the 3>&1 stream redirect.
+            $captured = Invoke-PortfolioRender -specPath $tempSpecCeil3 -issueScanLimit 3 3>&1
+
+            $warnings = @($captured | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+            $warnings.Count | Should -BeGreaterThan 0 `
+                -Because 'triage ceiling must emit Write-Warning when triage scan returns count >= issueScanLimit'
+
+            $script:GhEditCallCount | Should -BeGreaterThan 0 `
+                -Because 'render must complete (warn-and-continue, not abort) and write the control tower body'
+        }
+        finally {
+            if (Test-Path $tempSpecCeil3) { Remove-Item $tempSpecCeil3 -Force -ErrorAction SilentlyContinue }
+        }
+    }
 }

--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -1330,6 +1330,76 @@ rounds:
         }
     }
 
+    It 'closed-ceiling-throws-at-api-cap: closed guard fires at min(issueScanLimit,1000) when issueScanLimit exceeds Search API hard cap' {
+        # AC4 clamp-path coverage: with -issueScanLimit 1500 the effective closed ceiling is
+        # [Math]::Min(1500, 1000) = 1000. The closed stub returns exactly 1000 items so
+        # closedLeaves.Count (1000) >= closedCeiling (1000) -> guard fires. A regression
+        # replacing [Math]::Min($issueScanLimit,1000) with plain $issueScanLimit would make
+        # closedCeiling = 1500, the stub's 1000 results would no longer trigger the guard, and
+        # the test would fail — exactly the mutation that the existing closed-ceiling-throws
+        # test (with issueScanLimit 3) cannot catch.
+
+        $script:ScanReached    = $false
+        $script:GhEditCallCount = 0
+
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+            if ($ghArgs -contains 'edit') {
+                $script:GhEditCallCount++
+                $global:LASTEXITCODE = 0
+                return
+            }
+            if ($ghArgs -contains 'list') {
+                if ($ghArgs -contains 'closed') {
+                    $script:ScanReached = $true
+                    $global:LASTEXITCODE = 0
+                    # Return exactly 1000 items — hits [Math]::Min(1500, 1000) = 1000
+                    $rows = (1..1000 | ForEach-Object { "{`"number`":$_,`"title`":`"c$_`",`"closedAt`":`"2026-01-01T00:00:00Z`",`"labels`":[]}" }) -join ','
+                    return "[$rows]"
+                }
+                if ($ghArgs -contains 'triage') {
+                    $global:LASTEXITCODE = 0
+                    return '[]'
+                }
+                # open scan fallthrough — return 1 item, well below issueScanLimit 1500
+                $global:LASTEXITCODE = 0
+                return '[{"number":1,"title":"t1","labels":[],"createdAt":"2026-01-01T00:00:00Z"}]'
+            }
+            $global:LASTEXITCODE = 0
+        }
+
+        $tempSpecCeil4 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [425, 571]
+'@ | Set-Content -Path $tempSpecCeil4 -Encoding UTF8
+
+        try {
+            try {
+                Invoke-PortfolioRender -specPath $tempSpecCeil4 -issueScanLimit 1500
+            }
+            catch {
+                # Expected: closed ceiling guard throws at [Math]::Min(1500,1000)=1000; swallow.
+            }
+
+            $script:ScanReached | Should -BeTrue `
+                -Because 'closed scan stub must run before the guard — if false, the call never reached the closed scan'
+
+            $script:GhEditCallCount | Should -Be 0 `
+                -Because 'gh issue edit must not be reached when the closed ceiling fires at [Math]::Min(1500,1000)=1000'
+
+            { Invoke-PortfolioRender -specPath $tempSpecCeil4 -issueScanLimit 1500 } | Should -Throw
+        }
+        finally {
+            if (Test-Path $tempSpecCeil4) { Remove-Item $tempSpecCeil4 -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
     It 'triage-ceiling-warns: triage scan at limit emits Write-Warning and render completes (warn-and-continue)' {
         # RED driver for s2 fix: -issueScanLimit param does not exist yet, so
         # calling it throws ParameterBindingException (unhandled, no try/catch) —
@@ -1404,6 +1474,9 @@ rounds:
             $warnings = @($captured | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
             $warnings.Count | Should -BeGreaterThan 0 `
                 -Because 'triage ceiling must emit Write-Warning when triage scan returns count >= issueScanLimit'
+
+            $warnings[0].Message | Should -Match 'returned 3 results' `
+                -Because 'the captured warning must be the triage ceiling warning (count/limit included), not a parse or exit-code warning'
 
             $script:GhEditCallCount | Should -BeGreaterThan 0 `
                 -Because 'render must complete (warn-and-continue, not abort) and write the control tower body'

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -723,8 +723,12 @@ function Get-SplicedBody {
 # ---------------------------------------------------------------------------
 function Invoke-PortfolioRender {
     param(
-        [string]$specPath     = 'Documents/Planning/sequence.yaml',
-        [int]   $controlTower = 0   # 0 = read from spec
+        [string]$specPath       = 'Documents/Planning/sequence.yaml',
+        [int]   $controlTower   = 0,     # 0 = read from spec
+        # 2000 is ~9x the current open-issue count (226 as of 2026-06).
+        # Crossing it means revisit the paginate decision (see #746-class pagination),
+        # not just bump the number.
+        [int]   $issueScanLimit = 2000
     )
 
     # 1. Parse spec
@@ -754,7 +758,7 @@ function Invoke-PortfolioRender {
     # uses -ErrorAction Stop so the terminating error propagates cleanly through
     # Pester's try/catch without polluting the non-terminating error stream.
     $openLeavesRaw = gh issue list --repo Grimblaz/agent-orchestra --state open `
-        --json number,title,labels,createdAt --limit 200
+        --json number,title,labels,createdAt --limit $issueScanLimit
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to fetch open issue list (exit $LASTEXITCODE)" -ErrorAction Stop
     }
@@ -765,15 +769,16 @@ function Invoke-PortfolioRender {
     catch {
         Write-Error "Failed to parse open issue list JSON: $_" -ErrorAction Stop
     }
-    if ($openLeaves.Count -ge 200) {
-        Write-Error "Open issue list returned 200 results — refusing to render a potentially truncated board." -ErrorAction Stop
+    # Two-tier truncation contract: open/closed fail-loud (abort render); triage warn-and-continue (additive bucket).
+    if ($openLeaves.Count -ge $issueScanLimit) {
+        Write-Error "Open issue list returned $($openLeaves.Count) results (limit $issueScanLimit) — refusing to render a potentially truncated board." -ErrorAction Stop
     }
 
     # 2c. Repo-wide closed-leaf scan (AC9 data source).
     # Fail-loud: same hard-exit pattern as the open scan.
     $cutoffDate    = (Get-Date).AddDays(-$spec.recently_closed_days).ToString('yyyy-MM-dd')
     $closedRawJson = gh issue list --repo Grimblaz/agent-orchestra --state closed `
-        --search "closed:>=$cutoffDate" --json number,title,closedAt,labels --limit 200
+        --search "closed:>=$cutoffDate" --json number,title,closedAt,labels --limit $issueScanLimit
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to fetch closed issue list (exit $LASTEXITCODE)" -ErrorAction Stop
     }
@@ -784,8 +789,10 @@ function Invoke-PortfolioRender {
     catch {
         Write-Error "Failed to parse closed issue list JSON: $_" -ErrorAction Stop
     }
-    if ($closedLeaves.Count -ge 200) {
-        Write-Error "Closed issue list returned 200 results — refusing to render a potentially truncated RecentlyClosed section." -ErrorAction Stop
+    # Closed scan uses --search, routing through the GitHub Search API (hard cap: 1000 results regardless of --limit).
+    # Guard at min(issueScanLimit, 1000) so it can actually fire even when issueScanLimit > 1000.
+    if ($closedLeaves.Count -ge ([Math]::Min($issueScanLimit, 1000))) {
+        Write-Error "Closed issue list returned $($closedLeaves.Count) results (limit $([Math]::Min($issueScanLimit, 1000))) — refusing to render a potentially truncated RecentlyClosed section." -ErrorAction Stop
     }
 
     # 2d. Fetch open triage-labeled issues repo-wide (CR9 / d-triage-visibility,
@@ -796,7 +803,7 @@ function Invoke-PortfolioRender {
     #     warns and degrades (Triage may be incomplete) rather than aborting the
     #     whole render, consistent with the per-issue skip pattern below.
     $triageNums = @()
-    $triageRaw  = gh issue list --repo Grimblaz/agent-orchestra --label triage --state open --limit 200 --json number
+    $triageRaw  = gh issue list --repo Grimblaz/agent-orchestra --label triage --state open --limit $issueScanLimit --json number
     if ($LASTEXITCODE -ne 0) {
         Write-Warning "Failed to list open triage-labeled issues (exit $LASTEXITCODE) — Triage bucket may be incomplete."
     }
@@ -807,6 +814,12 @@ function Invoke-PortfolioRender {
         catch {
             Write-Warning "Failed to parse triage issue list — Triage bucket may be incomplete."
         }
+    }
+    # Triage truncation is an accepted advisory degradation: a best-effort additive bucket
+    # must not abort the whole render. count == limit is the only observable signal; a
+    # false-positive at exactly the ceiling is documented here as accepted.
+    if ($triageNums.Count -ge $issueScanLimit) {
+        Write-Warning "Triage issue list returned $($triageNums.Count) results (limit $issueScanLimit) — Triage bucket may be incomplete."
     }
 
     # Query set = sequenced issues ∪ repo-wide triage issues (deduplicated).

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -728,6 +728,7 @@ function Invoke-PortfolioRender {
         # 2000 is ~9x the current open-issue count (226 as of 2026-06).
         # Crossing it means revisit the paginate decision (see #746-class pagination),
         # not just bump the number.
+        [ValidateRange(1, [int]::MaxValue)]
         [int]   $issueScanLimit = 2000
     )
 

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -770,6 +770,7 @@ function Invoke-PortfolioRender {
         Write-Error "Failed to parse open issue list JSON: $_" -ErrorAction Stop
     }
     # Two-tier truncation contract: open/closed fail-loud (abort render); triage warn-and-continue (additive bucket).
+    # count == limit is the only observable truncation signal; false-positive at exactly the ceiling is treated as truncation and accepted.
     if ($openLeaves.Count -ge $issueScanLimit) {
         Write-Error "Open issue list returned $($openLeaves.Count) results (limit $issueScanLimit) — refusing to render a potentially truncated board." -ErrorAction Stop
     }
@@ -777,8 +778,11 @@ function Invoke-PortfolioRender {
     # 2c. Repo-wide closed-leaf scan (AC9 data source).
     # Fail-loud: same hard-exit pattern as the open scan.
     $cutoffDate    = (Get-Date).AddDays(-$spec.recently_closed_days).ToString('yyyy-MM-dd')
+    # Closed scan uses --search, routing through the GitHub Search API (hard cap: 1000 results regardless of --limit).
+    # Guard at min(issueScanLimit, 1000) so it can actually fire even when issueScanLimit > 1000.
+    $closedCeiling = [Math]::Min($issueScanLimit, 1000)
     $closedRawJson = gh issue list --repo Grimblaz/agent-orchestra --state closed `
-        --search "closed:>=$cutoffDate" --json number,title,closedAt,labels --limit $issueScanLimit
+        --search "closed:>=$cutoffDate" --json number,title,closedAt,labels --limit $closedCeiling
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to fetch closed issue list (exit $LASTEXITCODE)" -ErrorAction Stop
     }
@@ -789,10 +793,9 @@ function Invoke-PortfolioRender {
     catch {
         Write-Error "Failed to parse closed issue list JSON: $_" -ErrorAction Stop
     }
-    # Closed scan uses --search, routing through the GitHub Search API (hard cap: 1000 results regardless of --limit).
-    # Guard at min(issueScanLimit, 1000) so it can actually fire even when issueScanLimit > 1000.
-    if ($closedLeaves.Count -ge ([Math]::Min($issueScanLimit, 1000))) {
-        Write-Error "Closed issue list returned $($closedLeaves.Count) results (limit $([Math]::Min($issueScanLimit, 1000))) — refusing to render a potentially truncated RecentlyClosed section." -ErrorAction Stop
+    # Fail-loud tier: abort render (same contract as open guard above).
+    if ($closedLeaves.Count -ge $closedCeiling) {
+        Write-Error "Closed issue list returned $($closedLeaves.Count) results (limit $closedCeiling — GitHub Search API hard cap) — refusing to render a potentially truncated RecentlyClosed section." -ErrorAction Stop
     }
 
     # 2d. Fetch open triage-labeled issues repo-wide (CR9 / d-triage-visibility,


### PR DESCRIPTION
Closes #736

## Problem

`render-portfolio.yml` fails on every merge to `main` since PR #734 (issue #720) because all three `gh issue list` scans in `Invoke-PortfolioRender` were hard-capped at `--limit 200`. The repo now has 226+ open issues, tripping the fail-loud truncation guard added by CR-3. The #704 Control Tower board is frozen at the 2026-06-23 snapshot.

## Fix

Add `[int]$issueScanLimit = 2000` to `Invoke-PortfolioRender`, thread it through all three scan `--limit` args and guards. The closed scan (which routes through the GitHub Search API) uses `$closedCeiling = [Math]::Min($issueScanLimit, 1000)` for its `--limit` and guard, since the Search API hard-caps at 1000 regardless of `--limit`. Triage gains a new warn-and-continue ceiling check (degrade-don't-abort contract). The CI entrypoint stays unchanged — the `2000` default binds automatically.

## Changes

- `.github/scripts/render-portfolio.ps1` — added `$issueScanLimit` param, extracted `$closedCeiling`, updated `--limit` args and guards, added triage ceiling warning, documented two-tier contract
- `.github/scripts/Tests/render-portfolio.Tests.ps1` — 4 new ceiling tests: `open-ceiling-throws`, `closed-ceiling-throws`, `closed-ceiling-throws-at-api-cap` (exercises the `[Math]::Min` clamp at `issueScanLimit=1500` so a regression to plain `$issueScanLimit` fails), `triage-ceiling-warns`

## CE Gate

All 4 scenarios [auto] — S3/S4 verified by Pester; S1/S2 verified by CI run after merge.

| Scenario | Method | Evidence |
|---|---|---|
| S1: CI succeeds on merge with >200 open issues | `render-portfolio.yml` CI run | CI run on merge (post-PR) |
| S2: rendered board reflects all open issues | Compare rendered count vs `gh issue list --state open` | CI run on merge (post-PR) |
| S3: guard fires at ceiling (open → `$issueScanLimit`, closed → `min($issueScanLimit,1000)`) | Pester | `open-ceiling-throws`, `closed-ceiling-throws`, `closed-ceiling-throws-at-api-cap` — all green |
| S4: triage scan consistent + warn-not-abort at ceiling | Pester | `triage-ceiling-warns` — green |

**Pester result**: `Tests Passed: 45, Failed: 0` (41 pre-existing + 4 new ceiling tests)

## Adversarial review

Standard prosecution → defense → judge. Judge verdict: **ADDRESS THEN SHIP** (6 inline findings, all applied before PR).

| Finding | Category | Disposition |
|---|---|---|
| F1: Closed guard uses repeated `[Math]::Min(...)` expression | code-change | Addressed — extracted `$closedCeiling` variable |
| F2: No test covers `issueScanLimit > 1000` clamp path (AC4) | test-change | Addressed — `closed-ceiling-throws-at-api-cap` added |
| F3: Open guard missing false-positive boundary doc | comment-only | Addressed — added parallel comment to triage block |
| F4: Closed guard missing fail-loud tier marker | comment-only | Addressed — added `# Fail-loud tier: abort render` |
| F5: Closed `--limit` still uses `$issueScanLimit` not `$closedCeiling` | code-change | Addressed — closed `--limit $closedCeiling` |
| F7: Triage warning assertion too broad (`Count > 0`) | test-change | Addressed — sharpened to match `'returned 3 results'` |

<!-- pipeline-metrics
schema_version: 4
issue_id: 736
phase: orchestration
scope_tier: full
steps_completed:
  - implement-test
  - implement-code
  - code-review
  - post-review-fixes
  - ce-gate
credits:
  - role: code-smith
    step: implement-code
  - role: test-writer
    step: implement-test
  - role: code-critic
    step: code-review
  - role: code-review-response
    step: code-review
  - role: code-smith
    step: post-review-fixes
  - role: test-writer
    step: post-review-fixes
adversarial_review:
  verdict: ADDRESS_THEN_SHIP
  findings_total: 6
  findings_addressed: 6
ce_gate:
  s1: post-merge-ci
  s2: post-merge-ci
  s3: pester-green
  s4: pester-green
pester:
  total: 45
  passed: 45
  failed: 0
  new_tests: 4
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable scan limit for portfolio rendering, with clearer handling when issue lists reach that limit.
  * Open and closed scans now stop the render with a clear error if results are too large.
  * Triage scans now show a warning and continue instead of stopping the process.

* **Bug Fixes**
  * Closed-issue scanning now respects the GitHub search limit, preventing oversized requests from affecting the render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->