### PR TITLE
feat(#753): Control Tower v2 — ranked-umbrella board (active expanded + derived triage)

### DIFF
--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -591,43 +591,40 @@ Describe 'Format-PortfolioMarkdown' {
         $output | Should -Match 'portfolio content unchanged since \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z — rendered by render-portfolio\.ps1'
     }
 
-    It 'renders Now/Next/Blocked/Recently closed/Triage sections in that order' {
+    It 'v2-renders-Active/Umbrellas/Triage/RecentlyClosed sections in that order' {
+        # v2 layout: Active → Umbrellas (ranked) → Triage → Recently closed
         $timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
         $output = Format-PortfolioMarkdown -bucketModel $script:SimpleBuckets -timestamp $timestamp
 
-        $nowPos           = $output.IndexOf('Now')
-        $nextPos          = $output.IndexOf('Next')
-        $blockedPos       = $output.IndexOf('Blocked')
+        $activePos         = $output.IndexOf('Active')
+        $umbrellasPos      = $output.IndexOf('Umbrellas')
+        $triagePos         = $output.IndexOf('Triage')
         $recentlyClosedPos = $output.IndexOf('Recently closed')
-        $triagePos        = $output.IndexOf('Triage')
 
-        $nowPos            | Should -BeGreaterThan -1  -Because 'Now section must be present'
-        $nextPos           | Should -BeGreaterThan $nowPos           -Because 'Next must come after Now'
-        $blockedPos        | Should -BeGreaterThan $nextPos          -Because 'Blocked must come after Next'
-        $recentlyClosedPos | Should -BeGreaterThan $blockedPos       -Because 'Recently closed must come after Blocked'
-        $triagePos         | Should -BeGreaterThan $recentlyClosedPos -Because 'Triage must come after Recently closed'
+        $activePos         | Should -BeGreaterThan -1            -Because 'Active section must be present (v2)'
+        $umbrellasPos      | Should -BeGreaterThan $activePos    -Because 'Umbrellas (ranked) must come after Active (v2)'
+        $triagePos         | Should -BeGreaterThan $umbrellasPos -Because 'Triage must come after Umbrellas (v2)'
+        $recentlyClosedPos | Should -BeGreaterThan $triagePos    -Because 'Recently closed must come after Triage (v2)'
     }
 
-    It 'appends (+N more) when totalCount exceeds rendered count (pagination overflow F14)' {
-        # Fixture: 50 issues rendered, totalCount = 51 → should show (+1 more)
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $issues = @(
-            (New-IssueState -Number 425 -State 'OPEN' -BlockedBy @())
-        )
-        # Override totalCount to simulate overflow: 51 total, 1 rendered
+    It 'v2-triage-residual-overflow: (+N more) appears in Triage when TriageResidualCount > 0 (F14)' {
+        # v2: overflow in Triage section is controlled by TriageResidualCount from Get-PortfolioBuckets.
+        # When TriageResidualCount=50 and 1 item is rendered, (+50 more) must appear.
         $overflowBucketModel = [PSCustomObject]@{
-            Now            = @($issues[0])
-            NowTotalCount  = 51
-            Next           = @()
-            Blocked        = @()
-            RecentlyClosed = @()
-            Triage         = @()
+            ActiveUmbrella      = $null
+            ActiveChildren      = @()
+            RankedUmbrellas     = @()
+            Triage              = @( [PSCustomObject]@{ number = 425; title = 'Issue 425' } )
+            TriageResidualCount = 50
+            DriftWarnings       = @()
+            IntegrityWarnings   = @()
+            RecentlyClosed      = @()
         }
         $timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 
         $output = Format-PortfolioMarkdown -bucketModel $overflowBucketModel -timestamp $timestamp
 
-        $output | Should -Match '\(\+50 more\)' -Because 'totalCount(51) - rendered(1) = 50 overflow items must be shown'
+        $output | Should -Match '\(\+50 more\)' -Because 'TriageResidualCount=50 must appear as (+50 more) in Triage section (v2 pagination)'
     }
 
     It 'Now ordering tiebreaker: lower-numbered float precedes higher-numbered float (AC3/F18)' {
@@ -658,154 +655,111 @@ Describe 'Format-PortfolioMarkdown' {
     # All RED until s2/s3 implement single ranked list, tags, and cap-floor.
     # -----------------------------------------------------------------------
 
-    It 'Now list is a single ranked list — no umbrella section headers (AC3)' {
-        # The new Now list must NOT re-sort by number or add umbrella sub-headers.
-        # Formatter must preserve the producer ordering from the bucket model.
-        # RED until Format-PortfolioMarkdown is updated.
-        $bucketModel = [PSCustomObject]@{
-            Now            = @(
-                [PSCustomObject]@{ number = 571; title = 'Issue 571'; isFloat = $false; inProgress = $false }
-                [PSCustomObject]@{ number = 425; title = 'Issue 425'; isFloat = $false; inProgress = $false }
-            )
-            NowTotalCount  = 2
-            Next           = @()
-            NextTotalCount = 0
-            Blocked        = @()
-            BlockedTotalCount = 0
-            RecentlyClosed = @()
-            RecentlyClosedTotalCount = 0
-            Triage         = @()
-            TriageTotalCount = 0
-            CoverageGaps   = @()
-        }
-        $timestamp = '2026-06-25T00:00:00Z'
+    It 'v2-umbrellas-spec-order-preserved: Umbrellas section preserves spec list order — no re-sort by number (AC5)' {
+        # v2: Umbrellas (ranked) section must preserve spec list order verbatim.
+        # Formatter must NOT re-sort by number.
+        # Spec has umbrellas [571, 425] → 571 must appear before 425 in output.
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(571, 425))
+        $umbrella571 = New-IssueState -Number 571 -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella425 = New-IssueState -Number 425 -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
 
-        $output = Format-PortfolioMarkdown -bucketModel $bucketModel -timestamp $timestamp
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella571, $umbrella425)
+        $output  = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-06-25T00:00:00Z'
 
-        # 571 must appear BEFORE 425 (bucket model order preserved, no re-sort by number)
-        $pos571 = $output.IndexOf('#571')
-        $pos425 = $output.IndexOf('#425')
-        $pos571 | Should -BeGreaterThan -1  -Because '#571 must appear in output'
-        $pos425 | Should -BeGreaterThan -1  -Because '#425 must appear in output'
-        $pos571 | Should -BeLessThan $pos425 -Because 'formatter must NOT re-sort by number; bucket model order is authoritative (AC3)'
-        # No umbrella sub-headers: the Now section body must not contain "### " headers.
-        $nowMatch = [regex]::Match($output, '(?s)## Now(?<body>.*?)## Next')
-        $nowMatch.Success | Should -Be $true -Because 'Now section must appear before Next in the output'
-        $nowMatch.Groups['body'].Value | Should -Not -Match '(?m)^###\s' -Because 'single ranked Now list must not contain umbrella sub-headers (AC3)'
+        # Find positions in the Umbrellas section: 571 before 425
+        $umbrellasSectionMatch = [regex]::Match($output, '(?s)## Umbrellas \(ranked\)(?<body>.*?)## 🔥 Triage')
+        $umbrellasSectionMatch.Success | Should -Be $true -Because 'Umbrellas (ranked) section must appear before Triage'
+        $body = $umbrellasSectionMatch.Groups['body'].Value
+        $pos571 = $body.IndexOf('#571')
+        $pos425 = $body.IndexOf('#425')
+        $pos571 | Should -BeGreaterThan -1 -Because '#571 must appear in Umbrellas section'
+        $pos425 | Should -BeGreaterThan -1 -Because '#425 must appear in Umbrellas section'
+        $pos571 | Should -BeLessThan $pos425 -Because 'formatter must preserve spec order; #571 (listed first) must precede #425 (listed second) (AC5)'
     }
 
-    It 'float items in Now list are tagged with (unsequenced) (AC3/AC4)' {
-        # Float issues in Now must be rendered with "(unsequenced)" tag in the list item.
-        # RED until Format-PortfolioMarkdown adds (unsequenced) tag for isFloat items.
-        $bucketModel = [PSCustomObject]@{
-            Now            = @(
-                [PSCustomObject]@{ number = 800; title = 'Float Issue'; isFloat = $true; inProgress = $false }
-                [PSCustomObject]@{ number = 425; title = 'Issue 425';   isFloat = $false; inProgress = $false }
-            )
-            NowTotalCount  = 2
-            Next           = @()
-            NextTotalCount = 0
-            Blocked        = @()
-            BlockedTotalCount = 0
-            RecentlyClosed = @()
-            RecentlyClosedTotalCount = 0
-            Triage         = @()
-            TriageTotalCount = 0
-            CoverageGaps   = @()
-        }
-        $timestamp = '2026-06-25T00:00:00Z'
-
-        $output = Format-PortfolioMarkdown -bucketModel $bucketModel -timestamp $timestamp
-
-        $output | Should -Match '#800.*\(unsequenced\)' -Because 'float items in Now list must be tagged with (unsequenced) (AC3/AC4)'
-        $output | Should -Not -Match '#425.*\(unsequenced\)' -Because 'non-float items must NOT be tagged with (unsequenced)'
-    }
-
-    It 'in-progress items in Now list are tagged with (in progress) (AC3)' {
-        # Items with inProgress=$true (derived from "in progress" label) must be
-        # tagged with "(in progress)" in the list rendering.
-        # RED until Format-PortfolioMarkdown adds (in progress) tag.
-        $bucketModel = [PSCustomObject]@{
-            Now            = @(
-                [PSCustomObject]@{ number = 425; title = 'Issue 425'; isFloat = $false; inProgress = $true }
-                [PSCustomObject]@{ number = 571; title = 'Issue 571'; isFloat = $false; inProgress = $false }
-            )
-            NowTotalCount  = 2
-            Next           = @()
-            NextTotalCount = 0
-            Blocked        = @()
-            BlockedTotalCount = 0
-            RecentlyClosed = @()
-            RecentlyClosedTotalCount = 0
-            Triage         = @()
-            TriageTotalCount = 0
-            CoverageGaps   = @()
-        }
-        $timestamp = '2026-06-25T00:00:00Z'
-
-        $output = Format-PortfolioMarkdown -bucketModel $bucketModel -timestamp $timestamp
-
-        $output | Should -Match '#425.*\(in progress\)' -Because 'issues with inProgress=$true must be tagged (in progress) (AC3)'
-        $output | Should -Not -Match '#571.*\(in progress\)' -Because 'issues without inProgress flag must not be tagged'
-    }
-
-    It 'cap-floor N=15: top 15 float items rendered, (+M more) for the rest (AC10)' {
-        # When more than 15 floats exist, the formatter renders top 15 and shows "(+M more)".
-        # RED until Format-PortfolioMarkdown implements cap-floor.
-        $floats = 1..20 | ForEach-Object {
-            [PSCustomObject]@{
-                number     = 900 + $_
-                title      = "Float $_"
-                isFloat    = $true
-                inProgress = $false
+    It 'v2-active-children-blocked-annotation: blocked children show ⛔ annotation, non-blocked children do not (AC4)' {
+        # v2: in the Active section, blocked children must have ⛔ annotation; non-blocked must not.
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(100))
+        $blockedChild = New-IssueState -Number 800 -Title 'Blocked child' -State 'OPEN' -BlockedBy @(999) `
+            -Parent @{ number = 100 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $normalChild  = New-IssueState -Number 425 -Title 'Normal child' -State 'OPEN' -BlockedBy @() `
+            -Parent @{ number = 100 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella100  = New-IssueState -Number 100 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 2
+                nodes = @( @{ number = 800; state = 'OPEN' }, @{ number = 425; state = 'OPEN' } )
             }
-        }
-        $bucketModel = [PSCustomObject]@{
-            Now               = $floats    # 20 floats; only 15 should render
-            NowTotalCount     = 20
-            NowFloatCount     = 20
-            Next              = @()
-            NextTotalCount    = 0
-            Blocked           = @()
-            BlockedTotalCount = 0
-            RecentlyClosed    = @()
-            RecentlyClosedTotalCount = 0
-            Triage            = @()
-            TriageTotalCount  = 0
-            CoverageGaps      = @()
-        }
-        $timestamp = '2026-06-25T00:00:00Z'
 
-        $output = Format-PortfolioMarkdown -bucketModel $bucketModel -timestamp $timestamp
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella100, $blockedChild, $normalChild)
+        $output  = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-06-25T00:00:00Z'
 
-        # Should show (+5 more) because 20 total - 15 cap = 5 overflow
-        $output | Should -Match '\(\+5 more\)' -Because 'cap-floor: 20 floats - N=15 cap = 5 overflow, must show (+5 more) (AC10)'
-        # Must NOT render items beyond the cap
-        $output | Should -Not -Match '#920' -Because 'items beyond cap floor must not be rendered individually'
+        $output | Should -Match '#800.*⛔' -Because 'blocked child must have ⛔ blocked annotation (AC4)'
+        $output | Should -Not -Match '#425.*⛔' -Because 'non-blocked child must NOT have ⛔ annotation (AC4)'
     }
 
-    It 'empty Now bucket shows appropriate empty label' {
-        # When Now bucket is empty (no current-round work), formatter shows a label.
-        # This is consistent with the existing blocked/no-work distinction.
+    It 'v2-active-children-priority-ordering: children sorted priority-then-recency, not by number (AC4)' {
+        # v2: Active section children must be sorted by priority-label then createdAt desc.
+        # This verifies the formatter preserves Get-PortfolioBuckets output order.
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(100))
+        # #571 has lower number but no priority; #425 has priority:high → must appear first
+        $child571 = New-IssueState -Number 571 -State 'OPEN' -CreatedAt '2025-01-01T00:00:00Z' -Labels @() `
+            -Parent @{ number = 100 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $child425 = New-IssueState -Number 425 -State 'OPEN' -CreatedAt '2025-01-01T00:00:00Z' -Labels @('priority: high') `
+            -Parent @{ number = 100 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella100 = New-IssueState -Number 100 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 2
+                nodes = @( @{ number = 571; state = 'OPEN' }, @{ number = 425; state = 'OPEN' } )
+            }
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella100, $child571, $child425)
+        $output  = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-06-25T00:00:00Z'
+
+        # #425 has priority:high → key=0 → appears before #571 (unlabeled, key=3) despite larger number
+        $pos425 = $output.IndexOf('#425')
+        $pos571 = $output.IndexOf('#571')
+        $pos425 | Should -BeGreaterThan -1 -Because '#425 must appear in Active section'
+        $pos571 | Should -BeGreaterThan -1 -Because '#571 must appear in Active section'
+        $pos425 | Should -BeLessThan $pos571 `
+            -Because '#425 (priority:high) must appear before #571 (unlabeled) in Active section — formatter must not re-sort by number (AC4)'
+    }
+
+    It 'v2-triage-cap-floor: Get-PortfolioBuckets caps Triage at 5; TriageResidualCount carries overflow (AC6)' {
+        # v2: Triage is capped at 5 items by Get-PortfolioBuckets. The formatter renders all items
+        # it receives in Triage (no formatter-level cap), and appends (+N more) from TriageResidualCount.
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
+        # 8 triage candidates (none are umbrellas [476,571]) → cap at 5, residual = 3
+        $triageIssues = 1..8 | ForEach-Object {
+            New-IssueState -Number (900 + $_) -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
+        }
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $triageIssues
+        $output  = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-06-25T00:00:00Z'
+
+        # Residual = 3 → (+3 more) must appear
+        $output | Should -Match '\(\+3 more\)' -Because 'TriageResidualCount=3 must appear as (+3 more) after capped triage list (AC6)'
+        # Items beyond cap (#909) must not be rendered
+        $output | Should -Not -Match '#909' -Because 'item #909 (beyond triage cap of 5) must not be rendered individually (AC6)'
+    }
+
+    It 'v2-no-active-umbrella: empty state shown when ActiveUmbrella is null' {
+        # v2: when ActiveUmbrella is null (all closed or none in list), Active section
+        # shows an empty-state label matching '*(no' pattern (e.g. '*(none)*' or '*(no active umbrella)*').
         $bucketModel = [PSCustomObject]@{
-            Now               = @()
-            NowTotalCount     = 0
-            Next              = @()
-            NextTotalCount    = 0
-            Blocked           = @()
-            BlockedTotalCount = 0
-            RecentlyClosed    = @()
-            RecentlyClosedTotalCount = 0
-            Triage            = @()
-            TriageTotalCount  = 0
-            CoverageGaps      = @()
+            ActiveUmbrella      = $null
+            ActiveChildren      = @()
+            RankedUmbrellas     = @()
+            Triage              = @()
+            TriageResidualCount = 0
+            DriftWarnings       = @()
+            IntegrityWarnings   = @()
+            RecentlyClosed      = @()
         }
         $timestamp = '2026-06-25T00:00:00Z'
 
         $output = Format-PortfolioMarkdown -bucketModel $bucketModel -timestamp $timestamp
 
-        # Existing behavior: shows "*(no current-round work)*" or similar
-        $output | Should -Match '\*\(no' -Because 'empty Now bucket must show a labeled empty state message'
+        # Active section shows an empty-state label
+        $output | Should -Match '\*\(no' -Because 'null ActiveUmbrella must show a labeled empty state in Active section'
     }
 
     It 'repo-wide recently-closed section shows all leaf closures in window (AC9)' {
@@ -983,53 +937,237 @@ Describe 'Order independence' {
         $outputA | Should -Be $outputB -Because 'output must be byte-identical regardless of input issue ordering (sort by number ascending is deterministic)'
     }
 
-    It 'createdAt-desc ordering: creation order != number order → ranked by createdAt desc with priority tiebreak (AC3)' {
-        # Fixture where createdAt order DIFFERS from issue number order.
-        # AC3 full order key: current-round-spine-first → createdAt desc → priority-label → number.
-        # Floats mixed with labeled and unlabeled items.
-        # RED until Get-PortfolioBuckets implements createdAt-desc ordering for floats.
+    It 'v2-triage-ordering: priority then recency then number in Triage section (AC6)' {
+        # v2: #425, #800, #801, #802 are triage candidates (open, parent=null, totalCount=0, not in umbrella list).
+        # #571 IS an umbrella (in default spec umbrellas:[476,571]) → excluded from triage.
+        # Triage sort: priority-label key (asc) → Get-CreatedAtSortTicks (asc = newest first) → number asc.
+        # #800 (key=0/priority:high, 2025-02-01) → first
+        # #802 (key=3, 2025-06-01, newest among unlabeled) → second
+        # #801 (key=3, 2025-02-01, number 801) → third
+        # #425 (key=3, 2024-01-01, oldest) → fourth
         $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
 
-        # Round 1 spine issues (425, 571) — should appear first regardless of createdAt
-        # Float #802 (newer, unlabeled), float #800 (older, priority:high), float #801 (middle, unlabeled)
-        # Expected order after spine: 802 (newest) → 800 (older, priority:high beats #801 at same createdAt)
-        # Wait: all have different createdAt so priority-label tiebreak doesn't apply across them.
-        # Let's use 800/801 same date, 800 has priority:high.
-        # Order: 802 (newest) → 800 (same date as 801, priority:high wins) → 801 (same date, unlabeled)
+        $si0 = @{ totalCount = 0; nodes = @() }
         $issuesAscending = @(
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z')
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z')
-            (New-IssueState -Number 800  -State 'OPEN' -BlockedBy @() -CreatedAt '2025-02-01T00:00:00Z' -Labels @('priority: high'))
-            (New-IssueState -Number 801  -State 'OPEN' -BlockedBy @() -CreatedAt '2025-02-01T00:00:00Z' -Labels @())
-            (New-IssueState -Number 802  -State 'OPEN' -BlockedBy @() -CreatedAt '2025-06-01T00:00:00Z' -Labels @())
+            (New-IssueState -Number 425 -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z' -SubIssues $si0)
+            (New-IssueState -Number 571 -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z' -SubIssues $si0)
+            (New-IssueState -Number 800 -State 'OPEN' -BlockedBy @() -CreatedAt '2025-02-01T00:00:00Z' -Labels @('priority: high') -SubIssues $si0)
+            (New-IssueState -Number 801 -State 'OPEN' -BlockedBy @() -CreatedAt '2025-02-01T00:00:00Z' -Labels @() -SubIssues $si0)
+            (New-IssueState -Number 802 -State 'OPEN' -BlockedBy @() -CreatedAt '2025-06-01T00:00:00Z' -Labels @() -SubIssues $si0)
         )
         $issuesShuffled = @(
-            (New-IssueState -Number 802  -State 'OPEN' -BlockedBy @() -CreatedAt '2025-06-01T00:00:00Z' -Labels @())
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z')
-            (New-IssueState -Number 801  -State 'OPEN' -BlockedBy @() -CreatedAt '2025-02-01T00:00:00Z' -Labels @())
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z')
-            (New-IssueState -Number 800  -State 'OPEN' -BlockedBy @() -CreatedAt '2025-02-01T00:00:00Z' -Labels @('priority: high'))
+            (New-IssueState -Number 802 -State 'OPEN' -BlockedBy @() -CreatedAt '2025-06-01T00:00:00Z' -Labels @() -SubIssues $si0)
+            (New-IssueState -Number 571 -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z' -SubIssues $si0)
+            (New-IssueState -Number 801 -State 'OPEN' -BlockedBy @() -CreatedAt '2025-02-01T00:00:00Z' -Labels @() -SubIssues $si0)
+            (New-IssueState -Number 425 -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z' -SubIssues $si0)
+            (New-IssueState -Number 800 -State 'OPEN' -BlockedBy @() -CreatedAt '2025-02-01T00:00:00Z' -Labels @('priority: high') -SubIssues $si0)
         )
-        $knownChildSet = @()
 
-        $bucketsA = Get-PortfolioBuckets -spec $spec -issueStateObjects $issuesAscending -KnownChildSet $knownChildSet
-        $bucketsB = Get-PortfolioBuckets -spec $spec -issueStateObjects $issuesShuffled  -KnownChildSet $knownChildSet
+        $bucketsA = Get-PortfolioBuckets -spec $spec -issueStateObjects $issuesAscending
+        $bucketsB = Get-PortfolioBuckets -spec $spec -issueStateObjects $issuesShuffled
 
         $fixedTimestamp = '2026-06-12T12:00:00Z'
         $outputA = Format-PortfolioMarkdown -bucketModel $bucketsA -timestamp $fixedTimestamp
         $outputB = Format-PortfolioMarkdown -bucketModel $bucketsB -timestamp $fixedTimestamp
 
         # Output must be byte-identical regardless of input order (deterministic sort)
-        $outputA | Should -Be $outputB -Because 'createdAt-desc ordering must be deterministic regardless of input order (AC3)'
+        $outputA | Should -Be $outputB -Because 'v2 triage ordering must be deterministic regardless of input order (AC6)'
 
-        # Verify ordering: in Now section, #802 (newest float) must appear before #800 and #801
-        $pos802 = $outputA.IndexOf('#802')
+        # Verify ordering in the combined output:
+        # #800 (priority:high) must come before #802 (createdAt-desc secondary)
         $pos800 = $outputA.IndexOf('#800')
         $pos801 = $outputA.IndexOf('#801')
-        $pos802 | Should -BeLessThan $pos800 -Because '#802 (created 2025-06-01) must appear before #800 (created 2025-02-01) — createdAt desc'
-        $pos802 | Should -BeLessThan $pos801 -Because '#802 (created 2025-06-01) must appear before #801 (created 2025-02-01) — createdAt desc'
-        # Priority tiebreak: #800 (priority:high) before #801 (unlabeled) at same createdAt
-        $pos800 | Should -BeLessThan $pos801 -Because '#800 (priority:high) must rank before #801 (unlabeled) at same createdAt — priority-label tiebreak (AC3)'
+        $pos802 = $outputA.IndexOf('#802')
+        $pos425 = $outputA.IndexOf('#425')
+
+        $pos800 | Should -BeLessThan $pos802 `
+            -Because '#800 (priority:high) must appear before #802 (createdAt-desc secondary) — priority-label tiebreak (AC6)'
+        $pos802 | Should -BeLessThan $pos801 `
+            -Because '#802 (2025-06-01) must appear before #801 (2025-02-01) — createdAt desc within same priority group (AC6)'
+        $pos801 | Should -BeLessThan $pos425 `
+            -Because '#801 (2025-02-01) must appear before #425 (2024-01-01) — createdAt desc (AC6)'
+    }
+}
+
+# ===========================================================================
+Describe 'Format-PortfolioMarkdown v2' {
+# ===========================================================================
+
+    It 'v2-three-zone-layout: output contains Active, Umbrellas ranked, and Triage headers' {
+        # Minimal v2 bucket model with an active umbrella, one ranked umbrella, one triage issue
+        $buckets = [PSCustomObject]@{
+            ActiveUmbrella      = [PSCustomObject]@{ number = 100; title = 'Test Umbrella' }
+            ActiveChildren      = @()
+            RankedUmbrellas     = @(
+                [PSCustomObject]@{ Number = 100; Title = 'Test Umbrella'; State = 'OPEN'; Done = 0; Total = 0; DoneTotalLabel = '0/0 (no children linked)'; IsActive = $true }
+            )
+            Triage              = @(
+                [PSCustomObject]@{ number = 200; title = 'Triage Issue' }
+            )
+            TriageResidualCount = 0
+            DriftWarnings       = @()
+            IntegrityWarnings   = @()
+            RecentlyClosed      = @()
+        }
+
+        $output = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-01-01T00:00:00Z'
+
+        $output | Should -Match '## 🎯 Active' -Because 'v2 Active section header must appear (AC3)'
+        $output | Should -Match '## Umbrellas \(ranked\)' -Because 'v2 Umbrellas (ranked) section header must appear (AC5)'
+        $output | Should -Match '## 🔥 Triage' -Because 'v2 Triage section header must appear (AC6)'
+        $output | Should -Match '## Recently closed' -Because 'v2 Recently closed section must appear (AC9)'
+    }
+
+    It 'v2-active-section: active umbrella children listed with done/total footer' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(100))
+        $child200 = New-IssueState -Number 200 -State 'OPEN' `
+            -Parent @{ number = 100 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $child201 = New-IssueState -Number 201 -State 'CLOSED' `
+            -Parent @{ number = 100 } -SubIssues @{ totalCount = 0; nodes = @() } -ClosedAt '2026-01-01T00:00:00Z'
+        $umbrella100 = New-IssueState -Number 100 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 2
+                nodes = @(
+                    @{ number = 200; state = 'OPEN' },
+                    @{ number = 201; state = 'CLOSED' }
+                )
+            }
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella100, $child200, $child201)
+        $output  = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-01-01T00:00:00Z'
+
+        $output | Should -Match '#200' -Because 'open active child #200 must appear in Active section'
+        $output | Should -Match '1/2'  -Because 'done/total (1 closed of 2 children) must appear in active section footer'
+    }
+
+    It 'v2-active-blocked-child: blocked child shows ⛔ in active section' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(100))
+        $child200 = New-IssueState -Number 200 -State 'OPEN' -BlockedBy @(999) `
+            -Parent @{ number = 100 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella100 = New-IssueState -Number 100 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 1
+                nodes = @( @{ number = 200; state = 'OPEN' } )
+            }
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella100, $child200)
+        $output  = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-01-01T00:00:00Z'
+
+        $output | Should -Match '⛔' -Because 'blocked child must show ⛔ annotation in Active section (AC4)'
+    }
+
+    It 'v2-umbrellas-ranked-with-active-marker: active umbrella gets ◀ active marker' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(100, 200))
+        $umbrella100 = New-IssueState -Number 100 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella200 = New-IssueState -Number 200 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella100, $umbrella200)
+        $output  = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-01-01T00:00:00Z'
+
+        $output | Should -Match '◀ active' -Because 'active umbrella must have ◀ active marker in Umbrellas section (AC5)'
+        # spec order preserved: #100 before #200 in Umbrellas section
+        $pos100 = $output.IndexOf('#100')
+        $pos200 = $output.IndexOf('#200')
+        $pos100 | Should -BeLessThan $pos200 -Because 'spec order must be preserved in Umbrellas (ranked) section (AC5)'
+    }
+
+    It 'v2-triage-residual-count: (+N more) appears when TriageResidualCount > 0' {
+        $buckets = [PSCustomObject]@{
+            ActiveUmbrella      = $null
+            ActiveChildren      = @()
+            RankedUmbrellas     = @()
+            Triage              = @(
+                [PSCustomObject]@{ number = 1; title = 'T1' }
+            )
+            TriageResidualCount = 3
+            DriftWarnings       = @()
+            IntegrityWarnings   = @()
+            RecentlyClosed      = @()
+        }
+
+        $output = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-01-01T00:00:00Z'
+
+        $output | Should -Match '\(\+3 more\)' -Because 'TriageResidualCount=3 must appear as (+3 more) after triage list (AC6)'
+    }
+
+    It 'v2-drift-integrity-warnings: ⚠️ DriftWarnings and IntegrityWarnings appear after zones' {
+        $buckets = [PSCustomObject]@{
+            ActiveUmbrella      = $null
+            ActiveChildren      = @()
+            RankedUmbrellas     = @()
+            Triage              = @()
+            TriageResidualCount = 0
+            DriftWarnings       = @('⚠️ open umbrella #999 not in ranked list')
+            IntegrityWarnings   = @('⚠️ umbrella #100: subIssues.totalCount=5 but only 3 nodes returned')
+            RecentlyClosed      = @()
+        }
+
+        $output = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-01-01T00:00:00Z'
+
+        $output | Should -Match 'open umbrella #999' -Because 'DriftWarnings must appear in output (AC7)'
+        $output | Should -Match 'subIssues\.totalCount=5' -Because 'IntegrityWarnings must appear in output (AC8)'
+
+        # Warnings must appear after zone content (before footer)
+        $footerPos   = $output.IndexOf('portfolio content unchanged since')
+        $driftPos    = $output.IndexOf('open umbrella #999')
+        $driftPos | Should -BeLessThan $footerPos -Because 'warnings must appear before footer'
+    }
+
+    It 'v2-idempotency: Format-PortfolioMarkdown + Get-SplicedBody returns $null on second call with same data' {
+        $MARKER_BEGIN = '<!-- portfolio-tracker:begin -->'
+        $MARKER_END   = '<!-- portfolio-tracker:end -->'
+
+        $buckets = [PSCustomObject]@{
+            ActiveUmbrella      = $null
+            ActiveChildren      = @()
+            RankedUmbrellas     = @()
+            Triage              = @( [PSCustomObject]@{ number = 99; title = 'T99' } )
+            TriageResidualCount = 0
+            DriftWarnings       = @()
+            IntegrityWarnings   = @()
+            RecentlyClosed      = @()
+        }
+
+        $fixedTimestamp = '2026-01-01T00:00:00Z'
+        $inner1  = Format-PortfolioMarkdown -bucketModel $buckets -timestamp $fixedTimestamp
+        $block1  = "$MARKER_BEGIN`n$inner1$MARKER_END"
+
+        # Splice into empty body
+        $body1 = Get-SplicedBody -existingBody '' -contentBlock $block1
+
+        # Format again with different timestamp (same data)
+        $inner2 = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-06-01T00:00:00Z'
+        $block2 = "$MARKER_BEGIN`n$inner2$MARKER_END"
+
+        # Splice into already-spliced body
+        $result = Get-SplicedBody -existingBody $body1 -contentBlock $block2
+
+        $result | Should -BeNullOrEmpty -Because 'identical content with only timestamp change must return null (idempotency — no write needed)'
+    }
+
+    It 'v2-outside-marker-prose-preserved: text before portfolio marker is kept in spliced body' {
+        $MARKER_BEGIN = '<!-- portfolio-tracker:begin -->'
+        $MARKER_END   = '<!-- portfolio-tracker:end -->'
+
+        $existingBody = "Some prose before marker`n$MARKER_BEGIN`nold content`nportfolio content unchanged since 2026-01-01T00:00:00Z — rendered by render-portfolio.ps1`n$MARKER_END"
+
+        $buckets = [PSCustomObject]@{
+            ActiveUmbrella      = $null
+            ActiveChildren      = @()
+            RankedUmbrellas     = @()
+            Triage              = @()
+            TriageResidualCount = 0
+            DriftWarnings       = @()
+            IntegrityWarnings   = @()
+            RecentlyClosed      = @()
+        }
+        $inner   = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-06-01T00:00:00Z'
+        $block   = "$MARKER_BEGIN`n$inner$MARKER_END"
+        $result  = Get-SplicedBody -existingBody $existingBody -contentBlock $block
+
+        $result | Should -Match 'Some prose before marker' -Because 'text before portfolio marker must be preserved after splice'
     }
 }
 

--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -1095,26 +1095,21 @@ Describe 'Invoke-PortfolioRender' {
         # AC8: when the subIssues/float scan exits non-zero, Invoke-PortfolioRender
         # must hard-exit BEFORE writing — gh issue edit must be invoked 0 times.
         # The board must never be written in a partial/failed scan state.
-        # RED until s2/s3 add the AC8 hard-exit guard to Invoke-PortfolioRender.
         #
         # Stub behavior (from BeforeEach):
-        #   - `gh issue list`  → exit 1  (simulates scan failure)
-        #   - `gh api graphql` → exit 1  (simulates per-issue fetch failure)
+        #   - `gh api graphql` → exit 1  (Step-0 probe fails; pipeline halts before scan)
+        #   - `gh issue list`  → exit 1  (simulates scan failure; never reached due to probe halt)
         #   - `gh issue view`  → returns minimal JSON (control tower body fetch succeeds)
         #   - `gh issue edit`  → records call, returns 0 (would be the write step)
         #
-        # With the AC8 guard: pipeline exits before step 8 (write) → edit count = 0.
-        # Without the guard (current state): pipeline continues to step 8 → edit count > 0.
+        # With the Step-0 probe guard: pipeline exits before step 8 (write) → edit count = 0.
 
         $tempSpec = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
         @'
-schema_version: 1
+schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-rounds:
-  - lane: main
-    round: 1
-    issues: [425, 571]
+umbrellas: [425, 571]
 '@ | Set-Content -Path $tempSpec -Encoding UTF8
 
         try {
@@ -1134,21 +1129,24 @@ rounds:
         }
     }
 
-    It 'full pipeline: float appears in Now, repo-wide closed leaf in RecentlyClosed, and gh issue edit is called once (F1/F2/F3 wiring)' {
-        # Success-path integration test (F7 / review finding).
-        # Stubs all gh calls to return realistic data; exercises the full
+    It 'v2-full-pipeline: active umbrella expanded, triage by parent-edge, gh issue edit called once' {
+        # Success-path v2 integration test.
+        # Stubs all gh calls to return v2-model data; exercises the full
         # Invoke-PortfolioRender pipeline:
-        #   open-scan  → #800 float + umbrellas #425/#571
+        #   Step-0 probe (#704) → success
+        #   open-scan  → #900 (child of #425), #800 (triage candidate), #425, #571
         #   closed-scan → #801 recently-closed leaf (within window)
-        #   GraphQL #425 → OPEN, subIssues: [#900]
-        #   GraphQL #571 → OPEN, subIssues: []
+        #   GraphQL #425 → OPEN, parent: null, subIssues: [{#900, OPEN}]
+        #   GraphQL #571 → OPEN, parent: null, subIssues: []
+        #   GraphQL #900 (leaf) → parent: {number:425}, subIssues: {totalCount:0}
+        #   GraphQL #800 (leaf) → parent: null, subIssues: {totalCount:0}  → Triage candidate
         #   view #704   → body with no portfolio block yet
         #   edit #704   → captured to $script:GhEditBody
         #
-        # Expected board state after fix:
-        #   Now:            #425 (spine), #571 (spine), #800 (unsequenced float)
-        #   CoverageGaps:   (#571: no leaves modeled yet)   — #425 has child #900
-        #   RecentlyClosed: #801 (from ClosedLeafItems, not issueStateObjects)
+        # Expected board state after s3 fix:
+        #   Triage:         #800 (open, parent=null, totalCount=0, not in umbrella list)
+        #   RecentlyClosed: #801 (closed within window)
+        #   gh issue edit called exactly once
 
         $script:GhEditCallCount = 0
         $script:GhEditBody      = ''
@@ -1175,38 +1173,42 @@ rounds:
                     $global:LASTEXITCODE = 0
                     return "[{`"number`":801,`"title`":`"Recently closed leaf`",`"closedAt`":`"$closedAt801`",`"labels`":[]}]"
                 }
-                if ($ghArgs -contains 'triage') {
-                    $global:LASTEXITCODE = 0
-                    return '[]'
-                }
-                # open scan: spine leaf #900, float #800, umbrellas #425 and #571
+                # open scan: #900 (child of 425), #800 (triage), #425 umbrella, #571 umbrella
+                # No --label triage branch in v2
                 $global:LASTEXITCODE = 0
-                return '[{"number":900,"title":"Spine leaf 900","labels":[],"createdAt":"2026-01-02T00:00:00Z"},{"number":800,"title":"Float issue 800","labels":[],"createdAt":"2026-01-01T00:00:00Z"},{"number":425,"title":"Umbrella 425","labels":[],"createdAt":"2025-06-01T00:00:00Z"},{"number":571,"title":"Umbrella 571","labels":[],"createdAt":"2025-05-01T00:00:00Z"}]'
+                return '[{"number":900,"title":"Spine leaf 900","labels":[],"createdAt":"2026-01-02T00:00:00Z"},{"number":800,"title":"Triage candidate 800","labels":[],"createdAt":"2026-01-01T00:00:00Z"},{"number":425,"title":"Umbrella 425","labels":[],"createdAt":"2025-06-01T00:00:00Z"},{"number":571,"title":"Umbrella 571","labels":[],"createdAt":"2025-05-01T00:00:00Z"}]'
             }
 
             if ($ghArgs -contains 'api') {
-                # Dispatch by issue number in the query string (last element of args)
+                # Dispatch by issue number in the query string
                 $queryStr = $ghArgs | Where-Object { $_ -like 'query=*' } | Select-Object -Last 1
                 $issueNum = 0
                 if ($queryStr -match 'issue\(number:\s*(\d+)') { $issueNum = [int]$Matches[1] }
 
-                if ($issueNum -eq 425) {
+                if ($issueNum -eq 704) {
+                    # Step-0 probe: parent + subIssues fields available on control tower
                     $global:LASTEXITCODE = 0
-                    return '{"data":{"repository":{"issue":{"number":425,"title":"Umbrella 425","state":"OPEN","closedAt":null,"createdAt":"2025-06-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"subIssues":{"nodes":[{"number":900}]}}}}}'
+                    return '{"data":{"repository":{"issue":{"parent":null,"subIssues":{"totalCount":0}}}}}'
+                }
+                if ($issueNum -eq 425) {
+                    # Umbrella with one child (#900)
+                    $global:LASTEXITCODE = 0
+                    return '{"data":{"repository":{"issue":{"number":425,"title":"Umbrella 425","state":"OPEN","closedAt":null,"createdAt":"2025-06-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":null,"subIssues":{"totalCount":1,"nodes":[{"number":900,"state":"OPEN"}]}}}}}'
                 }
                 if ($issueNum -eq 571) {
+                    # Umbrella with no children
                     $global:LASTEXITCODE = 0
-                    return '{"data":{"repository":{"issue":{"number":571,"title":"Umbrella 571","state":"OPEN","closedAt":null,"createdAt":"2025-05-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"subIssues":{"nodes":[]}}}}}'
+                    return '{"data":{"repository":{"issue":{"number":571,"title":"Umbrella 571","state":"OPEN","closedAt":null,"createdAt":"2025-05-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":null,"subIssues":{"totalCount":0,"nodes":[]}}}}}'
                 }
                 if ($issueNum -eq 900) {
-                    # Spine leaf — known child of umbrella #425; queried in step 3b after CR-5 fix
+                    # Leaf child of #425: parent set, no sub-issues
                     $global:LASTEXITCODE = 0
-                    return '{"data":{"repository":{"issue":{"number":900,"title":"Spine leaf 900","state":"OPEN","closedAt":null,"createdAt":"2026-01-02T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]}}}}}'
+                    return '{"data":{"repository":{"issue":{"number":900,"title":"Spine leaf 900","state":"OPEN","closedAt":null,"createdAt":"2026-01-02T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":{"number":425},"subIssues":{"totalCount":0}}}}}'
                 }
                 if ($issueNum -eq 800) {
-                    # Float candidate — queried in step 3b, no subIssues field
+                    # Triage candidate: parent null, no sub-issues
                     $global:LASTEXITCODE = 0
-                    return '{"data":{"repository":{"issue":{"number":800,"title":"Float issue 800","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]}}}}}'
+                    return '{"data":{"repository":{"issue":{"number":800,"title":"Triage candidate 800","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":null,"subIssues":{"totalCount":0}}}}}'
                 }
                 $global:LASTEXITCODE = 0
                 return '{"data":{"repository":{"issue":null}}}'
@@ -1222,35 +1224,23 @@ rounds:
 
         $tempSpec2 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
         @'
-schema_version: 1
+schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-rounds:
-  - lane: main
-    round: 1
-    issues: [425, 571]
+umbrellas: [425, 571]
 '@ | Set-Content -Path $tempSpec2 -Encoding UTF8
 
         try {
             Invoke-PortfolioRender -specPath $tempSpec2
 
             $script:GhEditCallCount | Should -Be 1 `
-                -Because 'pipeline should write the board once when body changes'
+                -Because 'pipeline should write the board exactly once when body changes'
 
             $script:GhEditBody | Should -Match '#800' `
-                -Because 'float issue #800 must appear in the rendered board (AC4/AC1 wiring verified)'
+                -Because '#800 is a triage candidate (parent=null, totalCount=0) and must appear in the Triage section'
 
             $script:GhEditBody | Should -Match '#801' `
                 -Because 'repo-wide closed leaf #801 must appear in RecentlyClosed (AC9 wiring verified)'
-
-            $script:GhEditBody | Should -Match '#900' `
-                -Because '#900 is a spine leaf (known child of umbrella #425) and must appear in the rendered board (CR-5 fix verified)'
-
-            $script:GhEditBody | Should -Match 'unsequenced' `
-                -Because '#800 is a float and must be tagged (unsequenced) in Now'
-
-            $script:GhEditBody | Should -Match '571.*no leaves modeled yet' `
-                -Because '#571 has no sub-issues in KnownChildSet so CoverageGaps must emit a note for it (AC7)'
         }
         finally {
             if (Test-Path $tempSpec2) { Remove-Item $tempSpec2 -Force -ErrorAction SilentlyContinue }
@@ -1258,12 +1248,9 @@ rounds:
     }
 
     It 'open-ceiling-throws: open scan at limit fires fail-loud guard before gh issue edit is reached' {
-        # RED driver for s2 fix: -issueScanLimit param does not exist yet, so
-        # calling it throws ParameterBindingException.  $script:ScanReached stays
-        # $false and the ScanReached assertion fails — correct RED failure.
-        #
-        # GREEN (after s2): open scan stub sets ScanReached=$true, ceiling guard
-        # fires Write-Error -ErrorAction Stop, edit never reached, both assertions pass.
+        # GREEN (after s2/s3): Step-0 probe succeeds (returns valid JSON for tower #704),
+        # open scan stub sets ScanReached=$true at exactly the limit, ceiling guard fires
+        # Write-Error -ErrorAction Stop, edit never reached, both assertions pass.
 
         $script:ScanReached    = $false
         $script:GhEditCallCount = 0
@@ -1277,15 +1264,24 @@ rounds:
                 return
             }
 
+            if ($ghArgs -contains 'api') {
+                # Step-0 probe for tower #704 — return success so probe passes
+                $queryStr = $ghArgs | Where-Object { $_ -like 'query=*' } | Select-Object -Last 1
+                $issueNum = 0
+                if ($queryStr -match 'issue\(number:\s*(\d+)') { $issueNum = [int]$Matches[1] }
+                if ($issueNum -eq 704) {
+                    $global:LASTEXITCODE = 0
+                    return '{"data":{"repository":{"issue":{"parent":null,"subIssues":{"totalCount":0}}}}}'
+                }
+                $global:LASTEXITCODE = 1
+                return
+            }
+
             if ($ghArgs -contains 'list') {
                 if ($ghArgs -contains 'closed') {
                     # 1 item — below limit, closed guard won't fire
                     $global:LASTEXITCODE = 0
                     return '[{"number":10,"title":"c1","closedAt":"2026-01-01T00:00:00Z","labels":[]}]'
-                }
-                if ($ghArgs -contains 'triage') {
-                    $global:LASTEXITCODE = 0
-                    return '[]'
                 }
                 # open scan fallthrough — return exactly 3 items (= limit) and mark reached
                 $script:ScanReached = $true
@@ -1298,13 +1294,10 @@ rounds:
 
         $tempSpecCeil1 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
         @'
-schema_version: 1
+schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-rounds:
-  - lane: main
-    round: 1
-    issues: [425, 571]
+umbrellas: [425, 571]
 '@ | Set-Content -Path $tempSpecCeil1 -Encoding UTF8
 
         try {
@@ -1313,7 +1306,7 @@ rounds:
                 -Because 'ceiling guard must throw with the truncated-board message before gh issue edit is reached'
 
             $script:ScanReached | Should -BeTrue `
-                -Because 'gh stub must have been called before the ceiling guard fired — if false, function failed with ParameterBindingException instead'
+                -Because 'gh stub must have been called before the ceiling guard fired — if false, function failed before reaching the open scan'
 
             $script:GhEditCallCount | Should -Be 0 `
                 -Because 'gh issue edit must never be reached when the open ceiling guard fires'
@@ -1324,13 +1317,9 @@ rounds:
     }
 
     It 'closed-ceiling-throws: closed scan at limit fires fail-loud guard before gh issue edit is reached' {
-        # RED driver for s2 fix: -issueScanLimit param does not exist yet, so
-        # calling it throws ParameterBindingException.  $script:ScanReached stays
-        # $false and the ScanReached assertion fails — correct RED failure.
-        #
-        # GREEN (after s2): open scan (2 items) passes, closed scan stub sets
-        # ScanReached=$true, closed ceiling guard fires Write-Error -ErrorAction Stop,
-        # edit never reached, both assertions pass.
+        # GREEN (after s2/s3): Step-0 probe succeeds, open scan (2 items) passes,
+        # closed scan stub sets ScanReached=$true at exactly the limit, closed ceiling
+        # guard fires Write-Error -ErrorAction Stop, edit never reached.
 
         $script:ScanReached    = $false
         $script:GhEditCallCount = 0
@@ -1344,16 +1333,25 @@ rounds:
                 return
             }
 
+            if ($ghArgs -contains 'api') {
+                # Step-0 probe for tower #704 — return success so probe passes
+                $queryStr = $ghArgs | Where-Object { $_ -like 'query=*' } | Select-Object -Last 1
+                $issueNum = 0
+                if ($queryStr -match 'issue\(number:\s*(\d+)') { $issueNum = [int]$Matches[1] }
+                if ($issueNum -eq 704) {
+                    $global:LASTEXITCODE = 0
+                    return '{"data":{"repository":{"issue":{"parent":null,"subIssues":{"totalCount":0}}}}}'
+                }
+                $global:LASTEXITCODE = 1
+                return
+            }
+
             if ($ghArgs -contains 'list') {
                 if ($ghArgs -contains 'closed') {
                     # 3 items — exactly at limit, closed ceiling guard fires; mark reached
                     $script:ScanReached = $true
                     $global:LASTEXITCODE = 0
                     return '[{"number":10,"title":"c1","closedAt":"2026-01-01T00:00:00Z","labels":[]},{"number":11,"title":"c2","closedAt":"2026-01-01T00:00:00Z","labels":[]},{"number":12,"title":"c3","closedAt":"2026-01-01T00:00:00Z","labels":[]}]'
-                }
-                if ($ghArgs -contains 'triage') {
-                    $global:LASTEXITCODE = 0
-                    return '[]'
                 }
                 # open scan fallthrough — 2 items, below limit, open guard won't fire
                 $global:LASTEXITCODE = 0
@@ -1365,13 +1363,10 @@ rounds:
 
         $tempSpecCeil2 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
         @'
-schema_version: 1
+schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-rounds:
-  - lane: main
-    round: 1
-    issues: [425, 571]
+umbrellas: [425, 571]
 '@ | Set-Content -Path $tempSpecCeil2 -Encoding UTF8
 
         try {
@@ -1380,7 +1375,7 @@ rounds:
                 -Because 'ceiling guard must throw with the truncated-RecentlyClosed message before gh issue edit is reached'
 
             $script:ScanReached | Should -BeTrue `
-                -Because 'gh stub must have been called before the ceiling guard fired — if false, function failed with ParameterBindingException instead'
+                -Because 'gh stub must have been called before the ceiling guard fired — if false, function failed before reaching the closed scan'
 
             $script:GhEditCallCount | Should -Be 0 `
                 -Because 'gh issue edit must never be reached when the closed ceiling guard fires'
@@ -1409,6 +1404,18 @@ rounds:
                 $global:LASTEXITCODE = 0
                 return
             }
+            if ($ghArgs -contains 'api') {
+                # Step-0 probe for tower #704 — return success so probe passes
+                $queryStr = $ghArgs | Where-Object { $_ -like 'query=*' } | Select-Object -Last 1
+                $issueNum = 0
+                if ($queryStr -match 'issue\(number:\s*(\d+)') { $issueNum = [int]$Matches[1] }
+                if ($issueNum -eq 704) {
+                    $global:LASTEXITCODE = 0
+                    return '{"data":{"repository":{"issue":{"parent":null,"subIssues":{"totalCount":0}}}}}'
+                }
+                $global:LASTEXITCODE = 1
+                return
+            }
             if ($ghArgs -contains 'list') {
                 if ($ghArgs -contains 'closed') {
                     $script:ScanReached = $true
@@ -1416,10 +1423,6 @@ rounds:
                     # Return exactly 1000 items — hits [Math]::Min(1500, 1000) = 1000
                     $rows = (1..1000 | ForEach-Object { "{`"number`":$_,`"title`":`"c$_`",`"closedAt`":`"2026-01-01T00:00:00Z`",`"labels`":[]}" }) -join ','
                     return "[$rows]"
-                }
-                if ($ghArgs -contains 'triage') {
-                    $global:LASTEXITCODE = 0
-                    return '[]'
                 }
                 # open scan fallthrough — return 1 item, well below issueScanLimit 1500
                 $global:LASTEXITCODE = 0
@@ -1430,13 +1433,10 @@ rounds:
 
         $tempSpecCeil4 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
         @'
-schema_version: 1
+schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-rounds:
-  - lane: main
-    round: 1
-    issues: [425, 571]
+umbrellas: [425, 571]
 '@ | Set-Content -Path $tempSpecCeil4 -Encoding UTF8
 
         try {
@@ -1462,15 +1462,85 @@ rounds:
         }
     }
 
-    It 'triage-ceiling-warns: triage scan at limit emits Write-Warning and render completes (warn-and-continue)' {
-        # RED driver for s2 fix: -issueScanLimit param does not exist yet, so
-        # calling it throws ParameterBindingException (unhandled, no try/catch) —
-        # Pester marks the test FAILED with ParameterBindingException.  Correct RED.
-        #
-        # GREEN (after s2): open/closed scans below limit, triage scan at limit fires
-        # Write-Warning (warn-and-continue, never throw), render completes, gh issue edit
-        # is called exactly once, and the captured warning stream contains at least one
-        # WarningRecord for the triage ceiling.
+    It 'no-triage-label-query: Invoke-PortfolioRender never calls gh with --label triage in v2 model' {
+        # v2 triage detection is derived from parent-edge data, not a label query.
+        # Assert that no gh call in the full pipeline uses --label triage.
+
+        $script:GhCallLog = [System.Collections.Generic.List[object]]::new()
+        $closedAt801 = (Get-Date).AddDays(-5).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+            $script:GhCallLog.Add([array]$ghArgs)
+
+            if ($ghArgs -contains 'edit') {
+                $global:LASTEXITCODE = 0
+                return
+            }
+
+            if ($ghArgs -contains 'view') {
+                $global:LASTEXITCODE = 0
+                return '{"body":"# Control Tower\n\nNo portfolio block yet."}'
+            }
+
+            if ($ghArgs -contains 'api') {
+                $queryStr = $ghArgs | Where-Object { $_ -like 'query=*' } | Select-Object -Last 1
+                $issueNum = 0
+                if ($queryStr -match 'issue\(number:\s*(\d+)') { $issueNum = [int]$Matches[1] }
+                if ($issueNum -eq 704) {
+                    $global:LASTEXITCODE = 0
+                    return '{"data":{"repository":{"issue":{"parent":null,"subIssues":{"totalCount":0}}}}}'
+                }
+                if ($issueNum -eq 425) {
+                    $global:LASTEXITCODE = 0
+                    return '{"data":{"repository":{"issue":{"number":425,"title":"Umbrella 425","state":"OPEN","closedAt":null,"createdAt":"2025-06-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":null,"subIssues":{"totalCount":0,"nodes":[]}}}}}'
+                }
+                # Any other leaf query
+                $global:LASTEXITCODE = 0
+                return "{`"data`":{`"repository`":{`"issue`":{`"number`":$issueNum,`"title`":`"t$issueNum`",`"state`":`"OPEN`",`"closedAt`":null,`"createdAt`":`"2026-01-01T00:00:00Z`",`"labels`":{`"totalCount`":0,`"nodes`":[]},`"blockedBy`":{`"totalCount`":0,`"nodes`":[]},`"parent`":null,`"subIssues`":{`"totalCount`":0}}}}}"
+            }
+
+            if ($ghArgs -contains 'list') {
+                if ($ghArgs -contains 'closed') {
+                    $global:LASTEXITCODE = 0
+                    return "[{`"number`":801,`"title`":`"Closed 801`",`"closedAt`":`"$closedAt801`",`"labels`":[]}]"
+                }
+                # open scan
+                $global:LASTEXITCODE = 0
+                return '[{"number":425,"title":"Umbrella 425","labels":[],"createdAt":"2025-06-01T00:00:00Z"}]'
+            }
+
+            $global:LASTEXITCODE = 0
+        }
+
+        $tempSpecNoTriage = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        @'
+schema_version: 2
+control_tower: 704
+recently_closed_days: 14
+umbrellas: [425]
+'@ | Set-Content -Path $tempSpecNoTriage -Encoding UTF8
+
+        try {
+            try { Invoke-PortfolioRender -specPath $tempSpecNoTriage } catch { }
+
+            $labelTriageCalls = @($script:GhCallLog | Where-Object {
+                $call = $_
+                ($call -contains '--label' -and $call -contains 'triage') -or
+                ($call -contains '-label' -and $call -contains 'triage')
+            })
+            $labelTriageCalls.Count | Should -Be 0 `
+                -Because 'v2 model derives triage from parent-edge data; gh must never be called with --label triage'
+        }
+        finally {
+            if (Test-Path $tempSpecNoTriage) { Remove-Item $tempSpecNoTriage -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'step0-probe-fail-loud: Invoke-PortfolioRender exits before write when GraphQL parent field is unavailable' {
+        # v2 triage/drift model requires parent + subIssues GraphQL fields.
+        # If the Step-0 probe returns a GraphQL error for these fields, the pipeline must
+        # halt with a loud error before gh issue edit is ever called.
 
         $script:GhEditCallCount = 0
 
@@ -1483,68 +1553,41 @@ rounds:
                 return
             }
 
-            if ($ghArgs -contains 'view') {
+            if ($ghArgs -contains 'api') {
+                # GraphQL field error: parent field doesn't exist on Issue type
                 $global:LASTEXITCODE = 0
-                return '{"body":"# Control Tower\n\nNo portfolio block yet."}'
+                return '{"errors":[{"message":"Field parent doesn t exist on type Issue"}]}'
             }
 
             if ($ghArgs -contains 'list') {
-                if ($ghArgs -contains 'closed') {
-                    # 1 item — below limit, closed guard won't fire
-                    $global:LASTEXITCODE = 0
-                    return '[{"number":10,"title":"c1","closedAt":"2026-01-01T00:00:00Z","labels":[]}]'
-                }
-                if ($ghArgs -contains 'triage') {
-                    # 3 items — exactly at limit, triage ceiling fires Write-Warning
-                    $global:LASTEXITCODE = 0
-                    return '[{"number":1},{"number":2},{"number":3}]'
-                }
-                # open scan fallthrough — 1 item, below limit, open guard won't fire
                 $global:LASTEXITCODE = 0
-                return '[{"number":425,"title":"Umbrella 425","labels":[],"createdAt":"2025-06-01T00:00:00Z"}]'
-            }
-
-            if ($ghArgs -contains 'api') {
-                $queryStr = $ghArgs | Where-Object { $_ -like 'query=*' } | Select-Object -Last 1
-                $issueNum = 0
-                if ($queryStr -match 'issue\(number:\s*(\d+)') { $issueNum = [int]$Matches[1] }
-                $global:LASTEXITCODE = 0
-                return "{`"data`":{`"repository`":{`"issue`":{`"number`":$issueNum,`"title`":`"t$issueNum`",`"state`":`"OPEN`",`"closedAt`":null,`"createdAt`":`"2026-01-01T00:00:00Z`",`"labels`":{`"totalCount`":0,`"nodes`":[]},`"blockedBy`":{`"totalCount`":0,`"nodes`":[]},`"subIssues`":{`"nodes`":[]}}}}}"
+                return '[]'
             }
 
             $global:LASTEXITCODE = 0
         }
 
-        $tempSpecCeil3 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        $tempSpecProbe = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
         @'
-schema_version: 1
+schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-rounds:
-  - lane: main
-    round: 1
-    issues: [425, 571]
-'@ | Set-Content -Path $tempSpecCeil3 -Encoding UTF8
+umbrellas: [425, 571]
+'@ | Set-Content -Path $tempSpecProbe -Encoding UTF8
 
         try {
-            # NO try/catch: in RED state ParameterBindingException is unhandled
-            # and Pester marks the test FAILED — correct RED failure mode.
-            # In GREEN state the function completes (warn-and-continue) and
-            # warnings are captured via the 3>&1 stream redirect.
-            $captured = Invoke-PortfolioRender -specPath $tempSpecCeil3 -issueScanLimit 3 3>&1
+            try {
+                Invoke-PortfolioRender -specPath $tempSpecProbe
+            }
+            catch {
+                # Expected: probe fires Write-Error -ErrorAction Stop; swallow here.
+            }
 
-            $warnings = @($captured | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
-            $warnings.Count | Should -BeGreaterThan 0 `
-                -Because 'triage ceiling must emit Write-Warning when triage scan returns count >= issueScanLimit'
-
-            $warnings[0].Message | Should -Match 'returned 3 results' `
-                -Because 'the captured warning must be the triage ceiling warning (count/limit included), not a parse or exit-code warning'
-
-            $script:GhEditCallCount | Should -Be 1 `
-                -Because 'render must complete with exactly one control-tower write (warn-and-continue, not abort)'
+            $script:GhEditCallCount | Should -Be 0 `
+                -Because 'Step-0 probe must halt before gh issue edit when GraphQL parent/subIssues fields are unavailable'
         }
         finally {
-            if (Test-Path $tempSpecCeil3) { Remove-Item $tempSpecCeil3 -Force -ErrorAction SilentlyContinue }
+            if (Test-Path $tempSpecProbe) { Remove-Item $tempSpecProbe -Force -ErrorAction SilentlyContinue }
         }
     }
 }

--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -35,19 +35,32 @@ BeforeAll {
 
 # ---------------------------------------------------------------------------
 # Helper: build a minimal valid flat-YAML sequence spec string
+# v2 default: schema_version 2 with umbrellas inline list.
+# Legacy path: when $LegacyRoundsBlock is provided, emit schema_version 1 +
+# rounds block so surviving v1-format tests can still exercise old structure.
 # ---------------------------------------------------------------------------
 function New-ValidSpecYaml {
     param(
-        [int]   $SchemaVersion      = 1,
-        [int]   $ControlTower       = 704,
-        [int]   $RecentlyClosedDays = 14,
-        [string]$RoundsBlock        = "rounds:`n  - lane: main`n    round: 1`n    issues: [425, 571]"
+        [int]    $SchemaVersion      = 2,
+        [int]    $ControlTower       = 704,
+        [int]    $RecentlyClosedDays = 14,
+        [int[]]  $Umbrellas          = @(476, 571),
+        [string] $LegacyRoundsBlock  = $null
     )
+    if (-not [string]::IsNullOrEmpty($LegacyRoundsBlock)) {
+        return @"
+schema_version: 1
+control_tower: $ControlTower
+recently_closed_days: $RecentlyClosedDays
+$LegacyRoundsBlock
+"@
+    }
+    $umbrellaList = $Umbrellas -join ', '
     return @"
 schema_version: $SchemaVersion
 control_tower: $ControlTower
 recently_closed_days: $RecentlyClosedDays
-$RoundsBlock
+umbrellas: [$umbrellaList]
 "@
 }
 
@@ -55,17 +68,20 @@ $RoundsBlock
 # Helper: build a minimal issue-state object (mimics gh GraphQL response shape)
 # Extended in #720 s1: added CreatedAt (for AC3 createdAt-desc ordering) and
 # Labels extended to support 'in progress' simulation (AC3/AC10 inProgress tag).
+# Extended in #753 s1: added Parent and SubIssues for s2/s3 downstream tests.
 # ---------------------------------------------------------------------------
 function New-IssueState {
     param(
-        [int]     $Number,
-        [string]  $State        = 'OPEN',
-        [string[]]$Labels       = @(),
-        [int[]]   $BlockedBy    = @(),
-        [bool]    $BlockerInPlan = $true,
-        [string]  $Title        = "Issue $Number",
-        [string]  $ClosedAt     = $null,
-        [string]  $CreatedAt    = '2025-01-01T00:00:00Z'
+        [int]       $Number,
+        [string]    $State        = 'OPEN',
+        [string[]]  $Labels       = @(),
+        [int[]]     $BlockedBy    = @(),
+        [bool]      $BlockerInPlan = $true,
+        [string]    $Title        = "Issue $Number",
+        [string]    $ClosedAt     = $null,
+        [string]    $CreatedAt    = '2025-01-01T00:00:00Z',
+        [hashtable] $Parent       = $null,
+        [hashtable] $SubIssues    = $null
     )
     return [PSCustomObject]@{
         number        = $Number
@@ -77,6 +93,8 @@ function New-IssueState {
         closedAt      = $ClosedAt
         createdAt     = $CreatedAt
         totalCount    = 1  # default rendered count = totalCount (no overflow)
+        parent        = $Parent
+        subIssues     = $SubIssues
     }
 }
 
@@ -84,37 +102,140 @@ function New-IssueState {
 Describe 'ConvertFrom-SequenceSpec' {
 # ===========================================================================
 
-    It 'parses a valid flat schema and returns correct structure' {
+    It 'parses v2 schema with umbrellas: inline list' {
         $yaml = New-ValidSpecYaml
         $spec = ConvertFrom-SequenceSpec -yamlText $yaml
 
         $spec                        | Should -Not -BeNullOrEmpty
-        $spec.schema_version         | Should -Be 1
+        $spec.schema_version         | Should -Be 2
         $spec.control_tower          | Should -Be 704
         $spec.control_tower.GetType().Name | Should -Match 'Int'  # must be integer, not string
         $spec.recently_closed_days   | Should -Be 14
-        $spec.rounds                 | Should -HaveCount 1
-        $spec.rounds[0].lane         | Should -Be 'main'
-        $spec.rounds[0].round        | Should -Be 1
-        $spec.rounds[0].issues       | Should -Contain 425
-        $spec.rounds[0].issues       | Should -Contain 571
+        $spec.umbrellas              | Should -Not -BeNullOrEmpty
+        $spec.umbrellas              | Should -Contain 476
+        $spec.umbrellas              | Should -Contain 571
     }
 
-    It 'rejects block-style issues list and returns null' {
-        # Block-style issues list is a schema violation per the Renderer Contract
-        $blockStyleYaml = @"
+    It 'returns umbrellas as ordered int array matching YAML order' {
+        $yaml = New-ValidSpecYaml -Umbrellas @(476, 571, 674, 662, 343, 693, 732)
+        $spec = ConvertFrom-SequenceSpec -yamlText $yaml
+
+        $spec.umbrellas              | Should -HaveCount 7
+        $spec.umbrellas[0]           | Should -Be 476
+        $spec.umbrellas[1]           | Should -Be 571
+        $spec.umbrellas[2]           | Should -Be 674
+        $spec.umbrellas[3]           | Should -Be 662
+        $spec.umbrellas[4]           | Should -Be 343
+        $spec.umbrellas[5]           | Should -Be 693
+        $spec.umbrellas[6]           | Should -Be 732
+    }
+
+    It 'rejects schema_version 1 with descriptive error' {
+        $yaml = @"
 schema_version: 1
 control_tower: 704
 recently_closed_days: 14
 rounds:
   - lane: main
     round: 1
-    issues:
-      - 425
-      - 571
+    issues: [425, 571]
 "@
-        $result = ConvertFrom-SequenceSpec -yamlText $blockStyleYaml
-        $result | Should -BeNullOrEmpty
+        $result = ConvertFrom-SequenceSpec -yamlText $yaml 2>&1 | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }
+        # The function writes an error and returns $null
+        $result = ConvertFrom-SequenceSpec -yamlText $yaml -ErrorAction SilentlyContinue
+        $result | Should -BeNullOrEmpty -Because 'schema_version 1 is no longer supported'
+    }
+
+    It 'rejects block-style umbrellas list' {
+        $blockStyleYaml = @"
+schema_version: 2
+control_tower: 704
+recently_closed_days: 14
+umbrellas:
+  - 476
+  - 571
+"@
+        $result = ConvertFrom-SequenceSpec -yamlText $blockStyleYaml -ErrorAction SilentlyContinue
+        $result | Should -BeNullOrEmpty -Because 'block-style umbrellas list is a schema violation'
+    }
+
+    It 'rejects quoted numbers in umbrellas list' {
+        $quotedYaml = @"
+schema_version: 2
+control_tower: 704
+recently_closed_days: 14
+umbrellas: ["476", 571]
+"@
+        $result = ConvertFrom-SequenceSpec -yamlText $quotedYaml -ErrorAction SilentlyContinue
+        $result | Should -BeNullOrEmpty -Because 'quoted numbers in umbrellas list are not permitted'
+    }
+
+    It 'rejects empty umbrellas list' {
+        $emptyYaml = @"
+schema_version: 2
+control_tower: 704
+recently_closed_days: 14
+umbrellas: []
+"@
+        $result = ConvertFrom-SequenceSpec -yamlText $emptyYaml -ErrorAction SilentlyContinue
+        $result | Should -BeNullOrEmpty -Because 'empty umbrellas list must be rejected'
+    }
+
+    It 'rejects duplicate umbrella entries' {
+        $dupYaml = @"
+schema_version: 2
+control_tower: 704
+recently_closed_days: 14
+umbrellas: [476, 571, 476]
+"@
+        $result = ConvertFrom-SequenceSpec -yamlText $dupYaml -ErrorAction SilentlyContinue
+        $result | Should -BeNullOrEmpty -Because 'duplicate entries in umbrellas list must be rejected'
+    }
+
+    It 'rejects stray rounds: key in a v2 doc' {
+        $strayYaml = @"
+schema_version: 2
+control_tower: 704
+recently_closed_days: 14
+umbrellas: [476, 571]
+rounds:
+  - lane: main
+    round: 1
+    issues: [476]
+"@
+        $result = ConvertFrom-SequenceSpec -yamlText $strayYaml -ErrorAction SilentlyContinue
+        $result | Should -BeNullOrEmpty -Because "stray 'rounds:' key in a v2 doc must be rejected"
+    }
+
+    It 'rejects missing umbrellas: key' {
+        $noUmbrellasYaml = @"
+schema_version: 2
+control_tower: 704
+recently_closed_days: 14
+"@
+        $result = ConvertFrom-SequenceSpec -yamlText $noUmbrellasYaml -ErrorAction SilentlyContinue
+        $result | Should -BeNullOrEmpty -Because "missing 'umbrellas:' key must be rejected"
+    }
+
+    It 'returns null when control_tower is quoted' {
+        $yaml = @"
+schema_version: 2
+control_tower: "704"
+recently_closed_days: 14
+umbrellas: [476, 571]
+"@
+        $result = ConvertFrom-SequenceSpec -yamlText $yaml -ErrorAction SilentlyContinue
+        $result | Should -BeNullOrEmpty -Because 'quoted control_tower must be rejected'
+    }
+
+    It 'returns null when control_tower is absent' {
+        $yaml = @"
+schema_version: 2
+recently_closed_days: 14
+umbrellas: [476, 571]
+"@
+        $result = ConvertFrom-SequenceSpec -yamlText $yaml -ErrorAction SilentlyContinue
+        $result | Should -BeNullOrEmpty -Because 'absent control_tower must be rejected'
     }
 
     It 'returns null on malformed YAML input' {
@@ -178,7 +299,7 @@ Describe 'Get-PortfolioBuckets' {
         # #100 is a round-1 umbrella (blocked) → Now is empty; #100 lands in Blocked.
         # #200 is a round-2 umbrella (unblocked) → excluded from Next because umbrellas are not work items.
         # Spine leaf children of #200 would appear in Next, but none are provided here.
-        $twoRoundSpec = ConvertFrom-SequenceSpec (New-ValidSpecYaml -RoundsBlock @'
+        $twoRoundSpec = ConvertFrom-SequenceSpec (New-ValidSpecYaml -LegacyRoundsBlock @'
 rounds:
   - lane: main
     round: 1
@@ -226,20 +347,6 @@ rounds:
         $blockedEntry | Should -Not -BeNullOrEmpty
         $blockedEntry.blockerAnnotations | Should -Match 'blocked by #571(?!\s*\(out of plan\))' -Because 'an in-plan blocker must not be tagged out of plan'
         $blockedEntry.blockerAnnotations | Should -Match 'blocked by #999 \(out of plan\)' -Because 'an out-of-plan blocker must be tagged'
-    }
-
-    It 'throws on a multi-lane spec rather than silently merging lanes (CR8)' {
-        $multiLaneSpec = ConvertFrom-SequenceSpec (New-ValidSpecYaml -RoundsBlock @'
-rounds:
-  - lane: main
-    round: 1
-    issues: [100]
-  - lane: side
-    round: 1
-    issues: [200]
-'@)
-        { Get-PortfolioBuckets -spec $multiLaneSpec -issueStateObjects @() } |
-            Should -Throw -ExpectedMessage '*Multi-lane*' -Because 'per-lane derivation is unimplemented; merging lanes silently is the failure mode the tracker exists to kill'
     }
 
     It 'puts closed issues in Recently Closed only, not in Now or Next' {
@@ -362,7 +469,7 @@ rounds:
         # Umbrella #476 is in round 2 (non-active: round 1 [425,571] is active).
         # Child issue 900 is in the known-child-set of #476 → appears in Next, not Now, not float.
         # RED: child-set Next placement not yet implemented.
-        $threeRoundSpec = ConvertFrom-SequenceSpec (New-ValidSpecYaml -RoundsBlock @'
+        $threeRoundSpec = ConvertFrom-SequenceSpec (New-ValidSpecYaml -LegacyRoundsBlock @'
 rounds:
   - lane: main
     round: 1

--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -2,17 +2,16 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
-    RED Pester v5 suite for render-portfolio.ps1 (issue #692, slice s3; extended for #720, slice s1).
+    Pester v5 suite for render-portfolio.ps1 (v2 schema; issue #692 s3, #720 s1, #753 s1-s4).
 
 .DESCRIPTION
     Hoisted Renderer Contract tests covering:
       - ConvertFrom-SequenceSpec  : parse, schema validation, fail-open on bad input
-      - Get-PortfolioBuckets      : bucket placement, blocked logic, triage, recently closed,
-                                    float detection (sub-issue-set inversion), createdAt ordering,
-                                    dedup (spine wins), CoverageGaps
-      - Format-PortfolioMarkdown  : footer (new label), section order, pagination overflow,
-                                    single ranked Now list, (unsequenced)/(in progress) tags,
-                                    cap-floor N=15 (+M more), recently-closed repo-wide section
+      - Get-PortfolioBuckets      : v2 bucket placement (ActiveUmbrella, ActiveChildren,
+                                    RankedUmbrellas, Triage, RecentlyClosed, DriftWarnings,
+                                    IntegrityWarnings), createdAt ordering, priority-label sort
+      - Format-PortfolioMarkdown  : v2 three-zone layout (Active / Umbrellas ranked / Triage /
+                                    Recently closed), footer label, pagination overflow, warnings
       - Get-SplicedBody           : marker splice, idempotency, migration fixture (old→new label)
       - Order independence        : createdAt-desc ordering with priority-label tiebreak (AC3)
       - Invoke-PortfolioRender    : hard-exit guard — gh issue edit NOT called on scan failure (AC8)
@@ -23,8 +22,6 @@
       - Deterministic sort keys
       - No live gh CLI calls
       - No Sort-Object number in fixture ordering assertions (AC3: producer owns order)
-
-    Tests added in #720 s1 are RED until s2/s3/s4 implement production behavior.
 #>
 
 BeforeAll {
@@ -37,7 +34,7 @@ BeforeAll {
 # Helper: build a minimal valid flat-YAML sequence spec string
 # v2 default: schema_version 2 with umbrellas inline list.
 # Legacy path: when $LegacyRoundsBlock is provided, emit schema_version 1 +
-# rounds block so surviving v1-format tests can still exercise old structure.
+# rounds block so the v1-rejection tests can exercise the invalid-schema path.
 # ---------------------------------------------------------------------------
 function New-ValidSpecYaml {
     param(
@@ -66,9 +63,8 @@ umbrellas: [$umbrellaList]
 
 # ---------------------------------------------------------------------------
 # Helper: build a minimal issue-state object (mimics gh GraphQL response shape)
-# Extended in #720 s1: added CreatedAt (for AC3 createdAt-desc ordering) and
-# Labels extended to support 'in progress' simulation (AC3/AC10 inProgress tag).
-# Extended in #753 s1: added Parent and SubIssues for s2/s3 downstream tests.
+# Extended in #720 s1: added CreatedAt (for AC3 createdAt-desc ordering).
+# Extended in #753 s1: added Parent and SubIssues for v2 bucket classification.
 # ---------------------------------------------------------------------------
 function New-IssueState {
     param(
@@ -582,9 +578,8 @@ Describe 'Format-PortfolioMarkdown' {
         $script:SimpleBuckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues
     }
 
-    It "includes footer with new label 'portfolio content unchanged since ...'" {
-        # AC: footer label updated from 'as of' to 'portfolio content unchanged since' (#720 s1)
-        # RED until s2/s3 update Format-PortfolioMarkdown to write the new footer label.
+    It "includes footer with label 'portfolio content unchanged since ...'" {
+        # AC: footer label is 'portfolio content unchanged since' (updated from 'as of' in #720 s1)
         $timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
         $output = Format-PortfolioMarkdown -bucketModel $script:SimpleBuckets -timestamp $timestamp
 
@@ -627,33 +622,28 @@ Describe 'Format-PortfolioMarkdown' {
         $output | Should -Match '\(\+50 more\)' -Because 'TriageResidualCount=50 must appear as (+50 more) in Triage section (v2 pagination)'
     }
 
-    It 'Now ordering tiebreaker: lower-numbered float precedes higher-numbered float (AC3/F18)' {
-        # Two floats with no createdAt and no priority labels — the number-asc tiebreaker
-        # (last key in the Sort-Object in Get-PortfolioBuckets) must put #800 before #801.
-        # Uses floats rather than umbrellas: AC1 forbids umbrellas from appearing in Now.
+    It 'Triage ordering tiebreaker: lower-numbered issue precedes higher-numbered when priority and createdAt are equal (AC6/F18)' {
+        # Two triage candidates with no createdAt and no priority labels — the number-asc
+        # tiebreaker (last key in Sort-Object in Get-PortfolioBuckets) must put #800 before #801.
+        # #425 and #571 are listed umbrellas (excluded from Triage by the umbrella-set filter).
         $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
         $issues = @(
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @())  # active-round umbrella (excluded by AC1)
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @())  # active-round umbrella (excluded by AC1)
-            (New-IssueState -Number 801  -State 'OPEN' -BlockedBy @())  # float (no KnownChildSet entry)
-            (New-IssueState -Number 800  -State 'OPEN' -BlockedBy @())  # float (lower number — must sort first)
+            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @())  # listed umbrella — excluded from Triage
+            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @())  # listed umbrella — excluded from Triage
+            (New-IssueState -Number 801  -State 'OPEN' -BlockedBy @())  # triage candidate (higher number)
+            (New-IssueState -Number 800  -State 'OPEN' -BlockedBy @())  # triage candidate (lower number — must sort first)
         )
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues -KnownChildSet @()
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues
         $timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 
         $output = Format-PortfolioMarkdown -bucketModel $buckets -timestamp $timestamp
 
         $pos800 = $output.IndexOf('#800')
         $pos801 = $output.IndexOf('#801')
-        $pos800 | Should -BeGreaterThan -1  -Because '#800 float must appear in output'
-        $pos801 | Should -BeGreaterThan -1  -Because '#801 float must appear in output'
-        $pos800 | Should -BeLessThan $pos801 -Because 'lower-numbered float (#800) must precede higher-numbered float (#801) as number-asc tiebreaker (AC3)'
+        $pos800 | Should -BeGreaterThan -1  -Because '#800 must appear in Triage output'
+        $pos801 | Should -BeGreaterThan -1  -Because '#801 must appear in Triage output'
+        $pos800 | Should -BeLessThan $pos801 -Because 'lower-numbered issue (#800) must precede higher-numbered issue (#801) as number-asc tiebreaker (AC6)'
     }
-
-    # -----------------------------------------------------------------------
-    # NEW fixtures for #720 s1 (AC3, AC9, AC10)
-    # All RED until s2/s3 implement single ranked list, tags, and cap-floor.
-    # -----------------------------------------------------------------------
 
     It 'v2-umbrellas-spec-order-preserved: Umbrellas section preserves spec list order — no re-sort by number (AC5)' {
         # v2: Umbrellas (ranked) section must preserve spec list order verbatim.
@@ -762,27 +752,22 @@ Describe 'Format-PortfolioMarkdown' {
         $output | Should -Match '\*\(no' -Because 'null ActiveUmbrella must show a labeled empty state in Active section'
     }
 
-    It 'repo-wide recently-closed section shows all leaf closures in window (AC9)' {
-        # AC9: RecentlyClosed shows repo-wide leaf closures within recently_closed_days window.
-        # This test verifies the formatter renders the RecentlyClosed section from the model.
-        # RED until Format-PortfolioMarkdown is updated to render repo-wide closures (not
-        # just sequence-filtered closures).
+    It 'repo-wide recently-closed section shows all closures in window (AC9)' {
+        # AC9: RecentlyClosed shows repo-wide closures within recently_closed_days window.
+        # Verifies the formatter renders the RecentlyClosed section from the v2 bucket model.
         $recentlyClosed = @(
-            [PSCustomObject]@{ number = 700; title = 'Closed Issue 700'; isFloat = $false; inProgress = $false }
-            [PSCustomObject]@{ number = 701; title = 'Closed Issue 701'; isFloat = $false; inProgress = $false }
+            [PSCustomObject]@{ number = 700; title = 'Closed Issue 700' }
+            [PSCustomObject]@{ number = 701; title = 'Closed Issue 701' }
         )
         $bucketModel = [PSCustomObject]@{
-            Now                      = @()
-            NowTotalCount            = 0
-            Next                     = @()
-            NextTotalCount           = 0
-            Blocked                  = @()
-            BlockedTotalCount        = 0
-            RecentlyClosed           = $recentlyClosed
-            RecentlyClosedTotalCount = 2
-            Triage                   = @()
-            TriageTotalCount         = 0
-            CoverageGaps             = @()
+            ActiveUmbrella      = $null
+            ActiveChildren      = @()
+            RankedUmbrellas     = @()
+            Triage              = @()
+            TriageResidualCount = 0
+            DriftWarnings       = @()
+            IntegrityWarnings   = @()
+            RecentlyClosed      = $recentlyClosed
         }
         $timestamp = '2026-06-25T00:00:00Z'
 
@@ -800,7 +785,7 @@ Describe 'Get-SplicedBody' {
     BeforeAll {
         $script:BeginMarker = '<!-- portfolio-tracker:begin -->'
         $script:EndMarker   = '<!-- portfolio-tracker:end -->'
-        # Updated to new footer label in #720 s1 (RED until s2/s3 update Format-PortfolioMarkdown).
+        # Footer label updated in #720 s1: 'portfolio content unchanged since ...'
         $script:ContentBlock = @"
 $($script:BeginMarker)
 ## Now
@@ -825,7 +810,6 @@ $($script:EndMarker)
     It 'replaces content strictly between markers, preserving outside content' {
         $beforeText = 'BEFORE MARKER CONTENT'
         $afterText  = 'AFTER MARKER CONTENT'
-        # Updated to new footer label in #720 s1.
         $oldContent = "$($script:BeginMarker)`nold content`nportfolio content unchanged since 2026-01-01T00:00:00Z — rendered by render-portfolio.ps1`n$($script:EndMarker)"
         $existingBody = "$beforeText`n$oldContent`n$afterText"
 
@@ -849,11 +833,9 @@ $($script:EndMarker)
         $result | Should -BeNullOrEmpty -Because 'identical content after timestamp-strip must return null to prevent a no-op write'
     }
 
-    It 'returns null when only timestamp differs — idempotent (new footer label)' {
-        # Updated to new footer label in #720 s1.
-        # RED until s2/s3 update Get-SplicedBody footer strip pattern to match new label.
-        # The idempotency strip rule must recognize 'portfolio content unchanged since {ts}'
-        # just as it currently recognizes 'as of {ts}'.
+    It 'returns null when only timestamp differs — idempotent (footer label)' {
+        # The idempotency strip rule recognizes 'portfolio content unchanged since {ts}'
+        # and returns null when only the timestamp differs.
         $oldTimestampBlock = @"
 $($script:BeginMarker)
 ## Now
@@ -884,7 +866,6 @@ $($script:EndMarker)
         # new render uses 'portfolio content unchanged since' label.
         # The label change is a semantic content change → Get-SplicedBody must return
         # a non-null body (trigger exactly one write), not null (idempotent skip).
-        # RED until s2/s3 update Get-SplicedBody to detect label-change as content change.
         $oldLabelBlock = @"
 $($script:BeginMarker)
 ## Now
@@ -1174,9 +1155,8 @@ Describe 'Format-PortfolioMarkdown v2' {
 # ===========================================================================
 Describe 'Invoke-PortfolioRender' {
 # ===========================================================================
-# Net-new Describe block for #720 s1 (AC8).
-# All tests in this block are RED until s2/s3 implement Invoke-PortfolioRender
-# with the hard-exit-before-write guard on scan failure.
+# Tests for Invoke-PortfolioRender (added in #720 s1 / #753 s1-s4).
+# Covers: Step-0 probe, hard-exit guard, v2 full pipeline, ceiling guards.
 #
 # Stub strategy: define a PowerShell function named `gh` that shadows the
 # external `gh` executable within this test's scope chain.  PowerShell

--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -260,352 +260,311 @@ rounds:
 }
 
 # ===========================================================================
-Describe 'Get-PortfolioBuckets' {
+# Get-PortfolioBuckets v1 tests RETIRED (s2 of #753)
+# These tests referenced v1 model properties (.Now, .Next, .Blocked,
+# .CoverageGaps, isFloat, blockerAnnotations, KnownChildSet) which no
+# longer exist in the v2 implementation. Replaced by 'Get-PortfolioBuckets v2'
+# Describe block below.
 # ===========================================================================
 
-    It 'puts spine leaf children of active-round umbrellas in Now; umbrellas are excluded (AC1/CR-2)' {
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $issues = @(
-            (New-IssueState -Number 425 -State 'OPEN' -BlockedBy @())   # active-round umbrella
-            (New-IssueState -Number 571 -State 'OPEN' -BlockedBy @())   # active-round umbrella
-            (New-IssueState -Number 900 -State 'OPEN' -BlockedBy @())   # spine leaf (child of #425)
-        )
-        $knownChildSet = @([PSCustomObject]@{ number = 900; RoundIndex = 0; UmbrellaNumber = 425 })
+# ===========================================================================
+Describe 'Get-PortfolioBuckets v2' {
+# ===========================================================================
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues -KnownChildSet $knownChildSet
+    It 'ActiveUmbrella is first OPEN umbrella in list order (AC3)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella571 = New-IssueState -Number 571 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
 
-        $buckets.Now | Should -Not -BeNullOrEmpty
-        $buckets.Now.number | Should -Contain 900 -Because 'spine leaf child of active-round umbrella must appear in Now'
-        $buckets.Now.number | Should -Not -Contain 425 -Because 'umbrellas must not appear as work items in Now (AC1)'
-        $buckets.Now.number | Should -Not -Contain 571 -Because 'umbrellas must not appear as work items in Now (AC1)'
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $umbrella571)
+
+        $buckets.ActiveUmbrella | Should -Not -BeNullOrEmpty -Because 'first OPEN umbrella must be the ActiveUmbrella'
+        $buckets.ActiveUmbrella.number | Should -Be 476 -Because '#476 is first in spec list and OPEN → ActiveUmbrella'
     }
 
-    It 'returns empty Now when all issues in lowest round are blocked' {
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        # Both round-1 issues are blocked — Now should be empty (honest stuck signal)
-        $issues = @(
-            (New-IssueState -Number 425 -State 'OPEN' -BlockedBy @(999))
-            (New-IssueState -Number 571 -State 'OPEN' -BlockedBy @(998))
-        )
+    It 'skips CLOSED listed umbrella for ActiveUmbrella and emits DriftWarning (AC3)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $umbrella476 = New-IssueState -Number 476 -State 'CLOSED' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella571 = New-IssueState -Number 571 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $umbrella571)
 
-        $buckets.Now | Should -BeNullOrEmpty -Because 'all round-1 issues are blocked; Now must be empty to signal an honest stuck state'
+        $buckets.ActiveUmbrella.number | Should -Be 571 -Because '#476 is CLOSED → skip; #571 is OPEN → ActiveUmbrella'
+        $buckets.DriftWarnings | Should -Contain '⚠️ listed umbrella #476 is closed' `
+            -Because 'a CLOSED listed umbrella must emit a DriftWarning (AC3)'
     }
 
-    It 'holds empty Now when lowest round is all-blocked; round-2 umbrella excluded from Next (AC1/CR-2)' {
-        # Two-round spec: round 1 all-blocked, round 2 unblocked.
-        # CR-2: umbrellas are containers only — they do not appear as work items in Now or Next.
-        # #100 is a round-1 umbrella (blocked) → Now is empty; #100 lands in Blocked.
-        # #200 is a round-2 umbrella (unblocked) → excluded from Next because umbrellas are not work items.
-        # Spine leaf children of #200 would appear in Next, but none are provided here.
-        $twoRoundSpec = ConvertFrom-SequenceSpec (New-ValidSpecYaml -LegacyRoundsBlock @'
-rounds:
-  - lane: main
-    round: 1
-    issues: [100]
-  - lane: main
-    round: 2
-    issues: [200]
-'@)
-        $issues = @(
-            (New-IssueState -Number 100 -BlockedBy @(999)),   # round 1 umbrella, blocked
-            (New-IssueState -Number 200)                       # round 2 umbrella, unblocked — but excluded from Next (AC1)
-        )
-        $result = Get-PortfolioBuckets -spec $twoRoundSpec -issueStateObjects $issues
-        $result.Now   | Should -BeNullOrEmpty -Because 'round 1 is all-blocked; Now must be empty (honest stuck signal)'
-        $result.Blocked | Select-Object -ExpandProperty number | Should -Contain 100
-        $result.Next  | Should -BeNullOrEmpty -Because 'round-2 umbrella is a container only — not a work item in Next (AC1/CR-2)'
+    It 'ActiveUmbrella is null when all listed umbrellas are closed (AC3)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $umbrella476 = New-IssueState -Number 476 -State 'CLOSED' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella571 = New-IssueState -Number 571 -State 'CLOSED' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $umbrella571)
+
+        $buckets.ActiveUmbrella | Should -BeNullOrEmpty -Because 'no OPEN listed umbrella → ActiveUmbrella must be null'
     }
 
-    It "puts out-of-plan blockers in annotation format 'blocked by #N (out of plan)'" {
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        # Blocker 999 is not in sequence.yaml → out-of-plan
-        $issues = @(
-            (New-IssueState -Number 425 -State 'OPEN' -BlockedBy @(999) -BlockerInPlan $false)
-        )
+    It 'ActiveChildren are open direct children of active umbrella in priority→recency→number order (AC4)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $child900 = New-IssueState -Number 900 -State 'OPEN' -CreatedAt '2025-06-01T00:00:00Z' `
+            -Parent @{ number = 476 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $child901 = New-IssueState -Number 901 -State 'OPEN' -CreatedAt '2025-01-01T00:00:00Z' `
+            -Parent @{ number = 476 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 2
+                nodes = @(
+                    @{ number = 900; state = 'OPEN' },
+                    @{ number = 901; state = 'OPEN' }
+                )
+            }
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $child900, $child901)
 
-        $blockedEntry = $buckets.Blocked | Where-Object { $_.number -eq 425 }
-        $blockedEntry           | Should -Not -BeNullOrEmpty
-        $blockedEntry.blockerAnnotations | Should -Match 'blocked by #999 \(out of plan\)'
+        $buckets.ActiveChildren | Should -Not -BeNullOrEmpty
+        $buckets.ActiveChildren.Count | Should -Be 2 -Because 'both open children must appear'
+        # 900 has newer createdAt → must appear before 901
+        $idx900 = [array]::IndexOf([object[]]$buckets.ActiveChildren, ($buckets.ActiveChildren | Where-Object { $_.number -eq 900 }))
+        $idx901 = [array]::IndexOf([object[]]$buckets.ActiveChildren, ($buckets.ActiveChildren | Where-Object { $_.number -eq 901 }))
+        $idx900 | Should -BeLessThan $idx901 -Because '#900 (newer createdAt) must rank before #901 (AC4 priority→recency→number)'
     }
 
-    It 'annotates each blocker independently when an issue mixes in-plan and out-of-plan blockers (CR7)' {
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        # 425 is blocked by 571 (in sequence.yaml → in plan) AND 999 (not in
-        # sequence.yaml → out of plan). Each blocker must be labeled on its own
-        # merits, not collapsed to one issue-level verdict.
-        $issues = @(
-            (New-IssueState -Number 425 -State 'OPEN' -BlockedBy @(571, 999))
-        )
+    It 'ActiveChildren have BlockedAnnotation when blockedBy non-empty (AC4)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $child900 = New-IssueState -Number 900 -State 'OPEN' -BlockedBy @(800, 801) `
+            -Parent @{ number = 476 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 1
+                nodes = @( @{ number = 900; state = 'OPEN' } )
+            }
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $child900)
 
-        $blockedEntry = $buckets.Blocked | Where-Object { $_.number -eq 425 }
-        $blockedEntry | Should -Not -BeNullOrEmpty
-        $blockedEntry.blockerAnnotations | Should -Match 'blocked by #571(?!\s*\(out of plan\))' -Because 'an in-plan blocker must not be tagged out of plan'
-        $blockedEntry.blockerAnnotations | Should -Match 'blocked by #999 \(out of plan\)' -Because 'an out-of-plan blocker must be tagged'
+        $childEntry = $buckets.ActiveChildren | Where-Object { $_.number -eq 900 }
+        $childEntry | Should -Not -BeNullOrEmpty
+        $childEntry.BlockedAnnotation | Should -Match '⛔ blocked by' -Because 'AC4: blocked child must have BlockedAnnotation'
+        $childEntry.BlockedAnnotation | Should -Match '#800' -Because 'blocker #800 must appear in annotation'
+        $childEntry.BlockedAnnotation | Should -Match '#801' -Because 'blocker #801 must appear in annotation'
     }
 
-    It 'puts closed issues in Recently Closed only, not in Now or Next' {
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $closedAt = (Get-Date).AddDays(-3).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-        $issues = @(
-            (New-IssueState -Number 425 -State 'CLOSED' -ClosedAt $closedAt)
-            (New-IssueState -Number 571 -State 'OPEN'   -BlockedBy @())
-        )
+    It 'ActiveChildren number-asc tiebreak is deterministic for byte-identical renders (AC4)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $sameDate = '2025-06-01T00:00:00Z'
+        $child900 = New-IssueState -Number 900 -State 'OPEN' -CreatedAt $sameDate `
+            -Parent @{ number = 476 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $child901 = New-IssueState -Number 901 -State 'OPEN' -CreatedAt $sameDate `
+            -Parent @{ number = 476 } -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 2
+                nodes = @(
+                    @{ number = 901; state = 'OPEN' },
+                    @{ number = 900; state = 'OPEN' }
+                )
+            }
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $child900, $child901)
 
-        # 425 is closed — must NOT appear in Now
-        if ($buckets.Now) {
-            $buckets.Now.number | Should -Not -Contain 425 -Because 'closed issues must not appear in Now'
-        }
-        # 425 must appear in Recently Closed
-        $buckets.RecentlyClosed | Should -Not -BeNullOrEmpty
-        $buckets.RecentlyClosed.number | Should -Contain 425
+        $idx900 = [array]::IndexOf([object[]]$buckets.ActiveChildren, ($buckets.ActiveChildren | Where-Object { $_.number -eq 900 }))
+        $idx901 = [array]::IndexOf([object[]]$buckets.ActiveChildren, ($buckets.ActiveChildren | Where-Object { $_.number -eq 901 }))
+        $idx900 | Should -BeLessThan $idx901 -Because 'number-asc tiebreak: #900 before #901 when priority and createdAt are equal (AC4)'
     }
 
-    It 'puts triage-labeled issues in Triage bucket' {
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        # Issue 300 has triage label but is NOT in any round
-        $issues = @(
-            (New-IssueState -Number 425 -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 300 -State 'OPEN' -Labels @('triage'))
-        )
+    It 'RankedUmbrellas contains all listed umbrellas in spec order (AC5)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella571 = New-IssueState -Number 571 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $umbrella571)
+
+        $buckets.RankedUmbrellas | Should -HaveCount 2
+        $buckets.RankedUmbrellas[0].Number | Should -Be 476 -Because 'first ranked umbrella must match first in spec list'
+        $buckets.RankedUmbrellas[1].Number | Should -Be 571 -Because 'second ranked umbrella must match second in spec list'
+    }
+
+    It 'RankedUmbrellas Done/Total counts direct children only (AC5)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 2
+                nodes = @(
+                    @{ number = 900; state = 'OPEN'   },
+                    @{ number = 901; state = 'CLOSED' }
+                )
+            }
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476)
+
+        $ranked476 = $buckets.RankedUmbrellas | Where-Object { $_.Number -eq 476 }
+        $ranked476 | Should -Not -BeNullOrEmpty
+        $ranked476.Total | Should -Be 2 -Because 'Total = count of direct child nodes (AC5)'
+        $ranked476.Done  | Should -Be 1 -Because 'Done = count of CLOSED direct child nodes (AC5)'
+        $ranked476.DoneTotalLabel | Should -Be '1/2' -Because 'DoneTotalLabel must be Done/Total'
+    }
+
+    It 'closed child counts as Done in RankedUmbrellas regardless of its own children (AC5)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        # Node 900 is a closed child-umbrella; its own sub-issues are irrelevant for Done count
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 2
+                nodes = @(
+                    @{ number = 900; state = 'CLOSED' },   # closed child-umbrella → counts as Done
+                    @{ number = 901; state = 'OPEN'   }
+                )
+            }
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476)
+
+        $ranked476 = $buckets.RankedUmbrellas | Where-Object { $_.Number -eq 476 }
+        $ranked476.Done | Should -Be 1 -Because 'CLOSED child-umbrella counts as Done; grandchildren are irrelevant (AC5)'
+    }
+
+    It 'zero-children umbrella shows "0/0 (no children linked)" in RankedUmbrellas (AC5)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476)
+
+        $ranked476 = $buckets.RankedUmbrellas | Where-Object { $_.Number -eq 476 }
+        $ranked476.DoneTotalLabel | Should -Be '0/0 (no children linked)' `
+            -Because 'zero-children umbrella must show the no-children-linked label (AC5)'
+    }
+
+    It 'Triage contains open∧parent-null∧totalCount-0∧not-in-list issues (AC6)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+        # Classic triage candidate: open, parent null, totalCount 0, not in umbrella list
+        $triageIssue = New-IssueState -Number 999 -State 'OPEN' -Parent $null `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $triageIssue)
 
         $buckets.Triage | Should -Not -BeNullOrEmpty
-        $buckets.Triage.number | Should -Contain 300
+        ($buckets.Triage | ForEach-Object { $_.number }) | Should -Contain 999 `
+            -Because 'open∧parent-null∧totalCount-0∧not-in-list → Triage (AC6)'
     }
 
-    It 'puts registered-but-unsequenced issues in Triage bucket' {
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        # Issue 999 is open but appears in no round in sequence.yaml
-        $issues = @(
-            (New-IssueState -Number 425 -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 999 -State 'OPEN' -Labels @())
-        )
-
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues
-
-        # 999 is not in any round → must land in Triage
-        $buckets.Triage | Should -Not -BeNullOrEmpty
-        $buckets.Triage.number | Should -Contain 999 -Because 'open issues not in any sequence round belong in Triage'
-    }
-
-    # -----------------------------------------------------------------------
-    # NEW fixtures for #720 s1 (AC4 float detection, AC2 Next placement,
-    # AC5 dedup, AC6 blocked float, AC3 createdAt ordering, AC7 CoverageGaps)
-    # All RED until s2/s3 implement float-detection and createdAt ordering.
-    # -----------------------------------------------------------------------
-
-    It 'open non-umbrella issue NOT in known-child-set → float (AC4)' {
-        # Spec has umbrellas 425 and 571 as sequenced issues.
-        # Issue 800 is open but NOT in any round → it is a float.
-        # Float detection: open non-umbrella NOT in any sequenced umbrella child-set.
-        # RED: Get-PortfolioBuckets does not yet implement float sub-issue-set inversion.
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $issues = @(
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 800  -State 'OPEN' -BlockedBy @())   # not in any round → float
-        )
-        # Provide empty known-child-set (no subIssue children fetched)
-        $knownChildSet = @()
-
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues -KnownChildSet $knownChildSet
-
-        $floatEntry = $buckets.Now | Where-Object { $_.number -eq 800 -and $_.isFloat -eq $true }
-        $floatEntry | Should -Not -BeNullOrEmpty -Because 'open issue not in any sequenced umbrella child-set must appear in Now as a float (isFloat=$true)'
-    }
-
-    It 'issue IN the known-child-set → not a float (AC4)' {
-        # Issue 800 appears in a sequenced umbrella child-set → not a float.
-        # RED: same as above.
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $issues = @(
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 800  -State 'OPEN' -BlockedBy @())
-        )
-        $knownChildSet = @(800)   # 800 is a child of a sequenced umbrella
-
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues -KnownChildSet $knownChildSet
-
-        $entry = $buckets.Now | Where-Object { $_.number -eq 800 }
-        if ($entry) {
-            $entry.isFloat | Should -Not -Be $true -Because 'issue in the known-child-set must NOT be marked as a float'
+    It 'Triage cap is 5 with TriageResidualCount for overflow (AC6)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $triageIssues = 1..8 | ForEach-Object {
+            New-IssueState -Number (1000 + $_) -State 'OPEN' -Parent $null `
+                -SubIssues @{ totalCount = 0; nodes = @() }
         }
-        # It should land in Now/Next as a spine child, not in the float path
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $triageIssues
+
+        $buckets.Triage.Count | Should -Be 5 -Because 'Triage capped at 5 items (AC6)'
+        $buckets.TriageResidualCount | Should -Be 3 -Because '8 candidates - 5 cap = 3 residual (AC6)'
     }
 
-    It 'issues #711/#712 whose parent #692 is CLOSED → appear as floats (AC4)' {
-        # #692 is unsequenced/closed — its children #711 and #712 are not in any
-        # sequenced umbrella child-set → they appear as floats (isFloat=$true).
-        # RED: float detection not yet implemented.
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $issues = @(
-            (New-IssueState -Number 425  -State 'OPEN'   -BlockedBy @())
-            (New-IssueState -Number 571  -State 'OPEN'   -BlockedBy @())
-            (New-IssueState -Number 711  -State 'OPEN'   -BlockedBy @())
-            (New-IssueState -Number 712  -State 'OPEN'   -BlockedBy @())
-        )
-        # #692 is closed/unsequenced → 711 and 712 are NOT in the known-child-set
-        $knownChildSet = @()
+    It 'Triage excludes issues with non-null parent even when not in umbrella list (AC6 / M4 — NO inversion fallback)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        # Issue 900 has a parent → must NOT appear in Triage (parent-null is required)
+        $childIssue = New-IssueState -Number 900 -State 'OPEN' -Parent @{ number = 476 } `
+            -SubIssues @{ totalCount = 0; nodes = @() }
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues -KnownChildSet $knownChildSet
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($childIssue)
 
-        $float711 = $buckets.Now | Where-Object { $_.number -eq 711 -and $_.isFloat -eq $true }
-        $float712 = $buckets.Now | Where-Object { $_.number -eq 712 -and $_.isFloat -eq $true }
-        $float711 | Should -Not -BeNullOrEmpty -Because 'issue whose parent is closed/unsequenced must appear as a float (isFloat=$true)'
-        $float712 | Should -Not -BeNullOrEmpty -Because 'issue whose parent is closed/unsequenced must appear as a float (isFloat=$true)'
+        $triageNums = @($buckets.Triage | ForEach-Object { $_.number })
+        $triageNums | Should -Not -Contain 900 `
+            -Because 'non-null parent disqualifies from Triage regardless of umbrella membership (AC6 / M4 — no inversion fallback)'
     }
 
-    It 'non-active sequenced umbrella child → Next, not float (M9 / AC2)' {
-        # Umbrella #476 is in round 2 (non-active: round 1 [425,571] is active).
-        # Child issue 900 is in the known-child-set of #476 → appears in Next, not Now, not float.
-        # RED: child-set Next placement not yet implemented.
-        $threeRoundSpec = ConvertFrom-SequenceSpec (New-ValidSpecYaml -LegacyRoundsBlock @'
-rounds:
-  - lane: main
-    round: 1
-    issues: [425, 571]
-  - lane: main
-    round: 2
-    issues: [476, 662]
-'@)
-        $issues = @(
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 476  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 662  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 900  -State 'OPEN' -BlockedBy @())   # child of #476 (round 2)
-        )
-        $knownChildSet = @(900)   # 900 is a sub-issue of #476
+    It 'Triage excludes issues with subIssues.totalCount > 0 (AC6)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        # Issue 800 is open, parent-null, but has subIssues → NOT a triage candidate
+        $parentIssue = New-IssueState -Number 800 -State 'OPEN' -Parent $null `
+            -SubIssues @{ totalCount = 2; nodes = @(@{ number = 900; state = 'OPEN' }) }
 
-        $buckets = Get-PortfolioBuckets -spec $threeRoundSpec -issueStateObjects $issues -KnownChildSet $knownChildSet
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($parentIssue)
 
-        $inNow  = $buckets.Now  | Where-Object { $_.number -eq 900 }
-        $inNext = $buckets.Next | Where-Object { $_.number -eq 900 }
-        $inNow  | Should -BeNullOrEmpty -Because 'child of non-active round umbrella must NOT appear in Now'
-        $inNext | Should -Not -BeNullOrEmpty -Because 'child of non-active round umbrella must appear in Next'
-        if ($inNext) {
-            $inNext.isFloat | Should -Not -Be $true -Because 'spine child in Next must not be flagged as float'
-        }
+        $triageNums = @($buckets.Triage | ForEach-Object { $_.number })
+        $triageNums | Should -Not -Contain 800 `
+            -Because 'issues with subIssues.totalCount > 0 are not leaf issues and must be excluded from Triage (AC6)'
     }
 
-    It 'spine wins dedup — issue in both child-set and open scan appears once (AC5)' {
-        # Issue 800 appears in knownChildSet AND in the open issue list.
-        # It must appear exactly once in the output (spine wins).
-        # RED: dedup logic not yet implemented.
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $issues = @(
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 800  -State 'OPEN' -BlockedBy @())
-        )
-        $knownChildSet = @(800)
+    It 'DriftWarnings flags open issue with totalCount>0 not in list (AC7)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        # Issue 800 is open and has sub-issues but NOT in the umbrellas list → DriftWarning
+        $unlisted = New-IssueState -Number 800 -State 'OPEN' `
+            -SubIssues @{ totalCount = 3; nodes = @(@{ number = 900; state = 'OPEN' }) }
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues -KnownChildSet $knownChildSet
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($unlisted)
 
-        $allOutputNums = @(
-            @($buckets.Now)  + @($buckets.Next) + @($buckets.Blocked) +
-            @($buckets.Triage) + @($buckets.RecentlyClosed)
-        ) | ForEach-Object { $_.number }
-        $count800 = ($allOutputNums | Where-Object { $_ -eq 800 }).Count
-        $count800 | Should -Be 1 -Because 'issue in both the spine child-set and open scan must appear exactly once (spine wins dedup, AC5)'
+        $buckets.DriftWarnings | Should -Contain '⚠️ open umbrella #800 not in ranked list' `
+            -Because 'open issue with subIssues.totalCount>0 not in umbrella list must emit DriftWarning (AC7)'
     }
 
-    It 'float with open blockedBy → Blocked bucket with blocker annotation (AC6)' {
-        # Float (open, not in any child-set) that is also blocked → goes to Blocked,
-        # not to Now, with a blockerAnnotations field.
-        # RED: float detection not yet implemented; blocked floats may fall in wrong bucket.
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $issues = @(
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 800  -State 'OPEN' -BlockedBy @(999))   # float + blocked
-        )
-        $knownChildSet = @()
+    It 'DriftWarnings flags closed listed umbrella (AC7)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $umbrella476 = New-IssueState -Number 476 -State 'CLOSED' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
+        $umbrella571 = New-IssueState -Number 571 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues -KnownChildSet $knownChildSet
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $umbrella571)
 
-        $inNow     = $buckets.Now     | Where-Object { $_.number -eq 800 }
-        $inBlocked = $buckets.Blocked | Where-Object { $_.number -eq 800 }
-        $inNow | Should -BeNullOrEmpty -Because 'blocked float must NOT appear in Now'
-        $inBlocked | Should -Not -BeNullOrEmpty -Because 'float with open blockedBy must appear in Blocked (AC6)'
-        if ($inBlocked) {
-            $inBlocked.blockerAnnotations | Should -Not -BeNullOrEmpty -Because 'blocked float must carry blocker annotation'
-        }
+        $buckets.DriftWarnings | Should -Contain '⚠️ listed umbrella #476 is closed' `
+            -Because 'CLOSED listed umbrella must emit DriftWarning (AC7)'
     }
 
-    It 'createdAt-desc ordering: newer floats rank above older floats within Now (AC3)' {
-        # Fixture: float #801 created 2025-06-01 (newer), float #800 created 2025-01-01 (older).
-        # Issue numbers are reverse of creation date order to prove Sort-by-number is NOT used.
-        # AC3: order is createdAt desc (newest first) among floats.
-        # RED: createdAt-desc ordering not yet implemented.
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $issues = @(
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z')
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z')
-            # Float 801 (higher number) is older; float 800 (lower number) is newer
-            (New-IssueState -Number 801  -State 'OPEN' -BlockedBy @() -CreatedAt '2025-01-01T00:00:00Z')
-            (New-IssueState -Number 800  -State 'OPEN' -BlockedBy @() -CreatedAt '2025-06-01T00:00:00Z')
-        )
-        $knownChildSet = @()
+    It 'IntegrityWarnings fires when totalCount does not match returned nodes count (AC8)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        # totalCount says 5 but only 1 node returned → truncation warning
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 5
+                nodes = @( @{ number = 900; state = 'OPEN' } )
+            }
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues -KnownChildSet $knownChildSet
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476)
 
-        $floats = @($buckets.Now | Where-Object { $_.isFloat -eq $true })
-        $floats.Count | Should -BeGreaterOrEqual 2 -Because 'both floats must appear in Now'
-        $pos800 = [array]::IndexOf($floats, ($floats | Where-Object { $_.number -eq 800 }))
-        $pos801 = [array]::IndexOf($floats, ($floats | Where-Object { $_.number -eq 801 }))
-        $pos800 | Should -BeLessThan $pos801 -Because 'float #800 (newer, created 2025-06-01) must rank before #801 (older, created 2025-01-01) — createdAt desc; NOT sorted by number'
+        $buckets.IntegrityWarnings | Should -HaveCount 1
+        $buckets.IntegrityWarnings[0] | Should -Match 'umbrella #476.*totalCount=5.*only 1 nodes returned' `
+            -Because 'mismatch between totalCount and returned nodes must emit IntegrityWarning (AC8)'
     }
 
-    It 'priority-label tiebreak: priority:high float before unlabeled float at same createdAt (AC3)' {
-        # Two floats with identical createdAt — priority-label tiebreak applies.
-        # priority:high before priority:medium before priority:low before unlabeled.
-        # RED: priority-label tiebreak not yet implemented.
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $issues = @(
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z')
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @() -CreatedAt '2024-01-01T00:00:00Z')
-            # Both floats with same createdAt; #900 has priority:high label, #901 is unlabeled
-            (New-IssueState -Number 901  -State 'OPEN' -BlockedBy @() -CreatedAt '2025-03-01T00:00:00Z' -Labels @())
-            (New-IssueState -Number 900  -State 'OPEN' -BlockedBy @() -CreatedAt '2025-03-01T00:00:00Z' -Labels @('priority: high'))
-        )
-        $knownChildSet = @()
+    It 'IntegrityWarnings does not block rendering (AC8 warn-and-render)' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' `
+            -SubIssues @{
+                totalCount = 5
+                nodes = @( @{ number = 900; state = 'OPEN' } )
+            }
+        $umbrella571 = New-IssueState -Number 571 -State 'OPEN' `
+            -SubIssues @{ totalCount = 0; nodes = @() }
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues -KnownChildSet $knownChildSet
+        # Must not throw; must return a model with RankedUmbrellas even when warnings fire
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $umbrella571)
 
-        $floats = @($buckets.Now | Where-Object { $_.isFloat -eq $true })
-        $idx900 = [array]::IndexOf($floats, ($floats | Where-Object { $_.number -eq 900 }))
-        $idx901 = [array]::IndexOf($floats, ($floats | Where-Object { $_.number -eq 901 }))
-        $idx900 | Should -BeLessThan $idx901 -Because 'priority:high float must rank above unlabeled float when createdAt is equal (AC3 priority-label tiebreak)'
+        $buckets | Should -Not -BeNullOrEmpty -Because 'integrity warnings must warn-and-render, not abort (AC8)'
+        $buckets.RankedUmbrellas | Should -Not -BeNullOrEmpty -Because 'RankedUmbrellas must still be populated when IntegrityWarnings fire'
     }
 
-    It 'active-round umbrella with zero open sub-issues → CoverageGaps entry (AC7)' {
-        # Umbrella #425 is in round 1 (active) but has no open sub-issues in knownChildSet.
-        # → CoverageGaps must list umbrella #425.
-        # RED: CoverageGaps derivation not yet implemented.
-        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml)
-        $issues = @(
-            (New-IssueState -Number 425  -State 'OPEN' -BlockedBy @())
-            (New-IssueState -Number 571  -State 'OPEN' -BlockedBy @())
-        )
-        # No children in child-set for either active-round umbrella
-        $knownChildSet = @()
+    It 'RecentlyClosed includes issues closed within the window' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476, 571))
+        $recentClosedAt = (Get-Date).AddDays(-3).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        $oldClosedAt    = (Get-Date).AddDays(-30).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        $recent = New-IssueState -Number 700 -State 'CLOSED' -ClosedAt $recentClosedAt
+        $old    = New-IssueState -Number 701 -State 'CLOSED' -ClosedAt $oldClosedAt
 
-        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects $issues -KnownChildSet $knownChildSet
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($recent, $old)
 
-        $buckets.CoverageGaps | Should -Not -BeNullOrEmpty -Because 'active-round umbrella with zero open sub-issues must produce a CoverageGaps entry (AC7)'
-        $gapNums = @($buckets.CoverageGaps | ForEach-Object { $_.umbrella })
-        $gapNums | Should -Contain 425 -Because '#425 is an active-round umbrella with no known open sub-issues'
+        $rcNums = @($buckets.RecentlyClosed | ForEach-Object { $_.number })
+        $rcNums | Should -Contain 700 -Because '#700 closed within 14-day window must appear in RecentlyClosed'
+        $rcNums | Should -Not -Contain 701 -Because '#701 closed 30 days ago is outside the window'
     }
 }
 

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -513,7 +513,7 @@ function Format-PortfolioMarkdown {
     # --- UnresolvedNums ---
     if ($UnresolvedNums -and $UnresolvedNums.Count -gt 0) {
         foreach ($n in $UnresolvedNums) {
-            $null = $sb.AppendLine("⚠️ Warning: issue #$n not found in GitHub — remove from sequence.yaml")
+            $null = $sb.AppendLine("⚠️ Warning: issue #$n could not be fully resolved (not found or incomplete blocker data) — verify it exists in GitHub and is still in sequence.yaml")
         }
     }
 
@@ -632,8 +632,14 @@ query {
         Write-Error "Step 0 probe: GraphQL parent/subIssues fields unavailable (exit $LASTEXITCODE) — cannot render v2 board without parent-edge data." -ErrorAction Stop
     }
     $probeResponse = $null
-    try { $probeResponse = $probeRaw | ConvertFrom-Json } catch {}
-    if ($probeResponse -and $probeResponse.errors) {
+    try { $probeResponse = $probeRaw | ConvertFrom-Json }
+    catch {
+        Write-Error "Step 0 probe: GraphQL returned non-JSON output despite exit 0 — cannot trust parent-edge data." -ErrorAction Stop
+    }
+    if ($null -eq $probeResponse) {
+        Write-Error "Step 0 probe: GraphQL returned null/empty response — cannot trust parent-edge data." -ErrorAction Stop
+    }
+    if ($probeResponse.errors) {
         $errMsg = ($probeResponse.errors | ForEach-Object { $_.message }) -join '; '
         Write-Error "Step 0 probe: GraphQL parent/subIssues fields unavailable — $errMsg. Cannot render v2 board without parent-edge data." -ErrorAction Stop
     }
@@ -641,9 +647,8 @@ query {
     # 2b. Bulk open scan (all open issues — data source for triage/drift classification).
     # Fail-loud: if this scan fails, the board must not be written in a partial
     # state. Hard-exit BEFORE any write step (gh issue edit) per AC8.
-    # Use exit 1 (not throw) per the script's hard-exit contract; Write-Error
-    # uses -ErrorAction Stop so the terminating error propagates cleanly through
-    # Pester's try/catch without polluting the non-terminating error stream.
+    # Write-Error -ErrorAction Stop raises a terminating error that propagates cleanly
+    # through Pester's try/catch and terminates the script under direct invocation.
     $openIssuesRaw = gh issue list --repo Grimblaz/agent-orchestra --state open `
         --json number,title,labels,createdAt --limit $issueScanLimit
     if ($LASTEXITCODE -ne 0) {

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -240,10 +240,7 @@ function Get-PortfolioBuckets {
     foreach ($issue in $issueStateObjects) {
         # Open issue that looks like an umbrella (has subIssues.totalCount > 0) but not listed
         if ($issue.state -eq 'OPEN') {
-            $subIssuesTotalCount = 0
-            if ($null -ne $issue.subIssues -and $null -ne $issue.subIssues.totalCount) {
-                $subIssuesTotalCount = [int]$issue.subIssues.totalCount
-            }
+            $subIssuesTotalCount = [int]($issue.subIssues?.totalCount ?? 0)
             if ($subIssuesTotalCount -gt 0 -and -not $umbrellaSet.Contains([int]$issue.number)) {
                 $driftWarnings.Add("⚠️ open umbrella #$($issue.number) not in ranked list")
             }
@@ -288,7 +285,7 @@ function Get-PortfolioBuckets {
                 $childObj = [PSCustomObject]@{
                     number    = $childNode.number
                     state     = $childNode.state
-                    title     = if ($null -ne $childNode.title) { $childNode.title } else { "Issue $($childNode.number)" }
+                    title     = $childNode.title ?? "Issue $($childNode.number)"
                     labels    = @()
                     blockedBy = @()
                     createdAt = $null
@@ -357,18 +354,11 @@ function Get-PortfolioBuckets {
         if ($issue.state -ne 'OPEN') { continue }
         if ($umbrellaSet.Contains([int]$issue.number)) { continue }
 
-        # parent must be null (the .parent field is null/absent)
-        $parentIsNull = $true
-        if ($null -ne $issue.PSObject.Properties['parent'] -and $null -ne $issue.parent) {
-            $parentIsNull = $false
-        }
-        if (-not $parentIsNull) { continue }
+        # parent must be null (field is always present on reconstructed objects, absent == $null)
+        if ($null -ne $issue.parent) { continue }
 
         # subIssues.totalCount must be 0
-        $subTotalCount = 0
-        if ($null -ne $issue.subIssues -and $null -ne $issue.subIssues.totalCount) {
-            $subTotalCount = [int]$issue.subIssues.totalCount
-        }
+        $subTotalCount = [int]($issue.subIssues?.totalCount ?? 0)
         if ($subTotalCount -ne 0) { continue }
 
         $triageCandidates.Add($issue)
@@ -891,10 +881,10 @@ query {
         }
         $issueStates.Add([PSCustomObject]@{
             number              = $clNum
-            title               = if ($cl.PSObject.Properties['title']) { $cl.title } else { "Issue $clNum" }
+            title               = $cl.title ?? "Issue $clNum"
             state               = 'CLOSED'
-            closedAt            = if ($cl.PSObject.Properties['closedAt']) { $cl.closedAt } else { $null }
-            createdAt           = if ($cl.PSObject.Properties['createdAt']) { $cl.createdAt } else { $null }
+            closedAt            = $cl.closedAt
+            createdAt           = $cl.createdAt
             labels              = $clLabels
             blockedBy           = @()
             blockerInPlan       = $true

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -75,7 +75,10 @@ function ConvertFrom-SequenceSpec {
 
         # v1 is no longer supported
         if ($schema_version -eq 1) {
-            Write-Error "sequence.yaml: schema_version 1 is no longer supported; migrate to schema_version 2"
+            # -ErrorAction Continue: keep this diagnostic non-terminating so the function
+            # honors its "return $null on validation failure" contract even when the caller
+            # runs under $ErrorActionPreference = 'Stop' (e.g. GitHub Actions shell: pwsh).
+            Write-Error "sequence.yaml: schema_version 1 is no longer supported; migrate to schema_version 2" -ErrorAction Continue
             return $null
         }
 
@@ -92,7 +95,7 @@ function ConvertFrom-SequenceSpec {
 
         # Stray rounds: key is a schema violation in v2
         if ($yamlText -match '(?m)^\s*rounds\s*:') {
-            Write-Error "sequence.yaml: stray 'rounds:' key found in schema_version 2 document; remove it and use 'umbrellas:' instead"
+            Write-Error "sequence.yaml: stray 'rounds:' key found in schema_version 2 document; remove it and use 'umbrellas:' instead" -ErrorAction Continue
             return $null
         }
 
@@ -114,7 +117,7 @@ function ConvertFrom-SequenceSpec {
 
         # Empty list
         if ($rawList -eq '') {
-            Write-Error "sequence.yaml: umbrellas list is empty; at least one umbrella is required"
+            Write-Error "sequence.yaml: umbrellas list is empty; at least one umbrella is required" -ErrorAction Continue
             return $null
         }
 
@@ -125,7 +128,7 @@ function ConvertFrom-SequenceSpec {
             $token = $entry.Trim()
             # Reject quoted numbers
             if ($token -match '^".*"$' -or $token -match "^'.*'$") {
-                Write-Error "sequence.yaml: quoted number '$token' in umbrellas list; all entries must be bare integers"
+                Write-Error "sequence.yaml: quoted number '$token' in umbrellas list; all entries must be bare integers" -ErrorAction Continue
                 return $null
             }
             # Must be a bare integer
@@ -138,7 +141,7 @@ function ConvertFrom-SequenceSpec {
         # Reject duplicates
         $distinct = @($umbrellas | Sort-Object -Unique)
         if ($distinct.Count -ne $umbrellas.Count) {
-            Write-Error "sequence.yaml: duplicate entries in umbrellas list"
+            Write-Error "sequence.yaml: duplicate entries in umbrellas list" -ErrorAction Continue
             return $null
         }
 
@@ -150,7 +153,9 @@ function ConvertFrom-SequenceSpec {
         }
     }
     catch {
-        Write-Error "sequence.yaml: $_"
+        # Non-terminating so a thrown validation failure (e.g. non-integer umbrella entry)
+        # resolves to the documented $null return even under $ErrorActionPreference = 'Stop'.
+        Write-Error "sequence.yaml: $_" -ErrorAction Continue
         return $null
     }
 }

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -668,17 +668,36 @@ function Invoke-PortfolioRender {
 
     $tower = if ($controlTower -gt 0) { $controlTower } else { $spec.control_tower }
 
-    # 2. Collect all umbrella numbers from all rounds (used for leaf detection and
-    #    known-child-set building in steps 2c/2d).
-    $allIssueNums = @(
-        $spec.rounds | ForEach-Object { $_.issues } | Sort-Object -Unique
-    )
+    # 2. All umbrella numbers from the spec (v2: ordered list).
+    $allIssueNums = @($spec.umbrellas)
 
-    # Build the full set of umbrella numbers (sequenced umbrellas + control tower).
-    # An issue is a "leaf" if its number does NOT appear in this set.
+    # Umbrella numbers + control tower (for leaf detection).
     $umbrellaNumbers = @(@($allIssueNums) + @($tower) | Sort-Object -Unique)
 
-    # 2b. Bulk open-leaf scan (AC8 / AC4 data source).
+    # Step 0: Probe that parent + subIssues GraphQL fields are available.
+    # v2 triage/drift model depends on parent-edge data; fail loud if unavailable.
+    $probeQuery = @"
+query {
+  repository(owner: "Grimblaz", name: "agent-orchestra") {
+    issue(number: $tower) {
+      parent { number }
+      subIssues(first: 1) { totalCount }
+    }
+  }
+}
+"@
+    $probeRaw = gh api graphql -f query=$probeQuery
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Step 0 probe: GraphQL parent/subIssues fields unavailable (exit $LASTEXITCODE) — cannot render v2 board without parent-edge data." -ErrorAction Stop
+    }
+    $probeResponse = $null
+    try { $probeResponse = $probeRaw | ConvertFrom-Json } catch {}
+    if ($probeResponse -and $probeResponse.errors) {
+        $errMsg = ($probeResponse.errors | ForEach-Object { $_.message }) -join '; '
+        Write-Error "Step 0 probe: GraphQL parent/subIssues fields unavailable — $errMsg. Cannot render v2 board without parent-edge data." -ErrorAction Stop
+    }
+
+    # 2b. Bulk open scan (data source for leaf candidates).
     # Fail-loud: if this scan fails, the board must not be written in a partial
     # state. Hard-exit BEFORE any write step (gh issue edit) per AC8.
     # Use exit 1 (not throw) per the script's hard-exit contract; Write-Error
@@ -696,13 +715,13 @@ function Invoke-PortfolioRender {
     catch {
         Write-Error "Failed to parse open issue list JSON: $_" -ErrorAction Stop
     }
-    # Two-tier truncation contract: open/closed fail-loud (abort render); triage warn-and-continue (additive bucket).
+    # Two-tier truncation contract: open/closed fail-loud (abort render).
     # count == limit is the only observable truncation signal; false-positive at exactly the ceiling is treated as truncation and accepted.
     if ($openLeaves.Count -ge $issueScanLimit) {
         Write-Error "Open issue list returned $($openLeaves.Count) results (limit $issueScanLimit) — refusing to render a potentially truncated board." -ErrorAction Stop
     }
 
-    # 2c. Repo-wide closed-leaf scan (AC9 data source).
+    # 2c. Repo-wide closed scan (RecentlyClosed data source).
     # Fail-loud: same hard-exit pattern as the open scan.
     $cutoffDate    = (Get-Date).AddDays(-$spec.recently_closed_days).ToString('yyyy-MM-dd')
     # Closed scan uses --search, routing through the GitHub Search API (hard cap: 1000 results regardless of --limit).
@@ -725,59 +744,17 @@ function Invoke-PortfolioRender {
         Write-Error "Closed issue list returned $($closedLeaves.Count) results (limit $closedCeiling — GitHub Search API hard cap) — refusing to render a potentially truncated RecentlyClosed section." -ErrorAction Stop
     }
 
-    # 2d. Fetch open triage-labeled issues repo-wide (CR9 / d-triage-visibility,
-    #     AC #5). The Triage bucket promises open `triage`-labeled issues that
-    #     are NOT in any sequence round; those are never named in sequence.yaml,
-    #     so without this independent query they would never be fetched and the
-    #     bucket would silently stay empty. The query is additive: a failure
-    #     warns and degrades (Triage may be incomplete) rather than aborting the
-    #     whole render, consistent with the per-issue skip pattern below.
-    $triageNums = @()
-    $triageRaw  = gh issue list --repo Grimblaz/agent-orchestra --label triage --state open --limit $issueScanLimit --json number
-    if ($LASTEXITCODE -ne 0) {
-        Write-Warning "Failed to list open triage-labeled issues (exit $LASTEXITCODE) — Triage bucket may be incomplete."
-    }
-    else {
-        try {
-            $triageNums = @(($triageRaw | ConvertFrom-Json) | ForEach-Object { $_.number })
-        }
-        catch {
-            Write-Warning "Failed to parse triage issue list — Triage bucket may be incomplete."
-        }
-    }
-    # Triage truncation is an accepted advisory degradation: a best-effort additive bucket
-    # must not abort the whole render. count == limit is the only observable signal; a
-    # false-positive at exactly the ceiling is documented here as accepted.
-    if ($triageNums.Count -ge $issueScanLimit) {
-        Write-Warning "Triage issue list returned $($triageNums.Count) results (limit $issueScanLimit) — Triage bucket may be incomplete."
-    }
+    # Step 2d (v1 triage-label scan) is REMOVED in v2.
+    # Triage is now derived from parent-edge data in Get-PortfolioBuckets, not by label query.
 
-    # Query set = sequenced issues ∪ repo-wide triage issues (deduplicated).
-    # Plan membership ($allIssueNums) stays sequence-only — triage issues are by
-    # definition unsequenced and must NOT count as in-plan for blocker logic.
-    $queryNums = @($allIssueNums + $triageNums | Sort-Object -Unique)
-
-    # 3. Query each issue via gh GraphQL (first: 50 per connection)
+    # 3. Query each umbrella via gh GraphQL.
+    # v2: iterate $allIssueNums (spec.umbrellas) only; no $queryNums, no $triageNums.
+    # Each umbrella query includes parent { number } and subIssues(first:50) so
+    # Get-PortfolioBuckets v2 can detect ActiveChildren, drift, and triage.
     $issueStates    = [System.Collections.Generic.List[object]]::new()
     $unresolvedNums = @()
 
-    # Build round-index map for umbrella numbers: used to tag KnownChildSet entries
-    # with the correct RoundIndex so Get-PortfolioBuckets can route children correctly.
-    $sortedRoundsForSpec = @($spec.rounds | Sort-Object round)
-    $umbrellaRoundIdxMap = @{}
-    for ($ri = 0; $ri -lt $sortedRoundsForSpec.Count; $ri++) {
-        foreach ($rnum in $sortedRoundsForSpec[$ri].issues) {
-            $umbrellaRoundIdxMap[[int]$rnum] = $ri
-        }
-    }
-
-    # KnownChildSet: rich PSCustomObjects { number, UmbrellaNumber, RoundIndex } built
-    # from per-umbrella subIssues GraphQL responses. Passed to Get-PortfolioBuckets so
-    # float detection (AC4) and CoverageGaps (AC7) work correctly in the live pipeline.
-    $knownChildSet = [System.Collections.Generic.List[object]]::new()
-
-    foreach ($num in $queryNums) {
-        $isUmbrella = $allIssueNums -contains $num
+    foreach ($num in $allIssueNums) {
         $query = @"
 query {
   repository(owner: "Grimblaz", name: "agent-orchestra") {
@@ -791,12 +768,12 @@ query {
       blockedBy(first: 50) {
         totalCount
         nodes { number title state }
-      }$(if ($isUmbrella) {
-"
+      }
+      parent { number }
       subIssues(first: 50) {
-        nodes { number }
-      }"
-      })
+        totalCount
+        nodes { number state }
+      }
     }
   }
 }
@@ -850,6 +827,11 @@ query {
             }
         }
 
+        # Build parent and subIssues fields for v2 Get-PortfolioBuckets
+        $parentData    = if ($null -ne $issueData.parent) { @{ number = [int]$issueData.parent.number } } else { $null }
+        $subIssueNodes = @($issueData.subIssues.nodes | ForEach-Object { @{ number = [int]$_.number; state = $_.state } })
+        $subIssueData  = @{ totalCount = [int]$issueData.subIssues.totalCount; nodes = $subIssueNodes }
+
         $issueStates.Add([PSCustomObject]@{
             number              = $issueData.number
             title               = $issueData.title
@@ -860,40 +842,24 @@ query {
             blockedBy           = $openBlockers
             blockerInPlan       = $blockerInPlan
             blockedByTotalCount = $issueData.blockedBy.totalCount
+            parent              = $parentData
+            subIssues           = $subIssueData
         })
-
-        # Collect sub-issue children for this umbrella into KnownChildSet (AC4/AC7).
-        if ($isUmbrella -and $null -ne $issueData.subIssues) {
-            $umbRoundIdx = if ($umbrellaRoundIdxMap.ContainsKey([int]$num)) { $umbrellaRoundIdxMap[[int]$num] } else { 0 }
-            foreach ($child in $issueData.subIssues.nodes) {
-                if ($child.number -gt 0) {
-                    $knownChildSet.Add([PSCustomObject]@{
-                        number        = [int]$child.number
-                        UmbrellaNumber = [int]$num
-                        RoundIndex     = $umbRoundIdx
-                    })
-                }
-            }
-        }
     }
 
-    # 3b. Open-leaf detail pass (AC4): query full data for all non-umbrella open issues —
-    # both spine children (KnownChildSet members) and floats. Get-PortfolioBuckets classifies
-    # them: known children route to Now/Next/Blocked as spine; unknowns are floats (isFloat=$true).
-    # Previously KnownChildSet members were excluded here, causing spine leaves to never enter
-    # issueStates and never appear on the board. The exclusion was incorrect: we need full data
-    # for BOTH categories so blockedBy, labels, and createdAt are populated for all leaf issues.
-    # Fail-loud: a leaf-query failure warns and skips (same as per-issue skip pattern).
-    $knownChildNums = [System.Collections.Generic.HashSet[int]]::new()
-    foreach ($child in $knownChildSet) { $null = $knownChildNums.Add([int]$child.number) }
+    # 3b. Open-leaf detail pass: query ALL non-umbrella open issues from the open scan
+    # with parent { number } and subIssues(first:1) { totalCount } so Get-PortfolioBuckets
+    # can classify them as Triage (parent=null, totalCount=0) or DriftWarnings
+    # (totalCount>0, not in umbrella list). Fail-loud: a leaf-query failure warns and skips.
     $alreadyQueried = [System.Collections.Generic.HashSet[int]]::new()
-    foreach ($q in $queryNums) { $null = $alreadyQueried.Add([int]$q) }
+    foreach ($q in $allIssueNums) { $null = $alreadyQueried.Add([int]$q) }
+    $null = $alreadyQueried.Add([int]$tower)
 
     $openLeafCandidateNums = @(
         $openLeaves |
         Where-Object {
             $n = [int]$_.number
-            (-not ($umbrellaNumbers -contains $n)) -and (-not $alreadyQueried.Contains($n))
+            -not $alreadyQueried.Contains($n)
         } |
         ForEach-Object { [int]$_.number }
     )
@@ -913,18 +879,20 @@ query {
         totalCount
         nodes { number title state }
       }
+      parent { number }
+      subIssues(first: 1) { totalCount }
     }
   }
 }
 "@
         $rawJson = gh api graphql -f query=$query
         if ($LASTEXITCODE -ne 0) {
-            Write-Warning "GraphQL query failed for float #$num (exit $LASTEXITCODE) — skipping."
+            Write-Warning "GraphQL query failed for leaf #$num (exit $LASTEXITCODE) — skipping."
             continue
         }
         $response = $null
         try { $response = $rawJson | ConvertFrom-Json }
-        catch { Write-Warning "Failed to parse GraphQL response for float #$num — skipping."; continue }
+        catch { Write-Warning "Failed to parse GraphQL response for leaf #$num — skipping."; continue }
         $issueData = $response.data.repository.issue
         if ($null -eq $issueData) { continue }
         if ($response.errors) {
@@ -940,6 +908,12 @@ query {
         foreach ($b in $openBlockers) {
             if ($allIssueNums -notcontains $b) { $blockerInPlan = $false; break }
         }
+
+        # Build parent and subIssues for v2 triage/drift detection.
+        # Only first:1 was requested so nodes = @() (totalCount is sufficient for drift detection).
+        $parentData   = if ($null -ne $issueData.parent) { @{ number = [int]$issueData.parent.number } } else { $null }
+        $subIssueData = @{ totalCount = [int]$issueData.subIssues.totalCount; nodes = @() }
+
         $issueStates.Add([PSCustomObject]@{
             number              = $issueData.number
             title               = $issueData.title
@@ -950,6 +924,37 @@ query {
             blockedBy           = $openBlockers
             blockerInPlan       = $blockerInPlan
             blockedByTotalCount = $issueData.blockedBy.totalCount
+            parent              = $parentData
+            subIssues           = $subIssueData
+        })
+    }
+
+    # 3c. Add closed-scan results to issueStates for RecentlyClosed bucket.
+    # Get-PortfolioBuckets v2 derives RecentlyClosed from issueStateObjects where
+    # state == CLOSED and closedAt is within the window. The closed scan provides this data.
+    $closedAlreadyQueried = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($s in $issueStates) { $null = $closedAlreadyQueried.Add([int]$s.number) }
+    foreach ($cl in $closedLeaves) {
+        $clNum = [int]$cl.number
+        if ($closedAlreadyQueried.Contains($clNum)) { continue }
+        $clLabels = @()
+        if ($cl.PSObject.Properties['labels'] -and $null -ne $cl.labels) {
+            $clLabels = @($cl.labels | ForEach-Object {
+                if ($_ -is [string]) { $_ } elseif ($null -ne $_.name) { $_.name }
+            })
+        }
+        $issueStates.Add([PSCustomObject]@{
+            number              = $clNum
+            title               = if ($cl.PSObject.Properties['title']) { $cl.title } else { "Issue $clNum" }
+            state               = 'CLOSED'
+            closedAt            = if ($cl.PSObject.Properties['closedAt']) { $cl.closedAt } else { $null }
+            createdAt           = if ($cl.PSObject.Properties['createdAt']) { $cl.createdAt } else { $null }
+            labels              = $clLabels
+            blockedBy           = @()
+            blockerInPlan       = $true
+            blockedByTotalCount = 0
+            parent              = $null
+            subIssues           = $null
         })
     }
 

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -638,28 +638,28 @@ query {
         Write-Error "Step 0 probe: GraphQL parent/subIssues fields unavailable — $errMsg. Cannot render v2 board without parent-edge data." -ErrorAction Stop
     }
 
-    # 2b. Bulk open scan (data source for leaf candidates).
+    # 2b. Bulk open scan (all open issues — data source for triage/drift classification).
     # Fail-loud: if this scan fails, the board must not be written in a partial
     # state. Hard-exit BEFORE any write step (gh issue edit) per AC8.
     # Use exit 1 (not throw) per the script's hard-exit contract; Write-Error
     # uses -ErrorAction Stop so the terminating error propagates cleanly through
     # Pester's try/catch without polluting the non-terminating error stream.
-    $openLeavesRaw = gh issue list --repo Grimblaz/agent-orchestra --state open `
+    $openIssuesRaw = gh issue list --repo Grimblaz/agent-orchestra --state open `
         --json number,title,labels,createdAt --limit $issueScanLimit
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to fetch open issue list (exit $LASTEXITCODE)" -ErrorAction Stop
     }
-    $openLeaves = @()
+    $openIssues = @()
     try {
-        $openLeaves = @($openLeavesRaw | ConvertFrom-Json)
+        $openIssues = @($openIssuesRaw | ConvertFrom-Json)
     }
     catch {
         Write-Error "Failed to parse open issue list JSON: $_" -ErrorAction Stop
     }
     # Two-tier truncation contract: open/closed fail-loud (abort render).
     # count == limit is the only observable truncation signal; false-positive at exactly the ceiling is treated as truncation and accepted.
-    if ($openLeaves.Count -ge $issueScanLimit) {
-        Write-Error "Open issue list returned $($openLeaves.Count) results (limit $issueScanLimit) — refusing to render a potentially truncated board." -ErrorAction Stop
+    if ($openIssues.Count -ge $issueScanLimit) {
+        Write-Error "Open issue list returned $($openIssues.Count) results (limit $issueScanLimit) — refusing to render a potentially truncated board." -ErrorAction Stop
     }
 
     # 2c. Repo-wide closed scan (RecentlyClosed data source).
@@ -796,8 +796,8 @@ query {
     foreach ($q in $allIssueNums) { $null = $alreadyQueried.Add([int]$q) }
     $null = $alreadyQueried.Add([int]$tower)
 
-    $openLeafCandidateNums = @(
-        $openLeaves |
+    $openIssueCandidateNums = @(
+        $openIssues |
         Where-Object {
             $n = [int]$_.number
             -not $alreadyQueried.Contains($n)
@@ -805,7 +805,7 @@ query {
         ForEach-Object { [int]$_.number }
     )
 
-    foreach ($num in $openLeafCandidateNums) {
+    foreach ($num in $openIssueCandidateNums) {
         $query = @"
 query {
   repository(owner: "Grimblaz", name: "agent-orchestra") {

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -1,12 +1,12 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-    Renders the derived portfolio tracker for issue #692 (control tower issue).
+    Renders the derived portfolio tracker for issue #704 (control tower issue).
 
 .DESCRIPTION
     Implements the Renderer Contract:
       - ConvertFrom-SequenceSpec  : parse flat YAML sequence spec (no ConvertFrom-Yaml)
-      - Get-PortfolioBuckets      : classify issues into Now/Next/Blocked/RecentlyClosed/Triage
+      - Get-PortfolioBuckets      : classify issues into ActiveUmbrella/ActiveChildren/RankedUmbrellas/Triage/RecentlyClosed/DriftWarnings/IntegrityWarnings
       - Format-PortfolioMarkdown  : render bucket model to Markdown
       - Get-SplicedBody           : idempotent splice into issue body
       - Invoke-PortfolioRender    : full pipeline end-to-end
@@ -57,15 +57,6 @@ function Get-BucketTotal {
     return 0
 }
 
-# Returns the numeric model property $propName when present, otherwise $renderedCount.
-function Get-ModelTotal {
-    param([object]$model, [string]$propName, [int]$renderedCount)
-    $prop = $model.PSObject.Properties[$propName]
-    if ($null -ne $prop) {
-        return [int]$prop.Value
-    }
-    return $renderedCount
-}
 
 # ---------------------------------------------------------------------------
 # ConvertFrom-SequenceSpec
@@ -424,110 +415,69 @@ function Get-PortfolioBuckets {
 }
 
 # ---------------------------------------------------------------------------
-# Format-PortfolioMarkdown
-# Renders bucket model to Markdown string.
-# Bucket order: Now / Next / Blocked / Recently closed / Triage
-# Footer: "as of {timestamp} — rendered by render-portfolio.ps1"
-# Pagination: (+N more) when totalCount > rendered count.
+# Format-PortfolioMarkdown v2
+# Renders v2 bucket model to Markdown string.
+# Three-zone layout: Active / Umbrellas (ranked) / Triage / Recently closed
+# Warnings (DriftWarnings + IntegrityWarnings) appear after zones, before footer.
+# Footer: "portfolio content unchanged since {timestamp} — rendered by render-portfolio.ps1"
+# Get-SplicedBody strips the footer line for idempotency comparison — do not move it.
 # ---------------------------------------------------------------------------
 function Format-PortfolioMarkdown {
     param($bucketModel, [string]$timestamp, [int[]]$UnresolvedNums = @())
 
     $sb = [System.Text.StringBuilder]::new()
 
-    # --- Now ---
-    # Cap-floor constant (AC10): max float items to render before (+M more).
-    $floatCap = 15
-
-    $null = $sb.AppendLine('## Now')
-    # Consume producer ordering verbatim — do NOT Sort-Object number (AC3).
-    $nowItems = if ($bucketModel.Now) { @($bucketModel.Now) } else { @() }
-    if ($nowItems.Count -gt 0) {
-        # Separate spine items (isFloat=$false) from float items (isFloat=$true).
-        $spineItems = @($nowItems | Where-Object { -not ($_.PSObject.Properties['isFloat'] -and $_.isFloat -eq $true) })
-        $floatItems = @($nowItems | Where-Object {       $_.PSObject.Properties['isFloat'] -and $_.isFloat -eq $true  })
-
-        # Render ALL spine items with tags.
-        foreach ($issue in $spineItems) {
-            $tags = ''
-            if ($issue.PSObject.Properties['inProgress'] -and $issue.inProgress -eq $true) {
-                $tags += ' (in progress)'
+    # --- Active ---
+    if ($null -ne $bucketModel.ActiveUmbrella) {
+        $null = $sb.AppendLine("## 🎯 Active — #$($bucketModel.ActiveUmbrella.number) $($bucketModel.ActiveUmbrella.title)")
+        # Children: consume verbatim, do NOT re-sort
+        $children = if ($bucketModel.ActiveChildren) { @($bucketModel.ActiveChildren) } else { @() }
+        foreach ($child in $children) {
+            if ($child.BlockedAnnotation) {
+                $null = $sb.AppendLine("- #$($child.number) $($child.title) $($child.BlockedAnnotation)")
             }
-            $null = $sb.AppendLine("- #$($issue.number) $($issue.title)$tags")
-        }
-
-        # Render top N=15 float items with tags; compute total overflow.
-        $floatCount    = $floatItems.Count
-        $floatToRender = if ($floatCount -gt $floatCap) { $floatCap } else { $floatCount }
-        for ($fi = 0; $fi -lt $floatToRender; $fi++) {
-            $issue = $floatItems[$fi]
-            $tags = ' (unsequenced)'
-            if ($issue.PSObject.Properties['inProgress'] -and $issue.inProgress -eq $true) {
-                $tags += ' (in progress)'
+            else {
+                $null = $sb.AppendLine("- #$($child.number) $($child.title)")
             }
-            $null = $sb.AppendLine("- #$($issue.number) $($issue.title)$tags")
         }
-
-        # Overflow: combine cap-floor float overflow with NowTotalCount overflow.
-        # NowTotalCount may exceed Now.Count when the caller has more items than
-        # were passed in the Now array (pagination from the model).
-        $totalRendered   = $spineItems.Count + $floatToRender
-        $nowTotal        = Get-ModelTotal $bucketModel 'NowTotalCount' $nowItems.Count
-        $totalToAccount  = [math]::Max($nowTotal, $nowItems.Count)
-        $totalOverflow   = $totalToAccount - $totalRendered
-        if ($totalOverflow -gt 0) {
-            $null = $sb.AppendLine("(+$totalOverflow more)")
+        $null = $sb.AppendLine('')
+        # Done/total footer line
+        $activeEntry = @($bucketModel.RankedUmbrellas | Where-Object { $_.IsActive })[0]
+        if ($null -ne $activeEntry -and $activeEntry.Total -gt 0) {
+            $null = $sb.AppendLine("── $($activeEntry.Done)/$($activeEntry.Total) done ──")
+        }
+        else {
+            $null = $sb.AppendLine('── no children linked ──')
         }
     }
     else {
-        $blockedCount = if ($bucketModel.Blocked) { @($bucketModel.Blocked).Count } else { 0 }
-        $emptyMsg     = if ($blockedCount -gt 0) {
-            '*(no unblocked items — all current-round items are blocked)*'
-        } else {
-            '*(no current-round work)*'
-        }
-        $null = $sb.AppendLine($emptyMsg)
-    }
-    # CoverageGaps (AC7): render after Now content, even when Now is empty.
-    if ($bucketModel.CoverageGaps) {
-        foreach ($gap in $bucketModel.CoverageGaps) {
-            $null = $sb.AppendLine("- (#$($gap.umbrella): $($gap.note))")
-        }
+        $null = $sb.AppendLine('## 🎯 Active')
+        $null = $sb.AppendLine('*(no active umbrella)*')
     }
     $null = $sb.AppendLine('')
 
-    # --- Next ---
-    $null = $sb.AppendLine('## Next')
-    $nextItems = if ($bucketModel.Next) { @($bucketModel.Next | Sort-Object number) } else { @() }
-    if ($nextItems.Count -gt 0) {
-        foreach ($issue in $nextItems) {
-            $null = $sb.AppendLine("- #$($issue.number) $($issue.title)")
-        }
-        $nextTotal = Get-ModelTotal $bucketModel 'NextTotalCount' $nextItems.Count
-        if ($nextTotal -gt $nextItems.Count) {
-            $overflow = $nextTotal - $nextItems.Count
-            $null = $sb.AppendLine("(+$overflow more)")
-        }
+    # --- Umbrellas (ranked) ---
+    $null = $sb.AppendLine('## Umbrellas (ranked)')
+    $rankedUmbrellas = if ($bucketModel.RankedUmbrellas) { @($bucketModel.RankedUmbrellas) } else { @() }
+    foreach ($umb in $rankedUmbrellas) {
+        $activeMarker = if ($umb.IsActive) { ' ◀ active' } else { '' }
+        $null = $sb.AppendLine("- #$($umb.Number) $($umb.Title) $($umb.DoneTotalLabel)$activeMarker")
     }
-    else {
+    if ($rankedUmbrellas.Count -eq 0) {
         $null = $sb.AppendLine('*(none)*')
     }
     $null = $sb.AppendLine('')
 
-    # --- Blocked ---
-    $null = $sb.AppendLine('## Blocked')
-    $blockedItems = if ($bucketModel.Blocked) { @($bucketModel.Blocked | Sort-Object number) } else { @() }
-    if ($blockedItems.Count -gt 0) {
-        foreach ($issue in $blockedItems) {
-            $annotation = if ($issue.PSObject.Properties['blockerAnnotations']) {
-                " ($($issue.blockerAnnotations))"
-            } else { '' }
-            $null = $sb.AppendLine("- #$($issue.number) $($issue.title)$annotation")
+    # --- Triage ---
+    $null = $sb.AppendLine('## 🔥 Triage')
+    $triageItems = if ($bucketModel.Triage) { @($bucketModel.Triage) } else { @() }
+    if ($triageItems.Count -gt 0) {
+        foreach ($issue in $triageItems) {
+            $null = $sb.AppendLine("- #$($issue.number) $($issue.title)")
         }
-        $blockedTotal = Get-ModelTotal $bucketModel 'BlockedTotalCount' $blockedItems.Count
-        if ($blockedTotal -gt $blockedItems.Count) {
-            $overflow = $blockedTotal - $blockedItems.Count
-            $null = $sb.AppendLine("(+$overflow more)")
+        $residualCount = if ($null -ne $bucketModel.TriageResidualCount) { [int]$bucketModel.TriageResidualCount } else { 0 }
+        if ($residualCount -gt 0) {
+            $null = $sb.AppendLine("(+$residualCount more)")
         }
     }
     else {
@@ -537,48 +487,39 @@ function Format-PortfolioMarkdown {
 
     # --- Recently closed ---
     $null = $sb.AppendLine('## Recently closed')
-    $rcItems = if ($bucketModel.RecentlyClosed) { @($bucketModel.RecentlyClosed | Sort-Object number) } else { @() }
+    $rcItems = if ($bucketModel.RecentlyClosed) { @($bucketModel.RecentlyClosed) } else { @() }
     if ($rcItems.Count -gt 0) {
         foreach ($issue in $rcItems) {
             $null = $sb.AppendLine("- #$($issue.number) $($issue.title)")
         }
-        $rcTotal = Get-ModelTotal $bucketModel 'RecentlyClosedTotalCount' $rcItems.Count
-        if ($rcTotal -gt $rcItems.Count) {
-            $overflow = $rcTotal - $rcItems.Count
-            $null = $sb.AppendLine("(+$overflow more)")
-        }
     }
     else {
         $null = $sb.AppendLine('*(none)*')
     }
     $null = $sb.AppendLine('')
 
-    # --- Triage ---
-    $null = $sb.AppendLine('## Triage')
-    $triageItems = if ($bucketModel.Triage) { @($bucketModel.Triage | Sort-Object number) } else { @() }
-    if ($triageItems.Count -gt 0) {
-        foreach ($issue in $triageItems) {
-            $null = $sb.AppendLine("- #$($issue.number) $($issue.title)")
-        }
-        $triageTotal = Get-ModelTotal $bucketModel 'TriageTotalCount' $triageItems.Count
-        if ($triageTotal -gt $triageItems.Count) {
-            $overflow = $triageTotal - $triageItems.Count
-            $null = $sb.AppendLine("(+$overflow more)")
+    # --- Warnings (after zones, before footer) ---
+    if ($bucketModel.DriftWarnings) {
+        foreach ($warn in $bucketModel.DriftWarnings) {
+            $null = $sb.AppendLine($warn)
         }
     }
-    else {
-        $null = $sb.AppendLine('*(none)*')
+    if ($bucketModel.IntegrityWarnings) {
+        foreach ($warn in $bucketModel.IntegrityWarnings) {
+            $null = $sb.AppendLine($warn)
+        }
     }
-    $null = $sb.AppendLine('')
 
-    # --- Footer ---
-    $null = $sb.AppendLine("portfolio content unchanged since $timestamp — rendered by render-portfolio.ps1")
-
+    # --- UnresolvedNums ---
     if ($UnresolvedNums -and $UnresolvedNums.Count -gt 0) {
         foreach ($n in $UnresolvedNums) {
             $null = $sb.AppendLine("⚠️ Warning: issue #$n not found in GitHub — remove from sequence.yaml")
         }
     }
+
+    # --- Footer ---
+    # IMPORTANT: Get-SplicedBody strips this line for idempotency; do not move it.
+    $null = $sb.AppendLine("portfolio content unchanged since $timestamp — rendered by render-portfolio.ps1")
 
     return $sb.ToString()
 }

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -76,53 +76,78 @@ function ConvertFrom-SequenceSpec {
     param([string]$yamlText)
 
     try {
-        # Reject block-style issues list (issues on separate lines with leading dash)
-        if ($yamlText -match "issues:\s*\r?\n\s+-") {
+        # Require schema_version as integer
+        if ($yamlText -notmatch '(?m)^\s*schema_version:\s*(\d+)\s*$') {
             return $null
         }
-
-        # Require schema_version as integer
-        if ($yamlText -notmatch '(?m)^\s*schema_version:\s*(\d+)') { return $null }
         $schema_version = [int]$Matches[1]
+
+        # v1 is no longer supported
+        if ($schema_version -eq 1) {
+            Write-Error "sequence.yaml: schema_version 1 is no longer supported; migrate to schema_version 2"
+            return $null
+        }
 
         # Reject quoted control_tower
         if ($yamlText -match '(?m)^\s*control_tower:\s*"') { return $null }
 
         # Require control_tower as unquoted integer
-        if ($yamlText -notmatch '(?m)^\s*control_tower:\s*(\d+)') { return $null }
+        if ($yamlText -notmatch '(?m)^\s*control_tower:\s*(\d+)\s*$') { return $null }
         $control_tower = [int]$Matches[1]
 
         # Require recently_closed_days as integer
-        if ($yamlText -notmatch '(?m)^\s*recently_closed_days:\s*(\d+)') { return $null }
+        if ($yamlText -notmatch '(?m)^\s*recently_closed_days:\s*(\d+)\s*$') { return $null }
         $recently_closed_days = [int]$Matches[1]
 
-        # Parse rounds — each round block: "- lane: X\n    round: N\n    issues: [...]"
-        $rounds = @()
-        $roundMatches = [regex]::Matches(
-            $yamlText,
-            '-\s+lane:\s*(\S+)\s+round:\s*(\d+)\s+issues:\s*\[([^\]]*)\]'
-        )
-        foreach ($m in $roundMatches) {
-            $lane      = $m.Groups[1].Value.Trim()
-            $round     = [int]$m.Groups[2].Value
-            $rawList   = $m.Groups[3].Value
-            $issueNums = $rawList -split ',' |
-                         ForEach-Object { $_.Trim() } |
-                         Where-Object   { $_ -match '^\d+$' } |
-                         ForEach-Object { [int]$_ } |
-                         Where-Object   { $_ -gt 0 }
-            $rounds += [PSCustomObject]@{
-                lane   = $lane
-                round  = $round
-                issues = @($issueNums)
-            }
+        # Stray rounds: key is a schema violation in v2
+        if ($yamlText -match '(?m)^\s*rounds\s*:') {
+            Write-Error "sequence.yaml: stray 'rounds:' key found in schema_version 2 document; remove it and use 'umbrellas:' instead"
+            return $null
         }
 
-        # Validate: each "- lane:" block must produce exactly one parsed round
-        $expectedRoundCount = ([regex]::Matches($yamlText, '(?m)^\s*-\s+lane:')).Count
-        if ($expectedRoundCount -gt 0 -and $rounds.Count -ne $expectedRoundCount) {
-            Write-Error ("sequence.yaml: round parse mismatch — found {0} '- lane:' blocks but only {1} parsed correctly. " +
-                "Each round must have lane:, round:, and issues: on consecutive lines." -f $expectedRoundCount, $rounds.Count)
+        # Require umbrellas: key
+        if ($yamlText -notmatch '(?m)^\s*umbrellas\s*:') {
+            return $null
+        }
+
+        # Reject block-style umbrellas (items on separate lines with leading dash)
+        if ($yamlText -match '(?m)^\s*umbrellas\s*:\s*\r?\n\s*-') {
+            return $null
+        }
+
+        # Parse inline umbrellas list: umbrellas: [N, N, ...]
+        if ($yamlText -notmatch '(?m)^\s*umbrellas\s*:\s*\[([^\]]*)\]\s*$') {
+            return $null
+        }
+        $rawList = $Matches[1].Trim()
+
+        # Empty list
+        if ($rawList -eq '') {
+            Write-Error "sequence.yaml: umbrellas list is empty; at least one umbrella is required"
+            return $null
+        }
+
+        # Parse and validate each entry
+        $umbrellas = [System.Collections.Generic.List[int]]::new()
+        $entries = $rawList -split ','
+        foreach ($entry in $entries) {
+            $token = $entry.Trim()
+            # Reject quoted numbers
+            if ($token -match '^".*"$' -or $token -match "^'.*'$") {
+                Write-Error "sequence.yaml: quoted number '$token' in umbrellas list; all entries must be bare integers"
+                return $null
+            }
+            # Must be a bare integer
+            if ($token -notmatch '^\d+$') {
+                throw "sequence.yaml: non-integer entry '$token' in umbrellas list"
+            }
+            $umbrellas.Add([int]$token)
+        }
+
+        # Reject duplicates
+        $distinct = @($umbrellas | Sort-Object -Unique)
+        if ($distinct.Count -ne $umbrellas.Count) {
+            Write-Error "sequence.yaml: duplicate entries in umbrellas list"
             return $null
         }
 
@@ -130,10 +155,11 @@ function ConvertFrom-SequenceSpec {
             schema_version       = $schema_version
             control_tower        = $control_tower
             recently_closed_days = $recently_closed_days
-            rounds               = $rounds
+            umbrellas            = $umbrellas.ToArray()
         }
     }
     catch {
+        Write-Error "sequence.yaml: $_"
         return $null
     }
 }
@@ -1079,29 +1105,41 @@ query {
 
 function New-ValidSpecYaml {
     param(
-        [int]   $SchemaVersion      = 1,
-        [int]   $ControlTower       = 704,
-        [int]   $RecentlyClosedDays = 14,
-        [string]$RoundsBlock        = "rounds:`n  - lane: main`n    round: 1`n    issues: [425, 571]"
+        [int]    $SchemaVersion      = 2,
+        [int]    $ControlTower       = 704,
+        [int]    $RecentlyClosedDays = 14,
+        [int[]]  $Umbrellas          = @(476, 571),
+        [string] $LegacyRoundsBlock  = $null
     )
+    if (-not [string]::IsNullOrEmpty($LegacyRoundsBlock)) {
+        return @"
+schema_version: 1
+control_tower: $ControlTower
+recently_closed_days: $RecentlyClosedDays
+$LegacyRoundsBlock
+"@
+    }
+    $umbrellaList = $Umbrellas -join ', '
     return @"
 schema_version: $SchemaVersion
 control_tower: $ControlTower
 recently_closed_days: $RecentlyClosedDays
-$RoundsBlock
+umbrellas: [$umbrellaList]
 "@
 }
 
 function New-IssueState {
     param(
-        [int]     $Number,
-        [string]  $State        = 'OPEN',
-        [string[]]$Labels       = @(),
-        [int[]]   $BlockedBy    = @(),
-        [bool]    $BlockerInPlan = $true,
-        [string]  $Title        = "Issue $Number",
-        [string]  $ClosedAt     = $null,
-        [string]  $CreatedAt    = '2025-01-01T00:00:00Z'
+        [int]       $Number,
+        [string]    $State        = 'OPEN',
+        [string[]]  $Labels       = @(),
+        [int[]]     $BlockedBy    = @(),
+        [bool]      $BlockerInPlan = $true,
+        [string]    $Title        = "Issue $Number",
+        [string]    $ClosedAt     = $null,
+        [string]    $CreatedAt    = '2025-01-01T00:00:00Z',
+        [hashtable] $Parent       = $null,
+        [hashtable] $SubIssues    = $null
     )
     return [PSCustomObject]@{
         number        = $Number
@@ -1113,6 +1151,8 @@ function New-IssueState {
         closedAt      = $ClosedAt
         createdAt     = $CreatedAt
         totalCount    = 1  # default rendered count = totalCount (no overflow)
+        parent        = $Parent
+        subIssues     = $SubIssues
     }
 }
 

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -165,361 +165,261 @@ function ConvertFrom-SequenceSpec {
 }
 
 # ---------------------------------------------------------------------------
-# Get-PortfolioBuckets
-# Classifies issueStateObjects into Now/Next/Blocked/RecentlyClosed/Triage.
+# Get-SubIssueNodes
+# Returns a proper object[] from subIssues.nodes, handling the PowerShell
+# quirk where a single-element array stored in a hashtable value is unwrapped
+# to the single element on retrieval (so .nodes may be a hashtable, not array).
+# ---------------------------------------------------------------------------
+function Get-SubIssueNodes {
+    # Returns nodes from a subIssues hashtable as a proper object[], avoiding the
+    # PowerShell function-return unwrap that strips single-element array wrappers.
+    # Callers must use @(Get-SubIssueNodes ...) to force an array regardless of count.
+    param($subIssues)
+    if ($null -eq $subIssues -or $null -eq $subIssues.nodes) { return }
+    $raw = $subIssues.nodes
+    if ($raw -is [System.Collections.IEnumerable] -and -not ($raw -is [System.Collections.IDictionary]) -and -not ($raw -is [string])) {
+        # Already a proper collection (array/list) — enumerate to caller
+        foreach ($n in $raw) { $n }
+    } else {
+        # Single item (hashtable unwrapped by PowerShell) or scalar — emit as-is
+        $raw
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Get-PortfolioBuckets v2
+# Classifies issueStateObjects into the v2 model:
+#   ActiveUmbrella, ActiveChildren, RankedUmbrellas, Triage, TriageResidualCount,
+#   DriftWarnings, IntegrityWarnings, RecentlyClosed
 #
-# issueStateObjects fields:
+# issueStateObjects fields (v2):
 #   .number (int), .state ('OPEN'/'CLOSED'), .title (string), .labels (string[])
-#   .blockedBy (int[]), .blockerInPlan (bool), .closedAt (string ISO or $null)
-#   .totalCount (int)
+#   .blockedBy (int[]), .closedAt (string ISO or $null), .createdAt (string ISO)
+#   .parent (hashtable {number} | $null), .subIssues (hashtable {totalCount, nodes[{number,state}]} | $null)
 # ---------------------------------------------------------------------------
 function Get-PortfolioBuckets {
     param(
-        $spec,
-        $issueStateObjects,
-        # s3 parameters — KnownChildSet is an array of issue numbers that are
-        # children of sequenced umbrellas. OpenLeafCandidates and ClosedLeafItems
-        # come from s2's repo-wide scans and are passed through for RecentlyClosed.
-        $KnownChildSet      = $null,   # array of child issue numbers (from sequenced umbrellas)
-        $OpenLeafCandidates = $null,   # array of open-scan issue objects (unused in pure derivation)
-        $ClosedLeafItems    = $null    # array of closed-scan issue objects (for RecentlyClosed)
+        $spec,               # v2 PSCustomObject: .umbrellas (int[]), .control_tower, .recently_closed_days
+        $issueStateObjects   # array of issue objects
     )
 
-    # Multi-lane guard (CR8): the per-lane Now/Next/Blocked derivation required
-    # by the portfolio contract is not yet implemented — this function flattens
-    # all rounds and derives a single global flow. That is correct only for a
-    # single-lane spec. Rather than silently merge multiple lanes into one
-    # board (the silently-wrong-board failure this tracker exists to kill),
-    # fail loud until per-lane derivation lands.
-    $distinctLanes = @($spec.rounds | ForEach-Object { $_.lane } | Sort-Object -Unique)
-    if ($distinctLanes.Count -gt 1) {
-        throw "Multi-lane specs are not yet supported by bucket derivation (found lanes: $($distinctLanes -join ', ')). Per-lane Now/Next/Blocked derivation is tracked separately; refusing to render to avoid silently merging lanes into one board."
+    if ($null -eq $spec) {
+        Write-Error 'Get-PortfolioBuckets: $spec is null'
+        return $null
     }
 
-    # All umbrella numbers: every issue listed in any round of sequence.yaml.
-    $allIssueNumbers = @(
-        $spec.rounds | ForEach-Object { $_.issues } | Sort-Object -Unique
-    )
+    $umbrellaList    = @($spec.umbrellas)
+    $umbrellaSet     = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($u in $umbrellaList) { $null = $umbrellaSet.Add([int]$u) }
 
-    # Sorted rounds for active-round detection.
-    $sortedRounds = @($spec.rounds | Sort-Object round)
+    $driftWarnings     = [System.Collections.Generic.List[string]]::new()
+    $integrityWarnings = [System.Collections.Generic.List[string]]::new()
+    $driftWarnedNums   = [System.Collections.Generic.HashSet[int]]::new()
 
-    # Known child set: build a lookup set for O(1) membership checks.
-    # KnownChildSet from tests is a plain array of issue numbers.
-    $knownChildNumbers = [System.Collections.Generic.HashSet[int]]::new()
-    if ($null -ne $KnownChildSet) {
-        foreach ($item in $KnownChildSet) {
-            if ($item -is [int] -or $item -is [long] -or ($item -is [string] -and $item -match '^\d+$')) {
-                $null = $knownChildNumbers.Add([int]$item)
-            }
-            elseif ($null -ne $item -and $null -ne $item.PSObject.Properties['number']) {
-                $null = $knownChildNumbers.Add([int]$item.number)
-            }
-        }
-    }
-
-    # Umbrella number → round index lookup.
-    $umbrellaToRoundIdx = @{}
-    for ($ri = 0; $ri -lt $sortedRounds.Count; $ri++) {
-        foreach ($num in $sortedRounds[$ri].issues) {
-            $umbrellaToRoundIdx[[int]$num] = $ri
-        }
-    }
-
-    # KnownChildSet round-affiliation: when items are plain ints (no parent-umbrella info),
-    # we default their round index to 1 (non-active). This correctly routes non-active-round
-    # spine children (e.g. children of round-2 umbrellas) to Next rather than Now.
-    # When items are PSCustomObjects with RoundIndex or UmbrellaNumber, we use that directly.
-    $cutoff = [datetimeoffset](Get-Date -AsUTC).AddDays(-$spec.recently_closed_days)
-
-    $closedWithinWindow = [System.Collections.Generic.List[object]]::new()
-    $openBlocked        = [System.Collections.Generic.List[object]]::new()
-    $openUnblocked      = [System.Collections.Generic.List[object]]::new()
-    $triage             = [System.Collections.Generic.List[object]]::new()
-
-    # When ClosedLeafItems is provided (repo-wide closed scan), source RecentlyClosed
-    # from it directly — filtering out umbrella numbers (AC9 requires leaf closures only).
-    # This replaces the per-issueStateObjects CLOSED detection for RecentlyClosed.
-    if ($null -ne $ClosedLeafItems) {
-        foreach ($leaf in $ClosedLeafItems) {
-            if ($allIssueNumbers -contains [int]$leaf.number) { continue }
-            if ($leaf.closedAt) {
-                [datetimeoffset]$leafClosedDate = [datetimeoffset]::MinValue
-                if ([datetimeoffset]::TryParse($leaf.closedAt, [ref]$leafClosedDate)) {
-                    if ($leafClosedDate -ge $cutoff) {
-                        $closedWithinWindow.Add($leaf)
-                    }
-                }
-            }
-        }
-    }
-
-    # Build per-child round affiliation from KnownChildSet.
-    # Support two formats:
-    #   1. Array of int/string → child number only; round affiliation unknown → "spine-next"
-    #   2. Array of PSCustomObject with .number and .UmbrellaNumber/.RoundIndex → use parent info
-    $childRoundIndex = @{}   # child number → round index (0 = active, 1+ = non-active)
-    $childToUmbrella = @{}   # child number → parent umbrella number (rich-object path only)
-    if ($null -ne $KnownChildSet) {
-        foreach ($item in $KnownChildSet) {
-            $childNum = $null
-            $roundIdx = -1   # -1 = unknown
-            $umbNum   = $null
-
-            if ($item -is [int] -or $item -is [long]) {
-                $childNum = [int]$item
-            }
-            elseif ($item -is [string] -and $item -match '^\d+$') {
-                $childNum = [int]$item
-            }
-            elseif ($null -ne $item) {
-                $props = $item.PSObject.Properties
-                if ($null -ne $props['number']) {
-                    $childNum = [int]$item.number
-                }
-                if ($null -ne $props['RoundIndex']) {
-                    $roundIdx = [int]$item.RoundIndex
-                }
-                elseif ($null -ne $props['UmbrellaNumber']) {
-                    $umbNum = [int]$item.UmbrellaNumber
-                    if ($umbrellaToRoundIdx.ContainsKey($umbNum)) {
-                        $roundIdx = $umbrellaToRoundIdx[$umbNum]
-                    }
-                }
-                if ($null -ne $props['UmbrellaNumber']) {
-                    $umbNum = [int]$item.UmbrellaNumber
-                }
-            }
-
-            if ($null -ne $childNum) {
-                # If round index is unknown, default to 1 (non-active — round 1+ heuristic).
-                # This handles flat int array passing convention from tests.
-                if ($roundIdx -lt 0) { $roundIdx = 1 }
-                $childRoundIndex[[int]$childNum] = $roundIdx
-                if ($null -ne $umbNum) {
-                    $childToUmbrella[[int]$childNum] = [int]$umbNum
-                }
-            }
-        }
-    }
-
+    # Build lookup: number → issue state object
+    $issueByNumber = @{}
     foreach ($issue in $issueStateObjects) {
-        if ($issue.state -eq 'CLOSED') {
-            # Only add to RecentlyClosed from issueStateObjects when ClosedLeafItems is not
-            # provided (legacy path). When ClosedLeafItems is provided, RecentlyClosed is
-            # sourced from the repo-wide scan above (excluding umbrella closures per AC9).
-            if ($null -eq $ClosedLeafItems -and $issue.closedAt) {
-                [datetimeoffset]$closedDate = [datetimeoffset]::MinValue
-                if ([datetimeoffset]::TryParse($issue.closedAt, [ref]$closedDate)) {
-                    if ($closedDate -ge $cutoff) {
-                        $closedWithinWindow.Add($issue)
-                    }
-                }
-            }
-            continue
-        }
-
-        # Determine classification for this open issue.
-        $isUmbrella     = $allIssueNumbers -contains $issue.number
-        $isSpineChild   = $childRoundIndex.ContainsKey([int]$issue.number)
-        $hasTriageLabel = $issue.labels -contains 'triage'
-
-        # Triage: triage-labeled issues always go to Triage.
-        if ($hasTriageLabel) {
-            $triage.Add($issue)
-            continue
-        }
-
-        # Legacy path (KnownChildSet not provided): unsequenced open issues → Triage.
-        # When KnownChildSet is $null, the caller is using the old API convention where
-        # only sequenced issues were passed in issueStateObjects and any unsequenced
-        # issue (not in any round) belongs in Triage. This preserves backward compatibility
-        # with existing tests that don't pass KnownChildSet.
-        if ($null -eq $KnownChildSet -and (-not $isUmbrella) -and (-not $isSpineChild)) {
-            $triage.Add($issue)
-            continue
-        }
-
-        # Determine isFloat: open, not an umbrella, NOT in KnownChildSet
-        # (Only applies when KnownChildSet is provided — floats land in Now)
-        $isFloat = (-not $isUmbrella) -and (-not $isSpineChild)
-
-        # Determine inProgress: has 'in progress' label
-        $isInProgress = $issue.labels -contains 'in progress'
-
-        # Attach derived properties
-        $issue | Add-Member -NotePropertyName 'isFloat'    -NotePropertyValue $isFloat    -Force
-        $issue | Add-Member -NotePropertyName 'inProgress' -NotePropertyValue $isInProgress -Force
-
-        # Check blockers: blocked if blockedBy is non-empty (open blockers only — already filtered by Invoke-PortfolioRender)
-        $hasBlockers = $issue.blockedBy -and $issue.blockedBy.Count -gt 0
-
-        if ($hasBlockers) {
-            # Build per-blocker annotations (CR7)
-            $annotations = $issue.blockedBy | ForEach-Object {
-                $blockerNum = $_
-                if ($allIssueNumbers -notcontains $blockerNum) {
-                    "blocked by #$blockerNum (out of plan)"
-                }
-                else {
-                    "blocked by #$blockerNum"
-                }
-            }
-            $issue | Add-Member -NotePropertyName 'blockerAnnotations' `
-                                -NotePropertyValue ($annotations -join ', ') `
-                                -Force
-            $openBlocked.Add($issue)
-        }
-        else {
-            $openUnblocked.Add($issue)
-        }
+        $issueByNumber[[int]$issue.number] = $issue
     }
 
-    # Determine active round index: lowest round that has open issues (blocked or unblocked)
-    $allOpenIssues = @($openBlocked) + @($openUnblocked)
-    $nowRoundIdx   = -1
-    for ($i = 0; $i -lt $sortedRounds.Count; $i++) {
-        $roundUmbrellaNums = $sortedRounds[$i].issues
-        $hasOpenUmbrella   = $allOpenIssues | Where-Object { $roundUmbrellaNums -contains $_.number }
-        if ($hasOpenUmbrella) {
-            $nowRoundIdx = $i
+    # ---------------------------------------------------------------------------
+    # ActiveUmbrella (AC3): first OPEN umbrella in spec list order
+    # ---------------------------------------------------------------------------
+    $activeUmbrella = $null
+    foreach ($umbNum in $umbrellaList) {
+        $umbIssue = $issueByNumber[[int]$umbNum]
+        if ($null -eq $umbIssue) { continue }
+        if ($umbIssue.state -eq 'OPEN') {
+            $activeUmbrella = $umbIssue
             break
         }
-    }
-
-    $nowIssues  = [System.Collections.Generic.List[object]]::new()
-    $nextIssues = [System.Collections.Generic.List[object]]::new()
-
-    if ($nowRoundIdx -ge 0) {
-        $nowRoundNums = @($sortedRounds[$nowRoundIdx].issues)
-
-        # Partition open unblocked issues into Now/Next/float buckets.
-        foreach ($issue in $openUnblocked) {
-            $num = [int]$issue.number
-
-            if ($nowRoundNums -contains $num) {
-                # Active-round umbrella: container only — do not render as a work item
-                continue
-            }
-            elseif ($childRoundIndex.ContainsKey($num)) {
-                # Spine child — route by round index
-                $childRound = $childRoundIndex[$num]
-                if ($childRound -le $nowRoundIdx) {
-                    # Active-round spine child → Now
-                    $nowIssues.Add($issue)
-                }
-                else {
-                    # Non-active-round spine child → Next
-                    $nextIssues.Add($issue)
-                }
-            }
-            elseif ($allIssueNumbers -contains $num) {
-                # Non-active-round umbrella: container only — do not render as a work item
-                continue
-            }
-            else {
-                # Float (not umbrella, not spine child, not triage) → Now
-                $nowIssues.Add($issue)
+        else {
+            # CLOSED listed umbrella → DriftWarning (deduplicated)
+            if ($driftWarnedNums.Add([int]$umbNum)) {
+                $driftWarnings.Add("⚠️ listed umbrella #$umbNum is closed")
             }
         }
-
     }
-    else {
-        # No active round found — all open unblocked issues are floats → Now
-        foreach ($issue in $openUnblocked) {
-            $nowIssues.Add($issue)
+
+    # ---------------------------------------------------------------------------
+    # DriftWarnings (AC7): open issue with totalCount>0 not in umbrella list
+    # Also: CLOSED listed umbrella (already emitted above for pre-active ones;
+    # emit for any remaining CLOSED listed umbrellas not yet warned)
+    # ---------------------------------------------------------------------------
+    foreach ($issue in $issueStateObjects) {
+        # Open issue that looks like an umbrella (has subIssues.totalCount > 0) but not listed
+        if ($issue.state -eq 'OPEN') {
+            $subIssuesTotalCount = 0
+            if ($null -ne $issue.subIssues -and $null -ne $issue.subIssues.totalCount) {
+                $subIssuesTotalCount = [int]$issue.subIssues.totalCount
+            }
+            if ($subIssuesTotalCount -gt 0 -and -not $umbrellaSet.Contains([int]$issue.number)) {
+                $driftWarnings.Add("⚠️ open umbrella #$($issue.number) not in ranked list")
+            }
+        }
+        # CLOSED listed umbrella not yet warned
+        if ($issue.state -eq 'CLOSED' -and $umbrellaSet.Contains([int]$issue.number)) {
+            if ($driftWarnedNums.Add([int]$issue.number)) {
+                $driftWarnings.Add("⚠️ listed umbrella #$($issue.number) is closed")
+            }
         }
     }
 
-    # Apply ordering to Now: current-round-spine-first → createdAt desc → priority-label tiebreak → number asc
-    # Current-round spine: issues in nowRoundNums (not float)
-    # Floats: issues with isFloat=$true
-    $nowSorted = @(
-        $nowIssues | Sort-Object -Property `
-            @{ Expression = { if ($_.isFloat) { 1 } else { 0 } } },
-            @{ Expression = { Get-CreatedAtSortTicks $_.createdAt } },
+    # ---------------------------------------------------------------------------
+    # IntegrityWarnings (AC8): totalCount != returned nodes count
+    # ---------------------------------------------------------------------------
+    foreach ($umbNum in $umbrellaList) {
+        $umbIssue = $issueByNumber[[int]$umbNum]
+        if ($null -eq $umbIssue) { continue }
+        if ($null -ne $umbIssue.subIssues) {
+            $tc    = if ($null -ne $umbIssue.subIssues.totalCount) { [int]$umbIssue.subIssues.totalCount } else { 0 }
+            $nodes = @(Get-SubIssueNodes $umbIssue.subIssues)
+            if ($tc -ne $nodes.Count) {
+                $integrityWarnings.Add("⚠️ umbrella #${umbNum}: subIssues.totalCount=$tc but only $($nodes.Count) nodes returned (possible truncation)")
+            }
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # ActiveChildren (AC4): open direct sub-issues of ActiveUmbrella, ordered
+    # Sort: priority-label key → createdAt desc → number asc (mandatory tiebreak)
+    # ---------------------------------------------------------------------------
+    $activeChildren = @()
+    if ($null -ne $activeUmbrella -and $null -ne $activeUmbrella.subIssues) {
+        $allChildNodes  = @(Get-SubIssueNodes $activeUmbrella.subIssues)
+        $openChildNodes = @($allChildNodes | Where-Object { $_.state -eq 'OPEN' })
+        $enrichedChildren = [System.Collections.Generic.List[object]]::new()
+        foreach ($childNode in $openChildNodes) {
+            # Get full issue object from issueStateObjects if available; else use node directly
+            $childObj = $issueByNumber[[int]$childNode.number]
+            if ($null -eq $childObj) {
+                # Construct minimal object from node data
+                $childObj = [PSCustomObject]@{
+                    number    = $childNode.number
+                    state     = $childNode.state
+                    title     = if ($null -ne $childNode.title) { $childNode.title } else { "Issue $($childNode.number)" }
+                    labels    = @()
+                    blockedBy = @()
+                    createdAt = $null
+                }
+            }
+            # Blocked annotation
+            if ($childObj.blockedBy -and $childObj.blockedBy.Count -gt 0) {
+                $annotation = ($childObj.blockedBy | ForEach-Object { "#$_" }) -join ', '
+                $childObj | Add-Member -NotePropertyName 'BlockedAnnotation' `
+                                       -NotePropertyValue "⛔ blocked by $annotation" `
+                                       -Force
+            }
+            $enrichedChildren.Add($childObj)
+        }
+        $activeChildren = @(
+            $enrichedChildren | Sort-Object -Property `
+                @{ Expression = { Get-PriorityKey $_.labels } },
+                @{ Expression = { Get-CreatedAtSortTicks $_.createdAt } },
+                @{ Expression = { [int]$_.number } }
+        )
+    }
+
+    # ---------------------------------------------------------------------------
+    # RankedUmbrellas (AC5): all listed umbrellas in spec order with Done/Total
+    # Done/Total from direct children (.subIssues.nodes) only
+    # ---------------------------------------------------------------------------
+    $rankedUmbrellas = [System.Collections.Generic.List[object]]::new()
+    foreach ($umbNum in $umbrellaList) {
+        $umbIssue = $issueByNumber[[int]$umbNum]
+        $title    = if ($null -ne $umbIssue) { $umbIssue.title } else { "Issue $umbNum" }
+        $state    = if ($null -ne $umbIssue) { $umbIssue.state } else { 'UNKNOWN' }
+        $isActive = ($null -ne $activeUmbrella -and [int]$activeUmbrella.number -eq [int]$umbNum)
+
+        $done  = 0
+        $total = 0
+        $doneTotalLabel = '0/0 (no children linked)'
+
+        if ($null -ne $umbIssue -and $null -ne $umbIssue.subIssues) {
+            $nodes = @(Get-SubIssueNodes $umbIssue.subIssues)
+            $total = $nodes.Count
+            $done  = @($nodes | Where-Object { $_.state -eq 'CLOSED' }).Count
+            if ($total -gt 0) {
+                $doneTotalLabel = "$done/$total"
+            }
+            # else: zero children → keep '0/0 (no children linked)'
+        }
+
+        $rankedUmbrellas.Add([PSCustomObject]@{
+            Number        = [int]$umbNum
+            Title         = $title
+            State         = $state
+            Done          = $done
+            Total         = $total
+            DoneTotalLabel = $doneTotalLabel
+            IsActive      = $isActive
+        })
+    }
+
+    # ---------------------------------------------------------------------------
+    # Triage (AC6): open ∧ parent==null ∧ subIssues.totalCount==0 ∧ not in umbrella list
+    # Sort: priority-label key → createdAt desc → number asc; cap at 5
+    # NO inversion fallback (judge finding M4)
+    # ---------------------------------------------------------------------------
+    $triageCandidates = [System.Collections.Generic.List[object]]::new()
+    foreach ($issue in $issueStateObjects) {
+        if ($issue.state -ne 'OPEN') { continue }
+        if ($umbrellaSet.Contains([int]$issue.number)) { continue }
+
+        # parent must be null (the .parent field is null/absent)
+        $parentIsNull = $true
+        if ($null -ne $issue.PSObject.Properties['parent'] -and $null -ne $issue.parent) {
+            $parentIsNull = $false
+        }
+        if (-not $parentIsNull) { continue }
+
+        # subIssues.totalCount must be 0
+        $subTotalCount = 0
+        if ($null -ne $issue.subIssues -and $null -ne $issue.subIssues.totalCount) {
+            $subTotalCount = [int]$issue.subIssues.totalCount
+        }
+        if ($subTotalCount -ne 0) { continue }
+
+        $triageCandidates.Add($issue)
+    }
+
+    $triageSorted = @(
+        $triageCandidates | Sort-Object -Property `
             @{ Expression = { Get-PriorityKey $_.labels } },
-            @{ Expression = { $_.number } }
+            @{ Expression = { Get-CreatedAtSortTicks $_.createdAt } },
+            @{ Expression = { [int]$_.number } }
     )
 
-    # Apply ordering to Next: createdAt desc → priority → number asc
-    $nextSorted = @(
-        $nextIssues | Sort-Object -Property `
-            @{ Expression = { Get-CreatedAtSortTicks $_.createdAt } },
-            @{ Expression = { Get-PriorityKey $_.labels } },
-            @{ Expression = { $_.number } }
-    )
+    $triageCap = 5
+    $triageIssues    = @($triageSorted | Select-Object -First $triageCap)
+    $residualCount   = [math]::Max(0, $triageSorted.Count - $triageCap)
 
-    # CoverageGaps (AC7): for each active-round umbrella, if it has 0 open sub-issues
-    # in KnownChildSet that are in Now-eligible (unblocked), emit a CoverageGaps entry.
-    $coverageGaps = [System.Collections.Generic.List[object]]::new()
-    if ($nowRoundIdx -ge 0) {
-        $activeUmbrellaSet = @($sortedRounds[$nowRoundIdx].issues)
-        # Build set of child numbers that route to Now (active-round spine children, unblocked)
-        $activeChildNums = [System.Collections.Generic.HashSet[int]]::new()
-        foreach ($childNum in $childRoundIndex.Keys) {
-            $roundIdx = $childRoundIndex[$childNum]
-            if ($roundIdx -le $nowRoundIdx) {
-                # Check not blocked
-                $childIssue = $allOpenIssues | Where-Object { $_.number -eq $childNum }
-                if ($childIssue -and -not ($childIssue.blockedBy -and $childIssue.blockedBy.Count -gt 0)) {
-                    $null = $activeChildNums.Add($childNum)
+    # ---------------------------------------------------------------------------
+    # RecentlyClosed: issues in issueStateObjects closed within recently_closed_days
+    # ---------------------------------------------------------------------------
+    $cutoff = [datetimeoffset](Get-Date -AsUTC).AddDays(-$spec.recently_closed_days)
+    $recentlyClosed = [System.Collections.Generic.List[object]]::new()
+    foreach ($issue in $issueStateObjects) {
+        if ($issue.state -ne 'CLOSED') { continue }
+        if ($issue.closedAt) {
+            [datetimeoffset]$closedDate = [datetimeoffset]::MinValue
+            if ([datetimeoffset]::TryParse($issue.closedAt, [ref]$closedDate)) {
+                if ($closedDate -ge $cutoff) {
+                    $recentlyClosed.Add($issue)
                 }
-            }
-        }
-
-        foreach ($umbrellaNum in $activeUmbrellaSet) {
-            $umbrellaHasChildren = $false
-            if ($childToUmbrella.Count -gt 0) {
-                # Rich-object path: check if any child is attributed to THIS specific umbrella
-                # and is active-round eligible. This is per-umbrella accurate.
-                foreach ($childNum in $childToUmbrella.Keys) {
-                    if ($childToUmbrella[$childNum] -eq [int]$umbrellaNum) {
-                        $cRoundIdx = if ($childRoundIndex.ContainsKey([int]$childNum)) { $childRoundIndex[[int]$childNum] } else { -1 }
-                        if ($cRoundIdx -le $nowRoundIdx -and $cRoundIdx -ge 0) {
-                            $umbrellaHasChildren = $true
-                            break
-                        }
-                    }
-                }
-            }
-            else {
-                # Flat-int fallback: no per-umbrella association available; check if any
-                # KnownChildSet member is active-round eligible (conservative approximation).
-                foreach ($childNum in $knownChildNumbers) {
-                    $cRoundIdx = if ($childRoundIndex.ContainsKey([int]$childNum)) { $childRoundIndex[[int]$childNum] } else { -1 }
-                    if ($cRoundIdx -le $nowRoundIdx -and $cRoundIdx -ge 0) {
-                        $umbrellaHasChildren = $true
-                        break
-                    }
-                }
-            }
-
-            if (-not $umbrellaHasChildren) {
-                $coverageGaps.Add([PSCustomObject]@{
-                    umbrella = $umbrellaNum
-                    note     = 'no leaves modeled yet'
-                })
             }
         }
     }
-
-    $blockedSorted        = @($openBlocked        | Sort-Object number)
-    $recentlyClosedSorted = @($closedWithinWindow  | Sort-Object number)
-    $triageSorted         = @($triage              | Sort-Object number)
 
     return [PSCustomObject]@{
-        Now                      = $nowSorted
-        NowTotalCount            = Get-BucketTotal $nowSorted
-        Next                     = $nextSorted
-        NextTotalCount           = Get-BucketTotal $nextSorted
-        Blocked                  = $blockedSorted
-        BlockedTotalCount        = Get-BucketTotal $blockedSorted
-        RecentlyClosed           = $recentlyClosedSorted
-        RecentlyClosedTotalCount = Get-BucketTotal $recentlyClosedSorted
-        Triage                   = $triageSorted
-        TriageTotalCount         = Get-BucketTotal $triageSorted
-        CoverageGaps             = @($coverageGaps)
+        ActiveUmbrella      = $activeUmbrella
+        ActiveChildren      = $activeChildren
+        RankedUmbrellas     = $rankedUmbrellas.ToArray()
+        Triage              = $triageIssues
+        TriageResidualCount = $residualCount
+        DriftWarnings       = $driftWarnings.ToArray()
+        IntegrityWarnings   = $integrityWarnings.ToArray()
+        RecentlyClosed      = $recentlyClosed.ToArray()
     }
 }
 
@@ -1068,13 +968,10 @@ query {
     $existingBody = $ctData.body
 
     # 5. Derive buckets — pass fetched data as parameters so Get-PortfolioBuckets
-    #    remains pure (no I/O).
+    #    remains pure (no I/O). (v2 signature: spec + issueStateObjects only)
     $buckets = Get-PortfolioBuckets `
         -spec $spec `
-        -issueStateObjects $issueStates.ToArray() `
-        -KnownChildSet $knownChildSet.ToArray() `
-        -OpenLeafCandidates $openLeaves `
-        -ClosedLeafItems $closedLeaves
+        -issueStateObjects $issueStates.ToArray()
 
     # 6. Format content block
     $timestamp    = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')

--- a/Documents/Planning/sequence.yaml
+++ b/Documents/Planning/sequence.yaml
@@ -1,17 +1,7 @@
 # Agent Orchestra — Portfolio Sequence Spec
 # Managed by render-portfolio.ps1 — do not edit the control_tower value by hand.
-# Rounds represent work priority order within each lane.
-# Owner refines rounds via normal PRs.
-schema_version: 1
+# Umbrellas list work epics in priority order. New umbrellas insert at the correct rank.
+schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-rounds:
-  - lane: main
-    round: 1
-    issues: [425, 571]
-  - lane: main
-    round: 2
-    issues: [476, 662]
-  - lane: main
-    round: 3
-    issues: [674, 693]
+umbrellas: [476, 571, 674, 662, 343, 693, 732]


### PR DESCRIPTION
## Summary

Replaces the v1 lanes/rounds bucket model with the v2 ranked-umbrella board. Steps s1–s4 land atomically — a v2 `sequence.yaml` against the v1 parser renders a near-empty board, so schema + derivation + formatter must merge together.

- **s1**: `ConvertFrom-SequenceSpec` rewritten for `schema_version: 2` + `umbrellas: [N, N, ...]` inline ordered list; v1 rejected with loud error; `sequence.yaml` migrated (7 umbrellas, `#425` removed — closed)
- **s2**: `Get-PortfolioBuckets` rewritten — ActiveUmbrella (first open in spec order), ActiveChildren (open direct sub-issues, priority→recency→number), RankedUmbrellas (done/total direct children), Triage (parent==null ∧ totalCount==0 ∧ not-in-list, cap 5), DriftWarnings, IntegrityWarnings, RecentlyClosed
- **s3**: `Invoke-PortfolioRender` rewritten — Step-0 GraphQL probe for `parent`/`subIssues` field availability (fail loud if absent), umbrellas-list consumer, parent-edge data on all queried issues; triage-label scan removed
- **s4**: `Format-PortfolioMarkdown` rewritten — `## 🎯 Active` (expanded children + ⛔ + done/total footer), `## Umbrellas (ranked)` (done/total + ◀ active), `## 🔥 Triage` (top 5 + +N more), `## Recently closed`, ⚠️ drift/integrity warnings; header comment updated #692→#704
- **Refactor**: variable rename (`$openLeaves*` → `$openIssues*`), stale v1 comment cleanup, dead `Get-ModelTotal` helper removed
- **Judge fixes**: Step-0 probe fails loud on non-JSON exit-0 response; unresolved-item footer message decoupled from "not found" assumption; comment corrected to match actual `Write-Error -ErrorAction Stop` mechanism

**64 Pester tests pass, 0 fail** (full TDD red→green per step).

## Depends on
- **#746** (soft deferred): `first:50` subIssues cap; truncation is surfaced by IntegrityWarnings rather than silently corrupting the board. IntegrityWarning fires when `totalCount ≠ returned nodes count`.

## Follow-up tracked (judge rulings F3/F5/F7)
- F3: RecentlyClosed includes closed listed umbrellas (also in DriftWarnings) — minor double-report
- F5: Open-umbrella DriftWarning branch lacks dedup guard (latent; upstream pipeline dedups)
- F7: Active zone no inline `(+N more)` marker when >50 children — covered by IntegrityWarning but lacks inline signal (same #746 boundary)

## s5 (operator action — not in this PR)
Link all 7 umbrellas' open children as native sub-issues via `addSubIssue` GraphQL mutations. Enables accurate done/total and clean triage on the live board. CE Gate (s6) depends on s4 merged + s5 done.

## Test plan
- [x] `Invoke-Pester -Path .github/scripts/Tests/render-portfolio.Tests.ps1` — 64 pass, 0 fail
- [ ] s5 operator action: link sub-issues for all 7 umbrellas (#476, #571, #674, #662, #343, #693, #732)
- [ ] s6 CE Gate: run renderer, verify AC1–AC10, exercise S1–S5 scenarios
- [ ] Eyeball the rendered #704 board post-merge + post-s5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the portfolio view to an umbrella-based layout with distinct sections for active work (including active children with progress counts), ranked umbrellas, triage, and recently closed items.
  * Migrated the portfolio sequence spec to schema version 2 for the new umbrella format.

* **Bug Fixes**
  * Improved issue classification and ordering for more consistent results.
  * Added drift and integrity warnings to highlight inconsistencies in umbrella and sub-issue data.

* **Tests**
  * Updated helpers to cover the new schema and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->