### PR TITLE
fix(#746): guard render-portfolio GraphQL first:50 connection caps with overflow detection

### DIFF
--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -1481,4 +1481,456 @@ rounds:
             if (Test-Path $tempSpecCeil3) { Remove-Item $tempSpecCeil3 -Force -ErrorAction SilentlyContinue }
         }
     }
+
+    # ===========================================================================
+    # Connection overflow guards (issue #746)
+    # RED until Step 2 production code adds Test-ConnectionOverflow and
+    # the per-connection overflow checks in Invoke-PortfolioRender.
+    # ===========================================================================
+    Describe 'connection overflow guards' {
+
+        # ------------------------------------------------------------------
+        # Build the shared overflow JSON in BeforeAll so it is available
+        # when BeforeEach runs.
+        # All three connections (labels, blockedBy, subIssues) have
+        # totalCount=51 but only 50 nodes — overflow on all three.
+        # blockedBy nodes are all OPEN so without overflow the issue would be
+        # "Blocked"; with overflow it must become unresolved (AC2).
+        # ------------------------------------------------------------------
+        BeforeAll {
+            $labelNodes101    = (1..50 | ForEach-Object { '{"name":"label-' + $_ + '"}' }) -join ','
+            $blockerNodes101  = (1..50 | ForEach-Object { '{"number":' + $_ + ',"title":"Blocker ' + $_ + '","state":"OPEN"}' }) -join ','
+            $subIssueNodes101 = (1..50 | ForEach-Object { '{"number":' + (1000 + $_) + '}' }) -join ','
+            $script:OverflowJsonShared = '{"data":{"repository":{"issue":{"number":101,"title":"Test truncation guard issue","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","labels":{"totalCount":51,"nodes":[' + $labelNodes101 + ']},"blockedBy":{"totalCount":51,"nodes":[' + $blockerNodes101 + ']},"subIssues":{"totalCount":51,"nodes":[' + $subIssueNodes101 + ']}}}}}'
+        }
+
+        BeforeEach {
+            $script:GhEditCallCount = 0
+            $script:GhEditArgs      = @()
+            $script:GhEditBody      = ''
+
+            $script:OverflowJson = $script:OverflowJsonShared
+
+            function global:gh {
+                param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+
+                if ($ghArgs -contains 'edit') {
+                    $script:GhEditCallCount++
+                    $bodyIdx = [Array]::IndexOf([string[]]$ghArgs, '--body')
+                    if ($bodyIdx -ge 0 -and ($bodyIdx + 1) -lt $ghArgs.Count) {
+                        $script:GhEditBody = $ghArgs[$bodyIdx + 1]
+                    }
+                    $global:LASTEXITCODE = 0
+                    return
+                }
+
+                if ($ghArgs -contains 'list') {
+                    if ($ghArgs -contains 'closed') { $global:LASTEXITCODE = 0; return '[]' }
+                    if ($ghArgs -contains 'triage') { $global:LASTEXITCODE = 0; return '[]' }
+                    # open scan: umbrella #101 (has subIssues → is umbrella)
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":101,"title":"Test truncation guard issue","labels":["subIssues"],"createdAt":"2026-01-01T00:00:00Z"}]'
+                }
+
+                if ($ghArgs -contains 'api') {
+                    $global:LASTEXITCODE = 0
+                    return $script:OverflowJson
+                }
+
+                if ($ghArgs -contains 'view') {
+                    $global:LASTEXITCODE = 0
+                    return '{"body":"# Control Tower\n\nNo portfolio block yet."}'
+                }
+
+                $global:LASTEXITCODE = 0
+            }
+        }
+
+        AfterEach {
+            Remove-Item function:global:gh -ErrorAction SilentlyContinue
+            $script:GhEditCallCount = 0
+            $script:GhEditArgs      = @()
+            $script:GhEditBody      = ''
+            $script:OverflowJson    = $null
+        }
+
+        It 'labels overflow emits Write-Warning mentioning labels and issue number (AC5)' {
+            # RED until Step 2 adds overflow check that calls Write-Warning when
+            # labels.totalCount > labels.nodes.Count.
+            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [101]
+'@ | Set-Content -Path $tempSpecOvf -Encoding UTF8
+
+            try {
+                $captured = Invoke-PortfolioRender -specPath $tempSpecOvf 3>&1
+
+                $warnings = @($captured | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+                # Match-over-collection: NOT positional — any warning matching both criteria suffices.
+                $matchingWarnings = @($warnings | Where-Object { $_.Message -match 'labels' -and $_.Message -match '101' })
+                $matchingWarnings.Count | Should -BeGreaterThan 0 `
+                    -Because 'a Write-Warning mentioning "labels" and issue #101 must fire when labels overflow is detected (AC5)'
+            }
+            finally {
+                if (Test-Path $tempSpecOvf) { Remove-Item $tempSpecOvf -Force -ErrorAction SilentlyContinue }
+            }
+        }
+
+        It 'blockedBy overflow routes issue to unresolved section even when all visible blockers are closed (AC2)' {
+            # RED until Step 2 adds overflow check.
+            # Setup: all 50 visible blockers are CLOSED (so without overflow detection the issue
+            # would appear startable in Now/Next because no open blockers are visible).
+            # But totalCount=51 > 50 nodes → one blocker is hidden. The hidden blocker might be
+            # OPEN, so the issue MUST be routed to unresolved/overflow rather than startable.
+            # Without the Step 2 overflow check, the issue goes to Now/Next (startable) → RED.
+            # With the Step 2 check, the issue is routed to unresolved/overflow → GREEN.
+
+            $closedBlockerNodes = (1..50 | ForEach-Object { '{"number":' + $_ + ',"title":"Blocker ' + $_ + '","state":"CLOSED"}' }) -join ','
+            $subIssueNodes101   = (1..50 | ForEach-Object { '{"number":' + (1000 + $_) + '}' }) -join ','
+            $closedBlockerOverflowJson = '{"data":{"repository":{"issue":{"number":101,"title":"Test overflow issue","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":51,"nodes":[' + $closedBlockerNodes + ']},"subIssues":{"totalCount":51,"nodes":[' + $subIssueNodes101 + ']}}}}}'
+
+            function global:gh {
+                param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+                if ($ghArgs -contains 'edit') {
+                    $script:GhEditCallCount++
+                    $bodyIdx = [Array]::IndexOf([string[]]$ghArgs, '--body')
+                    if ($bodyIdx -ge 0 -and ($bodyIdx + 1) -lt $ghArgs.Count) {
+                        $script:GhEditBody = $ghArgs[$bodyIdx + 1]
+                    }
+                    $global:LASTEXITCODE = 0; return
+                }
+                if ($ghArgs -contains 'list') {
+                    if ($ghArgs -contains 'closed') { $global:LASTEXITCODE = 0; return '[]' }
+                    if ($ghArgs -contains 'triage') { $global:LASTEXITCODE = 0; return '[]' }
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":101,"title":"Test overflow issue","labels":["subIssues"],"createdAt":"2026-01-01T00:00:00Z"}]'
+                }
+                if ($ghArgs -contains 'api') { $global:LASTEXITCODE = 0; return $closedBlockerOverflowJson }
+                if ($ghArgs -contains 'view') { $global:LASTEXITCODE = 0; return '{"body":"# Control Tower\n\nNo portfolio block yet."}' }
+                $global:LASTEXITCODE = 0
+            }
+
+            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [101]
+'@ | Set-Content -Path $tempSpecOvf -Encoding UTF8
+
+            try {
+                Invoke-PortfolioRender -specPath $tempSpecOvf
+
+                $script:GhEditBody | Should -Match '101' `
+                    -Because 'issue #101 must appear in the rendered board'
+                # With Step 2 overflow detection: issue routes to unresolved/overflow.
+                # Without overflow detection (current): all visible blockers are CLOSED so
+                # openBlockers=[] → issue goes to Now/Next (startable) — body won't match
+                # 'overflow' pattern → test FAILS RED as required.
+                $script:GhEditBody | Should -Match 'overflow' `
+                    -Because 'blockedBy overflow must route #101 to an overflow section: visible blockers are all closed but totalCount=51 means a hidden blocker exists (AC2)'
+            }
+            finally {
+                if (Test-Path $tempSpecOvf) { Remove-Item $tempSpecOvf -Force -ErrorAction SilentlyContinue }
+            }
+        }
+
+        It 'subIssues overflow emits Write-Warning mentioning subIssues and issue number (AC5)' {
+            # RED until Step 2 adds overflow check for subIssues.totalCount > subIssues.nodes.Count.
+            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [101]
+'@ | Set-Content -Path $tempSpecOvf -Encoding UTF8
+
+            try {
+                $captured = Invoke-PortfolioRender -specPath $tempSpecOvf 3>&1
+
+                $warnings = @($captured | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+                # Match-over-collection: any warning matching both criteria suffices.
+                $matchingWarnings = @($warnings | Where-Object { $_.Message -match 'subIssues' -and $_.Message -match '101' })
+                $matchingWarnings.Count | Should -BeGreaterThan 0 `
+                    -Because 'a Write-Warning mentioning "subIssues" and issue #101 must fire when subIssues overflow is detected (AC5)'
+            }
+            finally {
+                if (Test-Path $tempSpecOvf) { Remove-Item $tempSpecOvf -Force -ErrorAction SilentlyContinue }
+            }
+        }
+
+        It 'render still completes with gh issue edit called AND overflow warning emitted (AC6 warn-and-continue)' {
+            # RED until Step 2: overflow guards must fire a Write-Warning AND still let render complete.
+            # This test requires BOTH conditions simultaneously:
+            #   1. at least one overflow warning was emitted (RED without Step 2 — no overflow code yet)
+            #   2. render completes (gh issue edit called >= 1)
+            # Condition 1 is the RED driver — current code emits no overflow warnings.
+            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [101]
+'@ | Set-Content -Path $tempSpecOvf -Encoding UTF8
+
+            try {
+                $captured = Invoke-PortfolioRender -specPath $tempSpecOvf 3>&1
+
+                # Condition 1 (RED driver): at least one overflow warning must have been emitted.
+                $overflowWarnings = @($captured | Where-Object {
+                    $_ -is [System.Management.Automation.WarningRecord] -and
+                    ($_.Message -match 'overflow' -or $_.Message -match 'totalCount' -or $_.Message -match 'labels' -or $_.Message -match 'blockedBy' -or $_.Message -match 'subIssues')
+                })
+                $overflowWarnings.Count | Should -BeGreaterThan 0 `
+                    -Because 'at least one overflow warning must be emitted before we can verify warn-and-continue (AC6 RED driver)'
+
+                # Condition 2 (non-regression): render must complete despite the warning.
+                $script:GhEditCallCount | Should -BeGreaterThan 0 `
+                    -Because 'render must complete and call gh issue edit at least once even when overflow is detected (AC6 warn-and-continue)'
+            }
+            finally {
+                if (Test-Path $tempSpecOvf) { Remove-Item $tempSpecOvf -Force -ErrorAction SilentlyContinue }
+            }
+        }
+
+        It 'idempotency: two renders of overflow issue produce identical body containing overflow marker (AC7)' {
+            # RED until Step 2: overflow handling must be deterministic AND produce an overflow
+            # indicator in the body.
+            # Two parts:
+            #   1. The rendered body must contain an overflow marker (RED driver — no overflow
+            #      code yet, so the body won't have 'overflow' in it → first Should -Match fails)
+            #   2. Two identical invocations must produce byte-identical bodies (AC7 idempotency)
+            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [101]
+'@ | Set-Content -Path $tempSpecOvf -Encoding UTF8
+
+            try {
+                Invoke-PortfolioRender -specPath $tempSpecOvf
+                $firstBody = $script:GhEditBody
+
+                # Part 1 (RED driver): body must contain overflow marker.
+                # Without Step 2, no overflow indicator appears → fails RED.
+                $firstBody | Should -Match 'overflow' `
+                    -Because 'overflow must be reflected in the rendered board body for idempotency to be meaningful (AC7 RED driver)'
+
+                # Reset call tracking for second render
+                $script:GhEditCallCount = 0
+                $script:GhEditBody      = ''
+
+                Invoke-PortfolioRender -specPath $tempSpecOvf
+                $secondBody = $script:GhEditBody
+
+                # Part 2: both renders must produce the same body.
+                $firstBody | Should -Be $secondBody `
+                    -Because 'two renders of the same overflow issue must produce byte-identical board bodies (AC7 idempotency)'
+            }
+            finally {
+                if (Test-Path $tempSpecOvf) { Remove-Item $tempSpecOvf -Force -ErrorAction SilentlyContinue }
+            }
+        }
+
+        It 'GITHUB_ACTIONS annotation emits ::warning:: to information stream when env var set (M6/AC3)' {
+            # RED until Step 2 adds GITHUB_ACTIONS annotation emission via Write-Host
+            # (information stream 6, NOT warning stream 3) when overflow is detected in CI.
+            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [101]
+'@ | Set-Content -Path $tempSpecOvf -Encoding UTF8
+
+            try {
+                $env:GITHUB_ACTIONS = 'true'
+                # Capture information stream (6) — Write-Host output goes here.
+                $output = Invoke-PortfolioRender -specPath $tempSpecOvf 6>&1
+                $annotations = @($output | Where-Object { $_ -match '::warning::' })
+                $annotations.Count | Should -BeGreaterThan 0 `
+                    -Because 'at least one ::warning:: annotation must be emitted to the information stream when GITHUB_ACTIONS is set and overflow is detected (M6/AC3)'
+            }
+            finally {
+                Remove-Item env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
+                if (Test-Path $tempSpecOvf) { Remove-Item $tempSpecOvf -Force -ErrorAction SilentlyContinue }
+            }
+        }
+
+        It 'warning message does not inject workflow commands from issue title (M9 log-injection guard)' {
+            # RED until Step 2 ensures warning messages interpolate only safe integer issue#
+            # and literal connection name — never the issue title or label names.
+            # A malicious issue title containing "::error::" must not appear in any warning
+            # or annotation, preventing CI log injection.
+
+            $injectLabelNodes   = (1..50 | ForEach-Object { '{"name":"lbl-' + $_ + '"}' }) -join ','
+            $injectSubIssueNodes = (1..50 | ForEach-Object { '{"number":' + (1000 + $_) + '}' }) -join ','
+            $script:InjectJson = '{"data":{"repository":{"issue":{"number":102,"title":"::error:: injected","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","labels":{"totalCount":51,"nodes":[' + $injectLabelNodes + ']},"blockedBy":{"totalCount":0,"nodes":[]},"subIssues":{"totalCount":51,"nodes":[' + $injectSubIssueNodes + ']}}}}}'
+
+            function global:gh {
+                param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+                if ($ghArgs -contains 'edit') { $script:GhEditCallCount++; $global:LASTEXITCODE = 0; return }
+                if ($ghArgs -contains 'list') {
+                    if ($ghArgs -contains 'closed') { $global:LASTEXITCODE = 0; return '[]' }
+                    if ($ghArgs -contains 'triage') { $global:LASTEXITCODE = 0; return '[]' }
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":102,"title":"::error:: injected","labels":["subIssues"],"createdAt":"2026-01-01T00:00:00Z"}]'
+                }
+                if ($ghArgs -contains 'api') { $global:LASTEXITCODE = 0; return $script:InjectJson }
+                if ($ghArgs -contains 'view') { $global:LASTEXITCODE = 0; return '{"body":"# Control Tower\n\nNo portfolio block yet."}' }
+                $global:LASTEXITCODE = 0
+            }
+
+            $tempSpecInject = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [102]
+'@ | Set-Content -Path $tempSpecInject -Encoding UTF8
+
+            try {
+                $env:GITHUB_ACTIONS = 'true'
+                # Capture warning stream (3) to check for title injection
+                $captured3 = Invoke-PortfolioRender -specPath $tempSpecInject 3>&1
+                $warnings = @($captured3 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+
+                # RED driver: overflow must have produced at least one warning — otherwise the
+                # injection-absence check is vacuously satisfied. Without Step 2, no overflow
+                # warnings are emitted, so this assertion fails → test is RED.
+                $overflowWarnings = @($warnings | Where-Object {
+                    $_.Message -match 'overflow' -or $_.Message -match 'totalCount' -or
+                    $_.Message -match 'labels' -or $_.Message -match 'subIssues'
+                })
+                $overflowWarnings.Count | Should -BeGreaterThan 0 `
+                    -Because 'overflow must produce at least one warning before injection-absence can be verified (M9 RED driver)'
+
+                # Warning messages must NOT contain ::error:: (injected from title)
+                $injectedWarnings = @($warnings | Where-Object { $_.Message -match '::error::' })
+                $injectedWarnings.Count | Should -Be 0 `
+                    -Because 'overflow warning messages must not embed the issue title — no ::error:: from title injection (M9)'
+
+                # Capture information stream (6) to check annotation for newline injection
+                $captured6 = Invoke-PortfolioRender -specPath $tempSpecInject 6>&1
+                $annotations = @($captured6 | Where-Object { $_ -match '::warning::' })
+
+                # ::warning:: annotations must not contain a newline (would inject a second command)
+                foreach ($ann in $annotations) {
+                    $ann.ToString() | Should -Not -Match "`n" `
+                        -Because '::warning:: annotation must not contain a newline (prevents multi-command log injection, M9)'
+                }
+            }
+            finally {
+                Remove-Item env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
+                if (Test-Path $tempSpecInject) { Remove-Item $tempSpecInject -Force -ErrorAction SilentlyContinue }
+                $script:InjectJson = $null
+            }
+        }
+    }
+}
+
+# ===========================================================================
+# Test-ConnectionOverflow pure predicate (no I/O, no gh stub needed)
+# ===========================================================================
+# RED until Step 2 adds Test-ConnectionOverflow to render-portfolio.ps1.
+# This Describe block is OUTSIDE Invoke-PortfolioRender so it needs no stub.
+Describe 'Test-ConnectionOverflow' {
+
+    It 'returns $true when totalCount (51) exceeds node count (50) — overflow case' {
+        # Canonical overflow: API returned 50 nodes but totalCount is 51.
+        $nodes = @(1..50 | ForEach-Object { [PSCustomObject]@{ number = $_ } })
+        Test-ConnectionOverflow -TotalCount 51 -Nodes $nodes | Should -BeTrue `
+            -Because 'totalCount (51) > node count (50) is a truncation overflow'
+    }
+
+    It 'returns $false when totalCount equals node count (50/50) — boundary no-overflow' {
+        # Exact match: no pages were dropped.
+        $nodes = @(1..50 | ForEach-Object { [PSCustomObject]@{ number = $_ } })
+        Test-ConnectionOverflow -TotalCount 50 -Nodes $nodes | Should -BeFalse `
+            -Because 'totalCount (50) == node count (50) is the boundary non-overflow case'
+    }
+
+    It 'returns $true when totalCount (51) exceeds a smaller node count (40) — semantics check' {
+        # Confirms the predicate compares against actual returned count, not a fixed page size.
+        $nodes = @(1..40 | ForEach-Object { [PSCustomObject]@{ number = $_ } })
+        Test-ConnectionOverflow -TotalCount 51 -Nodes $nodes | Should -BeTrue `
+            -Because 'totalCount (51) > node count (40): overflow regardless of page sparsity'
+    }
+
+    It 'returns $false for single-element connection (1/1) — no scalar-unwrap throw' {
+        # PowerShell auto-unwraps single-element arrays; the helper must handle this
+        # without throwing a comparison error.
+        $nodes = @([PSCustomObject]@{ number = 99 })
+        Test-ConnectionOverflow -TotalCount 1 -Nodes $nodes | Should -BeFalse `
+            -Because 'single-element connection is not overflow; scalar-unwrap must not cause a throw'
+    }
+
+    It 'returns $false for empty connection (0/0)' {
+        # Zero totalCount, zero nodes — vacuously not truncated.
+        $nodes = @()
+        Test-ConnectionOverflow -TotalCount 0 -Nodes $nodes | Should -BeFalse `
+            -Because 'empty connection (0 totalCount, 0 nodes) is not overflow'
+    }
+
+    It 'returns $false when nodes is $null and totalCount=5 (M3: no-data-is-not-overflow)' {
+        # M3 no-data-is-not-overflow: a null nodes collection means the field was absent
+        # from the response (e.g. non-umbrella issue has no subIssues field).
+        # Absence of data is not evidence of truncation — must return $false, not throw.
+        Test-ConnectionOverflow -TotalCount 5 -Nodes $null | Should -BeFalse `
+            -Because 'null nodes means the connection field was absent — absence is not overflow (M3)'
+    }
+
+    It 'returns $false when totalCount=50 and 50 raw nodes include closed items (M3 closed-blocker analog)' {
+        # M3 closed-blocker analog: the predicate operates on the RAW fetched node set,
+        # NOT on a downstream-filtered subset (e.g. only OPEN blockers).
+        # totalCount=50, 50 raw nodes fetched → no overflow, even if 10 are CLOSED.
+        # A regression passing filtered nodes would incorrectly report overflow.
+        $rawNodes = @(
+            1..10  | ForEach-Object { [PSCustomObject]@{ number = $_;    state = 'CLOSED' } }
+            11..50 | ForEach-Object { [PSCustomObject]@{ number = $_;    state = 'OPEN'   } }
+        )
+        Test-ConnectionOverflow -TotalCount 50 -Nodes $rawNodes | Should -BeFalse `
+            -Because 'totalCount=50 with 50 raw nodes is not overflow even when some are closed (M3: use raw count)'
+    }
+}
+
+# ===========================================================================
+# Query-string assertion (M1: totalCount field must be in subIssues umbrella query)
+# ===========================================================================
+Describe 'render-portfolio query strings' {
+
+    It 'subIssues umbrella query selects totalCount (M1 regression guard)' {
+        # M1: the subIssues connection in the umbrella GraphQL query must request
+        # totalCount so that Test-ConnectionOverflow can detect truncation.
+        # Reading the script source and asserting the field is present.
+        # If a future edit drops totalCount from the subIssues block, this test turns RED.
+        $scriptContent = Get-Content -Path $scriptPath -Raw
+        $scriptContent | Should -Match 'subIssues\(first:\s*\d+\)\s*\{[^}]*totalCount' `
+            -Because 'the subIssues connection block in the umbrella GraphQL query must include totalCount for overflow detection (M1)'
+    }
 }

--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -1638,6 +1638,8 @@ rounds:
                 # 'overflow' pattern → test FAILS RED as required.
                 $script:GhEditBody | Should -Match 'overflow' `
                     -Because 'blockedBy overflow must route #101 to an overflow section: visible blockers are all closed but totalCount=51 means a hidden blocker exists (AC2)'
+                $script:GhEditBody | Should -Not -Match 'not found in GitHub' `
+                    -Because 'a blockedBy-overflow issue exists in GitHub and must not render the false "not found — remove from sequence.yaml" footer line (P-M1 regression guard)'
             }
             finally {
                 if (Test-Path $tempSpecOvf) { Remove-Item $tempSpecOvf -Force -ErrorAction SilentlyContinue }
@@ -1849,6 +1851,146 @@ rounds:
                 Remove-Item env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
                 if (Test-Path $tempSpecInject) { Remove-Item $tempSpecInject -Force -ErrorAction SilentlyContinue }
                 $script:InjectJson = $null
+            }
+        }
+
+        It 'leaf-loop (float/non-umbrella) blockedBy overflow routes issue to overflow section, not startable (AC2 leaf path)' {
+            # Guards leaf-loop guard at render-portfolio.ps1:1058-1065 (the blockedBy overflow
+            # check inside foreach ($num in $openLeafCandidateNums)).
+            # Fixture: spec has umbrella #101; gh issue list open returns #101 AND #102.
+            # #102 is a non-umbrella float (no subIssues label, not in spec rounds).
+            # #102's blockedBy has totalCount=51 with 50 CLOSED nodes — without the leaf
+            # guard, #102's openBlockers=[] → classified startable (Now/Next). With the guard,
+            # it routes to the overflow section.
+            $closedLeafBlockers = (1..50 | ForEach-Object { '{"number":' + $_ + ',"title":"Blocker ' + $_ + '","state":"CLOSED"}' }) -join ','
+            $leafOverflowJson = '{"data":{"repository":{"issue":{"number":102,"title":"Leaf overflow issue","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":51,"nodes":[' + $closedLeafBlockers + ']}}}}}'
+            $umbrellaMinimalJson = '{"data":{"repository":{"issue":{"number":101,"title":"Umbrella issue","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"subIssues":{"totalCount":1,"nodes":[{"number":1001}]}}}}}'
+
+            $script:LeafApiCallCount = 0
+
+            function global:gh {
+                param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+                if ($ghArgs -contains 'edit') {
+                    $script:GhEditCallCount++
+                    $bodyIdx = [Array]::IndexOf([string[]]$ghArgs, '--body')
+                    if ($bodyIdx -ge 0 -and ($bodyIdx + 1) -lt $ghArgs.Count) {
+                        $script:GhEditBody = $ghArgs[$bodyIdx + 1]
+                    }
+                    $global:LASTEXITCODE = 0; return
+                }
+                if ($ghArgs -contains 'list') {
+                    if ($ghArgs -contains 'closed') { $global:LASTEXITCODE = 0; return '[]' }
+                    if ($ghArgs -contains 'triage') { $global:LASTEXITCODE = 0; return '[]' }
+                    # open scan: umbrella #101 + leaf float #102 (no subIssues label)
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":101,"title":"Umbrella issue","labels":["subIssues"],"createdAt":"2026-01-01T00:00:00Z"},{"number":102,"title":"Leaf overflow issue","labels":[],"createdAt":"2026-01-01T00:00:00Z"}]'
+                }
+                if ($ghArgs -contains 'api') {
+                    $script:LeafApiCallCount++
+                    $global:LASTEXITCODE = 0
+                    # First api call: umbrella #101 query (umbrella loop)
+                    # Second api call: leaf #102 query (leaf loop)
+                    if ($script:LeafApiCallCount -eq 1) { return $umbrellaMinimalJson }
+                    return $leafOverflowJson
+                }
+                if ($ghArgs -contains 'view') {
+                    $global:LASTEXITCODE = 0
+                    return '{"body":"# Control Tower\n\nNo portfolio block yet."}'
+                }
+                $global:LASTEXITCODE = 0
+            }
+
+            $tempSpecLeaf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [101]
+'@ | Set-Content -Path $tempSpecLeaf -Encoding UTF8
+
+            try {
+                $captured = Invoke-PortfolioRender -specPath $tempSpecLeaf 3>&1
+
+                # Leaf blockedBy overflow must emit a Write-Warning
+                $warnings = @($captured | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+                $leafWarnings = @($warnings | Where-Object { $_.Message -match 'blockedBy' -and $_.Message -match '102' })
+                $leafWarnings.Count | Should -BeGreaterThan 0 `
+                    -Because 'leaf-loop blockedBy overflow must emit a Write-Warning naming issue #102 and connection blockedBy (AC5 leaf path)'
+
+                # Leaf blockedBy overflow must route #102 to the overflow section, not Now/Next
+                $script:GhEditBody | Should -Match 'overflow' `
+                    -Because 'leaf-loop blockedBy overflow must render #102 in the overflow section (AC2 leaf path)'
+                $script:GhEditBody | Should -Not -Match 'not found in GitHub' `
+                    -Because 'a leaf blockedBy-overflow issue must not render the false "not found" footer line (P-M1 regression guard, leaf path)'
+            }
+            finally {
+                Remove-Item function:global:gh -ErrorAction SilentlyContinue
+                if (Test-Path $tempSpecLeaf) { Remove-Item $tempSpecLeaf -Force -ErrorAction SilentlyContinue }
+            }
+        }
+
+        It 'leaf-loop labels overflow emits Write-Warning mentioning labels and issue number (AC5 leaf path)' {
+            # Guards leaf-loop labels guard at render-portfolio.ps1:1051-1056.
+            $leafLabelsNodes  = (1..50 | ForEach-Object { '{"name":"lbl-' + $_ + '"}' }) -join ','
+            $leafLabelsJson   = '{"data":{"repository":{"issue":{"number":102,"title":"Leaf labels overflow","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","labels":{"totalCount":51,"nodes":[' + $leafLabelsNodes + ']},"blockedBy":{"totalCount":0,"nodes":[]}}}}}'
+            $umbrellaMinimalJson2 = '{"data":{"repository":{"issue":{"number":101,"title":"Umbrella issue","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"subIssues":{"totalCount":1,"nodes":[{"number":1001}]}}}}}'
+
+            $script:LeafLabelsApiCall = 0
+
+            function global:gh {
+                param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+                if ($ghArgs -contains 'edit') {
+                    $script:GhEditCallCount++
+                    $bodyIdx = [Array]::IndexOf([string[]]$ghArgs, '--body')
+                    if ($bodyIdx -ge 0 -and ($bodyIdx + 1) -lt $ghArgs.Count) {
+                        $script:GhEditBody = $ghArgs[$bodyIdx + 1]
+                    }
+                    $global:LASTEXITCODE = 0; return
+                }
+                if ($ghArgs -contains 'list') {
+                    if ($ghArgs -contains 'closed') { $global:LASTEXITCODE = 0; return '[]' }
+                    if ($ghArgs -contains 'triage') { $global:LASTEXITCODE = 0; return '[]' }
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":101,"title":"Umbrella issue","labels":["subIssues"],"createdAt":"2026-01-01T00:00:00Z"},{"number":102,"title":"Leaf labels overflow","labels":[],"createdAt":"2026-01-01T00:00:00Z"}]'
+                }
+                if ($ghArgs -contains 'api') {
+                    $script:LeafLabelsApiCall++
+                    $global:LASTEXITCODE = 0
+                    if ($script:LeafLabelsApiCall -eq 1) { return $umbrellaMinimalJson2 }
+                    return $leafLabelsJson
+                }
+                if ($ghArgs -contains 'view') {
+                    $global:LASTEXITCODE = 0
+                    return '{"body":"# Control Tower\n\nNo portfolio block yet."}'
+                }
+                $global:LASTEXITCODE = 0
+            }
+
+            $tempSpecLeaf2 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            @'
+schema_version: 1
+control_tower: 704
+recently_closed_days: 14
+rounds:
+  - lane: main
+    round: 1
+    issues: [101]
+'@ | Set-Content -Path $tempSpecLeaf2 -Encoding UTF8
+
+            try {
+                $captured = Invoke-PortfolioRender -specPath $tempSpecLeaf2 3>&1
+
+                $warnings = @($captured | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+                $leafLabelWarnings = @($warnings | Where-Object { $_.Message -match 'labels' -and $_.Message -match '102' })
+                $leafLabelWarnings.Count | Should -BeGreaterThan 0 `
+                    -Because 'leaf-loop labels overflow must emit a Write-Warning naming issue #102 and connection labels (AC5 leaf path)'
+            }
+            finally {
+                Remove-Item function:global:gh -ErrorAction SilentlyContinue
+                if (Test-Path $tempSpecLeaf2) { Remove-Item $tempSpecLeaf2 -Force -ErrorAction SilentlyContinue }
             }
         }
     }

--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -28,6 +28,12 @@ BeforeAll {
     $scriptPath = Join-Path $PSScriptRoot '..' 'render-portfolio.ps1'
     # This will fail until s4 creates the script — making tests RED.
     . $scriptPath
+
+    # New-TempSpecPath: returns a unique temp-file path for a YAML spec without creating a
+    # file on disk. Avoids the GetTempFileName() + -replace pattern which leaks the .tmp file.
+    function global:New-TempSpecPath {
+        return Join-Path ([System.IO.Path]::GetTempPath()) "$([System.Guid]::NewGuid().ToString()).yaml"
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -1222,7 +1228,7 @@ Describe 'Invoke-PortfolioRender' {
         #
         # With the Step-0 probe guard: pipeline exits before step 8 (write) → edit count = 0.
 
-        $tempSpec = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        $tempSpec = New-TempSpecPath
         @'
 schema_version: 2
 control_tower: 704
@@ -1340,7 +1346,7 @@ umbrellas: [425, 571]
             $global:LASTEXITCODE = 0
         }
 
-        $tempSpec2 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        $tempSpec2 = New-TempSpecPath
         @'
 schema_version: 2
 control_tower: 704
@@ -1410,7 +1416,7 @@ umbrellas: [425, 571]
             $global:LASTEXITCODE = 0
         }
 
-        $tempSpecCeil1 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        $tempSpecCeil1 = New-TempSpecPath
         @'
 schema_version: 2
 control_tower: 704
@@ -1479,7 +1485,7 @@ umbrellas: [425, 571]
             $global:LASTEXITCODE = 0
         }
 
-        $tempSpecCeil2 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        $tempSpecCeil2 = New-TempSpecPath
         @'
 schema_version: 2
 control_tower: 704
@@ -1549,7 +1555,7 @@ umbrellas: [425, 571]
             $global:LASTEXITCODE = 0
         }
 
-        $tempSpecCeil4 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        $tempSpecCeil4 = New-TempSpecPath
         @'
 schema_version: 2
 control_tower: 704
@@ -1631,7 +1637,7 @@ umbrellas: [425, 571]
             $global:LASTEXITCODE = 0
         }
 
-        $tempSpecNoTriage = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        $tempSpecNoTriage = New-TempSpecPath
         @'
 schema_version: 2
 control_tower: 704
@@ -1685,7 +1691,7 @@ umbrellas: [425]
             $global:LASTEXITCODE = 0
         }
 
-        $tempSpecProbe = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+        $tempSpecProbe = New-TempSpecPath
         @'
 schema_version: 2
 control_tower: 704
@@ -1732,6 +1738,7 @@ umbrellas: [425, 571]
         }
 
         BeforeEach {
+            $script:GhViewBody  = '{"body":"# Control Tower\n\nNo portfolio block yet."}'
             $script:GhEditCallCount = 0
             $script:GhEditArgs      = @()
             $script:GhEditBody      = ''
@@ -1746,6 +1753,9 @@ umbrellas: [425, 571]
                     $bodyIdx = [Array]::IndexOf([string[]]$ghArgs, '--body')
                     if ($bodyIdx -ge 0 -and ($bodyIdx + 1) -lt $ghArgs.Count) {
                         $script:GhEditBody = $ghArgs[$bodyIdx + 1]
+                        # Persist the written body so the view stub returns it on the next render.
+                        # Encode as JSON so Invoke-PortfolioRender can parse it via ConvertFrom-Json.
+                        $script:GhViewBody = @{ body = $script:GhEditBody } | ConvertTo-Json -Compress
                     }
                     $global:LASTEXITCODE = 0
                     return
@@ -1766,7 +1776,7 @@ umbrellas: [425, 571]
 
                 if ($ghArgs -contains 'view') {
                     $global:LASTEXITCODE = 0
-                    return '{"body":"# Control Tower\n\nNo portfolio block yet."}'
+                    return $script:GhViewBody
                 }
 
                 $global:LASTEXITCODE = 0
@@ -1778,13 +1788,14 @@ umbrellas: [425, 571]
             $script:GhEditCallCount = 0
             $script:GhEditArgs      = @()
             $script:GhEditBody      = ''
+            $script:GhViewBody      = $null
             $script:OverflowJson    = $null
         }
 
         It 'labels overflow emits Write-Warning mentioning labels and issue number (AC5)' {
             # RED until Step 2 adds overflow check that calls Write-Warning when
             # labels.totalCount > labels.nodes.Count.
-            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            $tempSpecOvf = New-TempSpecPath
             @'
 schema_version: 2
 control_tower: 704
@@ -1842,7 +1853,7 @@ umbrellas: [101]
                 $global:LASTEXITCODE = 0
             }
 
-            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            $tempSpecOvf = New-TempSpecPath
             @'
 schema_version: 2
 control_tower: 704
@@ -1865,6 +1876,16 @@ umbrellas: [101]
                     -Because 'blockedBy overflow must route #101 to the overflow section: visible blockers are all closed but totalCount=51 means a hidden blocker exists (AC2)'
                 $script:GhEditBody | Should -Not -Match 'not found in GitHub' `
                     -Because 'a blockedBy-overflow issue exists in GitHub and must not render the false "not found — remove from sequence.yaml" footer line (P-M1 regression guard)'
+
+                # AC3 assertion: #101 must be specifically annotated in the v2 overflow footer.
+                # The v2 board uses ⚠️ Issue #N: blockedBy overflow — excluded from startable routing
+                # (not Now/Next/Blocked sections, which are retired v1 headings).
+                $script:GhEditBody | Should -Match '⚠️ Issue #101.*blockedBy overflow' `
+                    -Because 'issue #101 must appear in the overflow footer annotation — excluded from startable routing (AC3)'
+                # AC3 negative: #101 must not appear as a Triage (startable) item.
+                $triageSection = [regex]::Match($script:GhEditBody, '(?s)##[^\r\n]*Triage[\r\n]+(?<triage>.*?)##').Groups['triage'].Value
+                $triageSection | Should -Not -Match '(?m)#101\b' `
+                    -Because 'blockedBy overflow must exclude #101 from the Triage (startable) section (AC3)'
             }
             finally {
                 if (Test-Path $tempSpecOvf) { Remove-Item $tempSpecOvf -Force -ErrorAction SilentlyContinue }
@@ -1873,7 +1894,7 @@ umbrellas: [101]
 
         It 'subIssues overflow emits Write-Warning mentioning subIssues and issue number (AC5)' {
             # RED until Step 2 adds overflow check for subIssues.totalCount > subIssues.nodes.Count.
-            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            $tempSpecOvf = New-TempSpecPath
             @'
 schema_version: 2
 control_tower: 704
@@ -1901,7 +1922,7 @@ umbrellas: [101]
             #   1. at least one overflow warning was emitted (RED without Step 2 — no overflow code yet)
             #   2. render completes (gh issue edit called >= 1)
             # Condition 1 is the RED driver — current code emits no overflow warnings.
-            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            $tempSpecOvf = New-TempSpecPath
             @'
 schema_version: 2
 control_tower: 704
@@ -1930,13 +1951,12 @@ umbrellas: [101]
         }
 
         It 'idempotency: two renders of overflow issue produce identical body containing overflow marker (AC7)' {
-            # RED until Step 2: overflow handling must be deterministic AND produce an overflow
-            # indicator in the body.
             # Two parts:
-            #   1. The rendered body must contain an overflow marker (RED driver — no overflow
-            #      code yet, so the body won't have 'overflow' in it → first Should -Match fails)
-            #   2. Two identical invocations must produce byte-identical bodies (AC7 idempotency)
-            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            #   1. The rendered body must contain an overflow marker (Part 1 RED driver — no
+            #      overflow code yet, so the body won't have 'overflow' in it → fails RED)
+            #   2. Second render must be a no-op: Get-SplicedBody detects the portfolio block is
+            #      already present (identical) and returns $null, skipping gh issue edit (AC7 true idempotency)
+            $tempSpecOvf = New-TempSpecPath
             @'
 schema_version: 2
 control_tower: 704
@@ -1958,15 +1978,13 @@ umbrellas: [101]
                 $script:GhEditBody      = ''
 
                 Invoke-PortfolioRender -specPath $tempSpecOvf
-                $secondBody = $script:GhEditBody
 
-                # Part 2: both renders must produce the same body. Strip the timestamp footer
-                # line (the only intentionally time-varying content — Get-SplicedBody strips it
-                # for its real idempotency comparison) so this assertion is not flaky when the two
-                # renders straddle a one-second boundary.
-                $stripTs = { param($b) ($b -split "`n" | Where-Object { $_ -notmatch '^portfolio content unchanged since ' }) -join "`n" }
-                (& $stripTs $firstBody) | Should -Be (& $stripTs $secondBody) `
-                    -Because 'two renders of the same overflow issue must produce identical board bodies modulo the timestamp footer (AC7 idempotency)'
+                # Part 2 (true idempotency): second render must be a no-op — Get-SplicedBody detects
+                # the portfolio block is already present and returns $null, skipping gh issue edit.
+                $script:GhEditCallCount | Should -Be 0 `
+                    -Because 'second render of an already-written board must be a no-op (AC7 no-op detection — Get-SplicedBody returns $null when content is identical)'
+                $script:GhViewBody | Should -Match 'overflow' `
+                    -Because 'persisted board body must still contain the overflow marker after the idempotent second render'
             }
             finally {
                 if (Test-Path $tempSpecOvf) { Remove-Item $tempSpecOvf -Force -ErrorAction SilentlyContinue }
@@ -1976,7 +1994,8 @@ umbrellas: [101]
         It 'GITHUB_ACTIONS annotation emits ::warning:: to information stream when env var set (M6/AC3)' {
             # RED until Step 2 adds GITHUB_ACTIONS annotation emission via Write-Host
             # (information stream 6, NOT warning stream 3) when overflow is detected in CI.
-            $tempSpecOvf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            $previousGithubActions = $env:GITHUB_ACTIONS
+            $tempSpecOvf = New-TempSpecPath
             @'
 schema_version: 2
 control_tower: 704
@@ -1993,7 +2012,11 @@ umbrellas: [101]
                     -Because 'at least one ::warning:: annotation must be emitted to the information stream when GITHUB_ACTIONS is set and overflow is detected (M6/AC3)'
             }
             finally {
-                Remove-Item env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
+                if ($null -eq $previousGithubActions) {
+                    Remove-Item env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
+                } else {
+                    $env:GITHUB_ACTIONS = $previousGithubActions
+                }
                 if (Test-Path $tempSpecOvf) { Remove-Item $tempSpecOvf -Force -ErrorAction SilentlyContinue }
             }
         }
@@ -2004,6 +2027,7 @@ umbrellas: [101]
             # A malicious issue title containing "::error::" must not appear in any warning
             # or annotation, preventing CI log injection.
 
+            $previousGithubActions = $env:GITHUB_ACTIONS
             $injectLabelNodes   = (1..50 | ForEach-Object { '{"name":"lbl-' + $_ + '"}' }) -join ','
             $injectSubIssueNodes = (1..50 | ForEach-Object { '{"number":' + (1000 + $_) + '}' }) -join ','
             $script:InjectJson = '{"data":{"repository":{"issue":{"number":102,"title":"::error:: injected","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","labels":{"totalCount":51,"nodes":[' + $injectLabelNodes + ']},"blockedBy":{"totalCount":0,"nodes":[]},"subIssues":{"totalCount":51,"nodes":[' + $injectSubIssueNodes + ']}}}}}'
@@ -2022,7 +2046,7 @@ umbrellas: [101]
                 $global:LASTEXITCODE = 0
             }
 
-            $tempSpecInject = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            $tempSpecInject = New-TempSpecPath
             @'
 schema_version: 2
 control_tower: 704
@@ -2055,6 +2079,9 @@ umbrellas: [102]
                 $captured6 = Invoke-PortfolioRender -specPath $tempSpecInject 6>&1
                 $annotations = @($captured6 | Where-Object { $_ -match '::warning::' })
 
+                $annotations.Count | Should -BeGreaterThan 0 `
+                    -Because 'GITHUB_ACTIONS overflow handling must emit at least one ::warning:: annotation before injection safety can be verified (M9 count guard)'
+
                 # ::warning:: annotations must not contain a newline (would inject a second command)
                 foreach ($ann in $annotations) {
                     $ann.ToString() | Should -Not -Match "`n" `
@@ -2062,7 +2089,11 @@ umbrellas: [102]
                 }
             }
             finally {
-                Remove-Item env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
+                if ($null -eq $previousGithubActions) {
+                    Remove-Item env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
+                } else {
+                    $env:GITHUB_ACTIONS = $previousGithubActions
+                }
                 if (Test-Path $tempSpecInject) { Remove-Item $tempSpecInject -Force -ErrorAction SilentlyContinue }
                 $script:InjectJson = $null
             }
@@ -2118,7 +2149,7 @@ umbrellas: [102]
                 $global:LASTEXITCODE = 0
             }
 
-            $tempSpecLeaf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            $tempSpecLeaf = New-TempSpecPath
             @'
 schema_version: 2
 control_tower: 704
@@ -2141,6 +2172,16 @@ umbrellas: [101]
                     -Because 'leaf-loop blockedBy overflow must render #102 in the overflow section (AC2 leaf path)'
                 $script:GhEditBody | Should -Not -Match 'not found in GitHub' `
                     -Because 'a leaf blockedBy-overflow issue must not render the false "not found" footer line (P-M1 regression guard, leaf path)'
+
+                # AC3 assertion: #102 must be specifically annotated in the v2 overflow footer.
+                # The v2 board uses ⚠️ Issue #N: blockedBy overflow — excluded from startable routing
+                # (not Now/Next/Blocked sections, which are retired v1 headings).
+                $script:GhEditBody | Should -Match '⚠️ Issue #102.*blockedBy overflow' `
+                    -Because 'issue #102 must appear in the overflow footer annotation — excluded from startable routing (AC3 leaf path)'
+                # AC3 negative: #102 must not appear as a Triage (startable) item.
+                $triageSection = [regex]::Match($script:GhEditBody, '(?s)##[^\r\n]*Triage[\r\n]+(?<triage>.*?)##').Groups['triage'].Value
+                $triageSection | Should -Not -Match '(?m)#102\b' `
+                    -Because 'blockedBy overflow must exclude #102 from the Triage (startable) section (AC3 leaf path)'
             }
             finally {
                 Remove-Item function:global:gh -ErrorAction SilentlyContinue
@@ -2189,7 +2230,7 @@ umbrellas: [101]
                 $global:LASTEXITCODE = 0
             }
 
-            $tempSpecLeaf2 = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.yaml'
+            $tempSpecLeaf2 = New-TempSpecPath
             @'
 schema_version: 2
 control_tower: 704

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -945,7 +945,6 @@ query {
             if ($env:GITHUB_ACTIONS -eq 'true') {
                 Write-Host "::warning::Issue #${num} blockedBy connection truncated (>50)"
             }
-            $unresolvedNums        += $num
             $blockedByOverflowNums += $num
             continue
         }
@@ -1060,7 +1059,6 @@ query {
             if ($env:GITHUB_ACTIONS -eq 'true') {
                 Write-Host "::warning::Issue #${num} blockedBy connection truncated (>50)"
             }
-            $unresolvedNums        += $num
             $blockedByOverflowNums += $num
             continue
         }

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -32,6 +32,15 @@ $MARKER_END   = '<!-- portfolio-tracker:end -->'
 # Pure helper functions (no I/O)
 # ---------------------------------------------------------------------------
 
+# Returns $true when the fetched connection was truncated (totalCount exceeds fetched
+# node count). Compares against the raw fetched nodes — never a filtered/derived set.
+# Null nodes => no data, not overflow.
+function Test-ConnectionOverflow {
+    param([int]$TotalCount, $Nodes)
+    if ($null -eq $Nodes) { return $false }
+    return $TotalCount -gt @($Nodes).Count
+}
+
 # Returns a sort-key integer for priority labels: lower = higher priority.
 function Get-PriorityKey {
     param([string[]]$labels)
@@ -505,7 +514,7 @@ function Get-PortfolioBuckets {
 # Pagination: (+N more) when totalCount > rendered count.
 # ---------------------------------------------------------------------------
 function Format-PortfolioMarkdown {
-    param($bucketModel, [string]$timestamp, [int[]]$UnresolvedNums = @())
+    param($bucketModel, [string]$timestamp, [int[]]$UnresolvedNums = @(), [int[]]$BlockedByOverflowNums = @())
 
     $sb = [System.Text.StringBuilder]::new()
 
@@ -647,6 +656,12 @@ function Format-PortfolioMarkdown {
 
     # --- Footer ---
     $null = $sb.AppendLine("portfolio content unchanged since $timestamp — rendered by render-portfolio.ps1")
+
+    if ($BlockedByOverflowNums -and $BlockedByOverflowNums.Count -gt 0) {
+        foreach ($n in $BlockedByOverflowNums) {
+            $null = $sb.AppendLine("⚠️ Issue #${n}: blockedBy overflow — excluded from startable routing (blocker list truncated at 50)")
+        }
+    }
 
     if ($UnresolvedNums -and $UnresolvedNums.Count -gt 0) {
         foreach ($n in $UnresolvedNums) {
@@ -833,7 +848,8 @@ function Invoke-PortfolioRender {
 
     # 3. Query each issue via gh GraphQL (first: 50 per connection)
     $issueStates    = [System.Collections.Generic.List[object]]::new()
-    $unresolvedNums = @()
+    $unresolvedNums         = @()
+    $blockedByOverflowNums  = @()
 
     # Build round-index map for umbrella numbers: used to tag KnownChildSet entries
     # with the correct RoundIndex so Get-PortfolioBuckets can route children correctly.
@@ -868,7 +884,7 @@ query {
       }$(if ($isUmbrella) {
 "
       subIssues(first: 50) {
-        nodes { number }
+        totalCount nodes { number }
       }"
       })
     }
@@ -908,7 +924,31 @@ query {
         }
 
         $labels       = @($issueData.labels.nodes | ForEach-Object { $_.name })
+        if (Test-ConnectionOverflow -TotalCount $issueData.labels.totalCount -Nodes $issueData.labels.nodes) {
+            Write-Warning "Issue #${num}: labels truncated ($($issueData.labels.totalCount) total, 50 fetched) — bucket routing may be incomplete."
+            if ($env:GITHUB_ACTIONS -eq 'true') {
+                Write-Host "::warning::Issue #${num} labels connection truncated (>50)"
+            }
+        }
+        # subIssues overflow check runs before blockedBy continue so warning fires even when
+        # blockedBy also overflows for the same issue (both warnings must be observable, AC5).
+        if ($isUmbrella -and $null -ne $issueData.subIssues -and
+            (Test-ConnectionOverflow -TotalCount $issueData.subIssues.totalCount -Nodes $issueData.subIssues.nodes)) {
+            Write-Warning "Issue #${num}: subIssues truncated ($($issueData.subIssues.totalCount) total, 50 fetched) — child list may be incomplete."
+            if ($env:GITHUB_ACTIONS -eq 'true') {
+                Write-Host "::warning::Issue #${num} subIssues connection truncated (>50)"
+            }
+        }
         $allBlockers  = $issueData.blockedBy.nodes
+        if (Test-ConnectionOverflow -TotalCount $issueData.blockedBy.totalCount -Nodes $issueData.blockedBy.nodes) {
+            Write-Warning "Issue #${num}: blockedBy truncated ($($issueData.blockedBy.totalCount) total, 50 fetched) — a dropped open blocker may misroute this issue as startable."
+            if ($env:GITHUB_ACTIONS -eq 'true') {
+                Write-Host "::warning::Issue #${num} blockedBy connection truncated (>50)"
+            }
+            $unresolvedNums        += $num
+            $blockedByOverflowNums += $num
+            continue
+        }
         $openBlockers = @(
             $allBlockers |
             Where-Object { $_.state -eq 'OPEN' } |
@@ -1008,7 +1048,22 @@ query {
         }
 
         $labels       = @($issueData.labels.nodes | ForEach-Object { $_.name })
+        if (Test-ConnectionOverflow -TotalCount $issueData.labels.totalCount -Nodes $issueData.labels.nodes) {
+            Write-Warning "Issue #${num}: labels truncated ($($issueData.labels.totalCount) total, 50 fetched) — bucket routing may be incomplete."
+            if ($env:GITHUB_ACTIONS -eq 'true') {
+                Write-Host "::warning::Issue #${num} labels connection truncated (>50)"
+            }
+        }
         $allBlockers  = $issueData.blockedBy.nodes
+        if (Test-ConnectionOverflow -TotalCount $issueData.blockedBy.totalCount -Nodes $issueData.blockedBy.nodes) {
+            Write-Warning "Issue #${num}: blockedBy truncated ($($issueData.blockedBy.totalCount) total, 50 fetched) — a dropped open blocker may misroute this issue as startable."
+            if ($env:GITHUB_ACTIONS -eq 'true') {
+                Write-Host "::warning::Issue #${num} blockedBy connection truncated (>50)"
+            }
+            $unresolvedNums        += $num
+            $blockedByOverflowNums += $num
+            continue
+        }
         $openBlockers = @($allBlockers | Where-Object { $_.state -eq 'OPEN' } | ForEach-Object { $_.number })
         $blockerInPlan = $true
         foreach ($b in $openBlockers) {
@@ -1052,7 +1107,7 @@ query {
 
     # 6. Format content block
     $timestamp    = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-    $innerContent = Format-PortfolioMarkdown -bucketModel $buckets -timestamp $timestamp -UnresolvedNums $unresolvedNums
+    $innerContent = Format-PortfolioMarkdown -bucketModel $buckets -timestamp $timestamp -UnresolvedNums $unresolvedNums -BlockedByOverflowNums $blockedByOverflowNums
     $fullContent  = "$MARKER_BEGIN`n$innerContent$MARKER_END"
 
     # 7. Splice into body


### PR DESCRIPTION
## Summary

- Adds `Test-ConnectionOverflow` pure predicate in `render-portfolio.ps1` that compares `totalCount` vs raw `@($Nodes).Count` (null-guarded, never compares against filtered sets like `$openBlockers`)
- Wires overflow guards at 5 connection sites (umbrella labels, umbrella subIssues, umbrella blockedBy, leaf labels, leaf blockedBy); labels/subIssues are warn-only, blockedBy overflow routes issue to `$blockedByOverflowNums` + `continue` (excludes from startable routing)
- Adds `subIssues(first: 50) { totalCount ... }` query field (M1)
- Adds `$blockedByOverflowNums` tracking so `Format-PortfolioMarkdown` renders an explicit body line per overflowed-blockedBy issue
- 17 new Pester tests: predicate unit tests, umbrella integration tests, leaf-loop integration tests (mutation-verified binding), GITHUB_ACTIONS annotation test, idempotency, log-injection guard, query-string M1 regression guard

## Pipeline metrics

```
<!-- pipeline-metrics-v4
issue: 746
branch: feature/issue-746-graphql-connection-overflow-guards
pipeline:
  - step: implement-test
    commit: e280bae
    status: completed
    notes: "15 RED Pester tests; 45 pre-existing GREEN preserved"
  - step: implement-code
    commit: 805e9cf
    status: completed
    notes: "+59 lines production code; 60/60 green"
  - step: review
    commit: 0ae5774
    status: completed
    notes: "5-pass prosecution (3 sustained-blocking: P-M1 false footer, P-M2 no negative assertion, P-M3 leaf untested); post-fix 2-line removal + 142-line leaf tests; judge score 0.55→pass-after-fix; 62/62 green; mutation-verified 3 failures on guard disable"
  - step: ce-gate
    status: completed
    notes: "S1/S3 auto-observable via Pester; S2 manual judgment pass; workflow_dispatch skip (no live overflow-triggering data)"
credits:
  - port: implement-test
    agent: test-writer
  - port: implement-code
    agent: code-smith
  - port: review
    agents: [code-critic-x5, code-review-response]
  - port: ce-gate
    agent: experience-owner
-->
```

## Adversarial review score

**Judge score: pass-after-fix (pre-fix 0.55 → post-fix ✅)**

3 blocking findings sustained and resolved:
- **P-M1** (4/5 passes): Removed redundant `$unresolvedNums += $num` from both overflow paths — eliminated false "not found in GitHub — remove from sequence.yaml" footer for overflow issues
- **P-M2** (3/5 passes): Added `Should -Not -Match 'not found in GitHub'` negative assertion to AC2 test
- **P-M3** (1/5 passes, mutation-confirmed): Added leaf-loop integration tests (blockedBy + labels); mutation verification: disabling guards → 3 failures

Dismissed: P-M4 (pre-existing KnownChildSet skip mirrors `:902-908`), P-M5 (blockedBy message interpolates only integers), P-m1 (pre-existing dead field), P-m3 (de-scoped DRY).

## CE Gate

| Scenario | Method | Result |
|----------|--------|--------|
| S1: over-cap connection surfaces overflow signal | Pester tests (auto) | ✅ PASS |
| S2: maintainer told explicitly; over-blocked not startable | Manual judgment + AC2/leaf tests | ✅ PASS |
| S3: no false alarm at 50/closed; never fatal | Pester tests (auto) | ✅ PASS |

## Test plan

- `pwsh -NoProfile -Command "Invoke-Pester -Path .github/scripts/Tests/render-portfolio.Tests.ps1"` → 62/62 green
- Verify `Test-ConnectionOverflow` describe (7 unit tests)
- Verify `connection overflow guards` describe (9 integration tests incl. 2 new leaf-loop tests)
- Verify `render-portfolio query strings` describe (M1 regression guard)

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of truncated GitHub GraphQL connection data during portfolio rendering.
  * Issues with incomplete `blockedBy` information are now routed more accurately and flagged with a dedicated warnings area (before unresolved warnings).
  * Portfolio output now remains stable across repeated runs when connection overflow occurs.
  * CI logs now emit clean, single-line warning annotations for affected connections and issue numbers, without exposing issue title content.
* **Tests**
  * Added coverage for connection overflow detection, warning/annotation behavior, and regression guards for the umbrella query.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->