### PR TITLE
fix(#760): cost-telemetry — stop CI clobber + cross-clone attribution

### DIFF
--- a/.github/scripts/Tests/cost-integration.Tests.ps1
+++ b/.github/scripts/Tests/cost-integration.Tests.ps1
@@ -149,7 +149,7 @@ some_legacy_field: value
         function Get-CostRollingHistory { param([int]$TimeoutSeconds = 10) return @{ timed_out = $false; entries = @() } }
         function Get-MostRecentRegimeCheckpoint { param([string]$Path) return $null }
         function Get-SessionCompleteness { param([object[]]$Events, [string]$ExcludeReason = '', [string]$Branch = '') return @{ completeness = 'unknown'; excluded_from_rolling_baseline = $true; exclude_reason = 'no-events' } }
-        function Resolve-CostDataPreservation { param($Current, $Prior) return @{ action = 'emit'; reason = 'no-prior' } }
+        function Resolve-CostDataPreservation { param($Current, $Prior) return @{ use_prior = $false; notice = '' } }
         function Get-CostAnomalyFlags { param($ThisRun, [object[]]$RollingHistory, $RegimeCheckpoint) return @() }
         function Format-CostPatternMarkdown { param($Attribution, $Completeness, [object[]]$AnomalyFlags, $RollingMeta, [int]$Pr, [string]$Branch) return '## Cost Pattern' }
         function Format-CostPatternYaml { param($Attribution, $Completeness, [object[]]$AnomalyFlags, [int]$Pr, [string]$Branch) return "<!-- cost-pattern-data`npr: $Pr`n-->" }
@@ -266,7 +266,7 @@ some_legacy_field: value
         function Get-CostRollingHistory { param([int]$TimeoutSeconds = 10) return @{ timed_out = $false; entries = @() } }
         function Get-MostRecentRegimeCheckpoint { param([string]$Path) return $null }
         function Get-SessionCompleteness { param([object[]]$Events, [string]$ExcludeReason = '', [string]$Branch = '') return @{ completeness = 'unknown'; excluded_from_rolling_baseline = $true; exclude_reason = 'no-events' } }
-        function Resolve-CostDataPreservation { param($Current, $Prior) return @{ action = 'emit'; reason = 'no-prior' } }
+        function Resolve-CostDataPreservation { param($Current, $Prior) return @{ use_prior = $false; notice = '' } }
         function Get-CostAnomalyFlags { param($ThisRun, [object[]]$RollingHistory, $RegimeCheckpoint) return @() }
         function Format-CostPatternMarkdown {
             param($Attribution, $Completeness, [object[]]$AnomalyFlags, $RollingMeta, [int]$Pr, [string]$Branch)
@@ -282,6 +282,137 @@ some_legacy_field: value
         # Apply the same exit-code translation the top-level script applies in warn mode:
         # warn mode never sets exitCode > 0 for IsInternalError or HasBlock — it stays 0.
         # Only enforce mode escalates to exit 3 (HasBlock) or exit 5 (IsInternalError).
+        $processExitCode = 0
+        return @{
+            ExitCode = $processExitCode
+            Comment  = if ($null -ne $result.Comment) { [string]$result.Comment } else { '' }
+        }
+        }
+        finally {
+            $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = $previousInline
+            $env:FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = $previousNoSleep
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    # Variant of InvokeOrchestratorInProcess that does NOT stub
+    # Resolve-CostDataPreservation, allowing the real function (dot-sourced via
+    # the orchestrator) to run. Used by the CI-contract preserve test (AC1).
+    # Get-SessionCompleteness is still stubbed to return 'unknown' (simulating
+    # the empty-walk CI enforce condition). Invoke-CostTranscriptWalk and
+    # Get-CostAttribution stubs are preserved (s4 removes them; see s2<->s4
+    # fixture coupling note in the plan).
+    # -------------------------------------------------------------------------
+    $script:InvokeOrchestratorInProcessWithRealPreservation = {
+        param(
+            [string]$PrBody = '',
+            [string]$CostMarkdown = '## Cost Pattern',
+            [string]$CostYaml = "<!-- cost-pattern-data`npr: 467`n-->",
+            [object[]]$Comments = @(),
+            [string]$CostBranch = 'feature/test-cost-integration'
+        )
+
+        $bodyJson = (@{ body = $PrBody; comments = $Comments } | ConvertTo-Json -Compress -Depth 5)
+        $capturedCostMarkdown = $CostMarkdown
+        $capturedCostYaml = $CostYaml
+        $capturedRepoRoot = $script:RepoRoot
+
+        $previousInline = $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE
+        $previousNoSleep = $env:FRAME_CREDIT_LEDGER_TEST_NO_SLEEP
+        try {
+        $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = '1'
+        $env:FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'
+
+        . $script:OrchestratorPath -Pr 467 -Mode 'warn'
+
+        function git {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            if ($joined -match 'rev-parse --show-toplevel') {
+                $global:LASTEXITCODE = 0
+                return $capturedRepoRoot
+            }
+            if ($joined -match 'config --get remote\.origin\.url') {
+                $global:LASTEXITCODE = 0
+                return 'https://github.com/example/example.git'
+            }
+            if ($joined -match 'rev-parse --abbrev-ref HEAD') {
+                $global:LASTEXITCODE = 0
+                return $CostBranch
+            }
+            $global:LASTEXITCODE = 0
+            return ''
+        }
+
+        function gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            if ($joined -match 'pr view \d+ --json baseRefOid') {
+                $global:LASTEXITCODE = 0
+                return '{"baseRefOid":"abc123"}'
+            }
+            if ($joined -match 'pr view \d+ --json body') {
+                $global:LASTEXITCODE = 0
+                return $bodyJson
+            }
+            if ($joined -match 'issue view \d+ --json comments') {
+                $global:LASTEXITCODE = 0
+                return '{"comments":[]}'
+            }
+            if ($joined -match '(issue|pr) comment \d+ --body') {
+                $global:LASTEXITCODE = 0
+                return 'https://github.com/example/example/pull/467#issuecomment-1'
+            }
+            if ($joined -match 'api repos/[^/]+/[^/]+ ') {
+                $global:LASTEXITCODE = 0
+                return '{"owner":{"login":"example"},"name":"example"}'
+            }
+            if ($joined -match 'api -X PATCH repos/[^/]+/[^/]+/issues/comments/\d+') {
+                $global:LASTEXITCODE = 0
+                return '{"html_url":"https://github.com/example/example/pull/467#issuecomment-2"}'
+            }
+            if ($joined -match 'pr edit \d+ --body-file') {
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $global:LASTEXITCODE = 0
+            return ''
+        }
+
+        function Get-CostTranscriptSlug {
+            param([string]$CwdPath)
+            return 'test-slug'
+        }
+        function Invoke-CostTranscriptWalk {
+            param([string]$Slug, [string]$Branch, [string]$ParentCwd, [Nullable[int]]$IssueNumber = $null)
+            return @()
+        }
+        function Invoke-CostCopilotWalk {
+            param([string]$Branch, [string]$RepoRoot, [string]$OtelJsonlPath, [string]$WorkspaceFolderBasename = '')
+            return @()
+        }
+        function Get-CostAttribution {
+            param([object[]]$Events, [string]$RateTablePath = '')
+            return @{ ports = @{}; orchestrator_overhead = @{}; dispatches = @{}; totals = @{ total_cost_usd = 0.0 } }
+        }
+        function Get-CostRollingHistory { param([int]$TimeoutSeconds = 10) return @{ timed_out = $false; entries = @() } }
+        function Get-MostRecentRegimeCheckpoint { param([string]$Path) return $null }
+        # Get-SessionCompleteness returns 'unknown' — simulates the empty-walk CI enforce condition.
+        # Resolve-CostDataPreservation is NOT stubbed here; the real function (dot-sourced from the
+        # orchestrator's cost lib) is used so the skip gate can fire when prior is complete.
+        function Get-SessionCompleteness { param([object[]]$Events, [string]$ExcludeReason = '', [string]$Branch = '') return @{ completeness = 'unknown'; excluded_from_rolling_baseline = $true; exclude_reason = 'no-events' } }
+        function Get-CostAnomalyFlags { param($ThisRun, [object[]]$RollingHistory, $RegimeCheckpoint) return @() }
+        function Format-CostPatternMarkdown {
+            param($Attribution, $Completeness, [object[]]$AnomalyFlags, $RollingMeta, [int]$Pr, [string]$Branch)
+            return $capturedCostMarkdown
+        }
+        function Format-CostPatternYaml {
+            param($Attribution, $Completeness, [object[]]$AnomalyFlags, [int]$Pr, [string]$Branch)
+            return $capturedCostYaml
+        }
+
+        $script:FrameCreditLedgerRepoRoot = $capturedRepoRoot
+        $result = Invoke-FrameCreditLedger -Pr 467 -Mode 'warn'
         $processExitCode = 0
         return @{
             ExitCode = $processExitCode
@@ -521,6 +652,51 @@ Describe 'frame-credit-ledger cost integration' {
             $result.ExitCode | Should -Be 0
             # Confirm the run completed and produced port coverage output
             $result.Comment | Should -Match '(?i)frame-credit-ledger-467'
+        }
+    }
+
+    Context 'D1 CI-contract preservation (skip-when-absent gate)' {
+
+        It 'preserves prior cost-pattern-data block when projects root is absent (CI enforce path)' {
+            # When the CI enforce run produces completeness='unknown' (empty walk) and
+            # the prior comment contains a session_completeness: complete block, the
+            # skip-when-absent gate must fire and the output comment must contain the
+            # prior block's cost-pattern-data plus the preservation notice.
+            # The InvokeOrchestratorInProcessWithRealPreservation variant omits the
+            # Resolve-CostDataPreservation stub so the real function can return use_prior=true.
+            $priorCostBody = "## Cost Pattern`n<!-- cost-pattern-data`nversion: 1`nsession_completeness: complete`nexcluded_from_rolling_baseline: false`ngenerated_at: 2026-04-01T00:00:00Z`nports:`nanomaly_flags: []`npr: 467`n-->"
+            $comments = @([pscustomobject]@{ body = $priorCostBody; databaseId = 2001 })
+
+            $result = & $script:InvokeOrchestratorInProcessWithRealPreservation `
+                -PrBody $script:V4AllCoveredBody `
+                -Comments $comments
+
+            $result.ExitCode | Should -Be 0
+            $result.Comment | Should -Match '<!-- cost-pattern-data'
+            # Preservation notice must be surfaced in the output (> [!NOTE] block)
+            $result.Comment | Should -Match 'NOTE'
+        }
+
+        It 'returns use_prior=true when current is unknown and prior is complete' {
+            # Unit test directly against Resolve-CostDataPreservation with the
+            # corrected flat $Prior shape (completeness + rendered_at keys).
+            . $script:OrchestratorPath -Pr 467 -Mode 'warn'
+            $prior = @{ completeness = 'complete'; rendered_at = '2026-01-01T00:00:00Z' }
+            $current = @{ completeness = 'unknown'; excluded_from_rolling_baseline = $true }
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior
+            $result['use_prior'] | Should -Be $true
+            $result['notice'] | Should -Not -BeNullOrEmpty
+        }
+
+        It 'renders fresh cost section without crash when no prior comment exists (cold start)' {
+            # Verify that when there is no prior cost-pattern-data comment (cold start),
+            # the orchestrator still renders normally — no crash, no preservation fires.
+            $result = & $script:InvokeOrchestratorInProcess `
+                -PrBody $script:V4AllCoveredBody `
+                -CostMarkdown '## Cost Pattern' `
+                -CostYaml "<!-- cost-pattern-data`npr: 467`n-->"
+            $result.ExitCode | Should -Be 0
+            $result.Comment | Should -Match '<!-- cost-pattern-data'
         }
     }
 }

--- a/.github/scripts/Tests/cost-integration.Tests.ps1
+++ b/.github/scripts/Tests/cost-integration.Tests.ps1
@@ -655,6 +655,56 @@ Describe 'frame-credit-ledger cost integration' {
         }
     }
 
+    Context 'D2 — non-vacuous walker accuracy' {
+
+        It 'attributed events are correct and stable across two runs' {
+            # Create a synthetic projects root with known events.
+            # 3 events on the target branch + 1 on main (must be excluded by branch filter).
+            $tmp = Join-Path ([IO.Path]::GetTempPath()) "cost-accuracy-$([System.Guid]::NewGuid())"
+            $slug = 'c--Users-Test-myrepo'
+            $slugDir = Join-Path $tmp $slug
+            $null = New-Item -ItemType Directory -Path $slugDir -Force
+
+            $branch = 'feature/test-accuracy'
+            $cwd = 'C:\Users\Test\myrepo'
+
+            $events = @(
+                @{ type = 'assistant'; uuid = 'acc-0001'; timestamp = '2026-01-01T00:00:00Z'; cwd = $cwd; gitBranch = $branch; message = @{ usage = @{ input_tokens = 100; output_tokens = 50 }; content = @() } }
+                @{ type = 'assistant'; uuid = 'acc-0002'; timestamp = '2026-01-01T00:01:00Z'; cwd = $cwd; gitBranch = $branch; message = @{ usage = @{ input_tokens = 200; output_tokens = 100 }; content = @() } }
+                @{ type = 'assistant'; uuid = 'acc-0003'; timestamp = '2026-01-01T00:02:00Z'; cwd = $cwd; gitBranch = 'main'; message = @{ usage = @{ input_tokens = 999; output_tokens = 999 }; content = @() } }
+                @{ type = 'assistant'; uuid = 'acc-0004'; timestamp = '2026-01-01T00:03:00Z'; cwd = $cwd; gitBranch = $branch; message = @{ usage = @{ input_tokens = 300; output_tokens = 150 }; content = @() } }
+            )
+            $events | ForEach-Object { $_ | ConvertTo-Json -Compress -Depth 10 } | Set-Content -Path (Join-Path $slugDir 'session.jsonl') -Encoding utf8NoBOM
+
+            # Run the real walker twice in isolated scriptblock scopes to verify
+            # determinism. Each scriptblock dot-sources the walker fresh so stubs
+            # in the outer test scope do not shadow the real functions.
+            # Use .GetNewClosure() to capture local variables into the scriptblock scope
+            # (avoids $using: which is only valid in remote/parallel contexts).
+            $libDir = $script:LibDir
+            $walkerBlock = {
+                param($WSlug, $WBranch, $WCwd, $WTmp, $WLibDir)
+                . (Join-Path $WLibDir 'cost-walker.ps1')
+                . (Join-Path $WLibDir 'path-normalize.ps1')
+                @(Invoke-CostTranscriptWalk -Slug $WSlug -Branch $WBranch -ParentCwd $WCwd -ProjectsRoot $WTmp)
+            }
+            $run1 = & $walkerBlock $slug $branch $cwd $tmp $libDir
+            $run2 = & $walkerBlock $slug $branch $cwd $tmp $libDir
+
+            # Non-vacuous: must find exactly the 3 target-branch events (acc-0003 is on main → excluded).
+            $run1.Count | Should -Be 3
+            # Stable across 2 runs.
+            $run2.Count | Should -Be 3
+            # UUIDs are exactly the expected set.
+            $run1Uuids = @($run1 | ForEach-Object { $_['uuid'] } | Sort-Object)
+            $run1Uuids | Should -Be @('acc-0001', 'acc-0002', 'acc-0004')
+            $run2Uuids = @($run2 | ForEach-Object { $_['uuid'] } | Sort-Object)
+            $run2Uuids | Should -BeExactly $run1Uuids
+
+            Remove-Item -Recurse -Force $tmp
+        }
+    }
+
     Context 'D1 CI-contract preservation (skip-when-absent gate)' {
 
         It 'preserves prior cost-pattern-data block when projects root is absent (CI enforce path)' {

--- a/.github/scripts/Tests/cost-integration.Tests.ps1
+++ b/.github/scripts/Tests/cost-integration.Tests.ps1
@@ -725,6 +725,10 @@ Describe 'frame-credit-ledger cost integration' {
             $result.Comment | Should -Match '<!-- cost-pattern-data'
             # Preservation notice must be surfaced in the output (> [!NOTE] block)
             $result.Comment | Should -Match 'NOTE'
+            # Verify the prior block's content survived (not replaced by fresh-empty render).
+            # The prior body contains 'generated_at: 2026-04-01' which the fresh stub does not.
+            # A clobber would produce only 'pr: 467' with no prior timestamp.
+            $result.Comment | Should -Match '2026-04-01'
         }
 
         It 'returns use_prior=true when current is unknown and prior is complete' {

--- a/.github/scripts/Tests/cost-integration.Tests.ps1
+++ b/.github/scripts/Tests/cost-integration.Tests.ps1
@@ -731,6 +731,32 @@ Describe 'frame-credit-ledger cost integration' {
             $result.Comment | Should -Match '2026-04-01'
         }
 
+        It 'preserves malformed-but-present prior block verbatim (Fix #760-F9)' {
+            # Regression for the C3 erase defect: when a prior cost-pattern-data block
+            # exists (matches loose selector) but its body cannot be extracted by the
+            # strict multiline regex (malformed — no newline after marker), the C3 fix
+            # correctly defaults priorCostData to 'complete' → use_prior=true.  Before
+            # the F9 fix, the section-rebuild re-called the failing extractor, got $null,
+            # left $costSection='', and ERASED the prior block.  After the fix, the raw
+            # block is carried verbatim, honoring the D1 invariant.
+            # A malformed block: matches '<!-- cost-pattern-data' (loose) but the strict
+            # multiline regex '<!--\s*cost-pattern-data\s*\r?\n([\s\S]*?)\r?\n?-->' fails
+            # because there is no newline after the marker — single-line form.
+            $malformedBlockSentinel = 'f9-sentinel-malformed-unique'
+            $priorCostBody = "## Cost Pattern`n<!-- cost-pattern-data $malformedBlockSentinel -->"
+            $comments = @([pscustomobject]@{ body = $priorCostBody; databaseId = 2999 })
+
+            $result = & $script:InvokeOrchestratorInProcessWithRealPreservation `
+                -PrBody $script:V4AllCoveredBody `
+                -Comments $comments
+
+            $result.ExitCode | Should -Be 0
+            # The malformed block must survive verbatim — if F9 regresses, $costSection
+            # is '' and the sentinel disappears from the comment.
+            $result.Comment | Should -Match $malformedBlockSentinel -Because 'malformed prior block must be carried verbatim, not erased'
+            $result.Comment | Should -Match '<!-- cost-pattern-data' -Because 'cost marker must be present'
+        }
+
         It 'returns use_prior=true when current is unknown and prior is complete' {
             # Unit test directly against Resolve-CostDataPreservation with the
             # corrected flat $Prior shape (completeness + rendered_at keys).

--- a/.github/scripts/Tests/cost-rolling-history.Tests.ps1
+++ b/.github/scripts/Tests/cost-rolling-history.Tests.ps1
@@ -695,6 +695,47 @@ totals:
             ($refs | Where-Object { $_ -eq '#4690' }).Count | Should -Be 1
         }
 
+        It 'maps session_completeness->completeness and generated_at->rendered_at at the parse boundary (Fix #760-T3)' {
+            # ConvertFrom-CostPatternYaml projects the renderer's `session_completeness`
+            # and `generated_at` fields onto the `completeness` / `rendered_at` keys that
+            # Resolve-CostDataPreservation reads. Without these mappings the preservation
+            # gate silently sees null completeness and clobbers a complete prior block.
+            # The integration AC2 test hand-builds the flat shape and bypasses the parser,
+            # so this asserts the mappings directly — a revert of either line fails here.
+            $bodyText = @"
+<!-- cost-pattern-data
+version: 1
+session_completeness: complete
+generated_at: 2026-05-20T08:30:00Z
+pr: 1234
+branch: feature/issue-760-t3
+ports:
+- name: experience
+    cost_estimate_usd: 0.05
+orchestrator_overhead:
+  cost_estimate_usd: 0.01
+dispatches:
+  general_purpose_count: 1
+  unattributed_count: 0
+totals:
+  cost_estimate_usd: 0.06
+-->
+"@
+            $graphqlResp = New-GraphQLResponse -CommentBodies @($bodyText)
+            Install-GhMock -GraphQLResponse $graphqlResp
+
+            $result = Get-CostRollingHistory -CachePath $script:TestCachePath -RepoRoot $script:RepoRoot -TimeoutSeconds 30
+
+            $result.timed_out | Should -Be $false
+            $result.entries.Count | Should -Be 1
+            $entry = $result.entries[0]
+            # Both source field and mapped alias must be populated.
+            $entry['session_completeness'] | Should -Be 'complete'
+            $entry['completeness']         | Should -Be 'complete' -Because 'preservation gate reads $Prior[''completeness'']'
+            $entry['generated_at']         | Should -Be '2026-05-20T08:30:00Z'
+            $entry['rendered_at']          | Should -Be '2026-05-20T08:30:00Z' -Because 'preservation notice reads $Prior[''rendered_at'']'
+        }
+
         It 'returns empty entries array when no matching comments found (GraphQL 200 empty)' {
             # M19 regression: zero nodes is a valid zero-PR result
             Install-GhMock -GraphQLResponse (New-GraphQLEmptyNodesResponse) -GraphQLExitCode 0

--- a/.github/scripts/Tests/cost-walker.Tests.ps1
+++ b/.github/scripts/Tests/cost-walker.Tests.ps1
@@ -797,3 +797,51 @@ Describe 'Invoke-CostTranscriptWalk' {
         }
     }
 }
+
+Describe 'Resolve-CostWalkerRepoIdentity' {
+    BeforeAll {
+        $script:LibPath = Join-Path $PSScriptRoot '../lib/cost-walker.ps1'
+        if (Test-Path $script:LibPath) {
+            . $script:LibPath
+            . (Join-Path $PSScriptRoot '../lib/path-normalize.ps1')
+        }
+    }
+
+    Context 'transport-agnostic normalization (Fix #760-E1)' {
+        It 'normalizes plain HTTPS to host/path' {
+            script:Resolve-CostWalkerRepoIdentity -RawUrl 'https://github.com/owner/repo' |
+                Should -Be 'github.com/owner/repo'
+        }
+        It 'strips a trailing .git suffix' {
+            script:Resolve-CostWalkerRepoIdentity -RawUrl 'https://github.com/owner/repo.git' |
+                Should -Be 'github.com/owner/repo'
+        }
+        It 'normalizes scp-like SSH form to the same identity as HTTPS' {
+            $ssh   = script:Resolve-CostWalkerRepoIdentity -RawUrl 'git@github.com:owner/repo.git'
+            $https = script:Resolve-CostWalkerRepoIdentity -RawUrl 'https://github.com/owner/repo'
+            $ssh   | Should -Be 'github.com/owner/repo'
+            $ssh   | Should -Be $https -Because 'SSH and HTTPS forms of the same repo must match'
+        }
+        It 'normalizes ssh:// scheme form to the same identity' {
+            script:Resolve-CostWalkerRepoIdentity -RawUrl 'ssh://git@github.com/owner/repo.git' |
+                Should -Be 'github.com/owner/repo'
+        }
+        It 'strips credential userinfo (x-access-token) from HTTPS' {
+            script:Resolve-CostWalkerRepoIdentity -RawUrl 'https://x-access-token:ghs_SECRET@github.com/owner/repo' |
+                Should -Be 'github.com/owner/repo'
+        }
+        It 'is case-insensitive and trims trailing slashes' {
+            script:Resolve-CostWalkerRepoIdentity -RawUrl 'HTTPS://GitHub.com/Owner/Repo/' |
+                Should -Be 'github.com/owner/repo'
+        }
+        It 'returns $null for empty or whitespace input (fail-closed)' {
+            script:Resolve-CostWalkerRepoIdentity -RawUrl ''    | Should -BeNullOrEmpty
+            script:Resolve-CostWalkerRepoIdentity -RawUrl '   '  | Should -BeNullOrEmpty
+        }
+        It 'distinguishes different repos on the same host' {
+            $a = script:Resolve-CostWalkerRepoIdentity -RawUrl 'git@github.com:owner/repo-a.git'
+            $b = script:Resolve-CostWalkerRepoIdentity -RawUrl 'https://github.com/owner/repo-b'
+            $a | Should -Not -Be $b
+        }
+    }
+}

--- a/.github/scripts/Tests/cost-walker.Tests.ps1
+++ b/.github/scripts/Tests/cost-walker.Tests.ps1
@@ -623,36 +623,60 @@ Describe 'Invoke-CostTranscriptWalk' {
             $script:TestRepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
         }
 
-        It 'admits events from two slug dirs that both resolve to the same git remote identity' {
-            # Both slug dirs contain events whose first-event cwd is the real repo root.
-            # git -C $TestRepoRoot remote get-url origin resolves to the same URL for both,
-            # so identity matching admits both dirs.
-            $tmp = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-d2-$([System.Guid]::NewGuid())"
-            $branch = 'feature/d2-cross-clone'
+        It 'admits events from two slug dirs with different cwd paths that resolve to the same git remote identity (AC3)' {
+            # Get the target remote URL from the real repo
+            $targetRemote = @(& git -C $script:TestRepoRoot remote get-url origin 2>&1) | Select-Object -First 1
+            if ($global:LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($targetRemote)) {
+                Set-ItResult -Skipped -Because 'cannot resolve test repo remote (no git remote configured)'
+                return
+            }
+            $targetRemote = $targetRemote.Trim()
 
+            $tmpProj = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-ac3-$([System.Guid]::NewGuid())"
+            $tmpProjects = Join-Path $tmpProj 'projects'
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+
+            # Primary slug — events cwd is the actual repo root
             $primarySlug = Get-CostTranscriptSlug -CwdPath $script:TestRepoRoot
-            $primaryDir = Join-Path $tmp $primarySlug
+            $primaryDir = Join-Path $tmpProjects $primarySlug
             $null = New-Item -ItemType Directory -Path $primaryDir -Force
 
-            # Second slug dir — different name (simulates a cross-clone slug) but also has
-            # events pointing to the real repo root so git resolves the same identity.
-            $siblingSlug = 'cross-clone-sibling-slug'
-            $siblingDir = Join-Path $tmp $siblingSlug
+            # Sibling clone — a DIFFERENT cwd path, but same remote URL (simulates sibling clone)
+            $siblingCwdPath = Join-Path $tmpProj 'sibling-clone'
+            $null = New-Item -ItemType Directory -Path $siblingCwdPath -Force
+            $null = & git init $siblingCwdPath 2>&1
+            $null = & git -C $siblingCwdPath remote add origin $targetRemote  # same remote as TestRepoRoot
+
+            $siblingSlug = Get-CostTranscriptSlug -CwdPath $siblingCwdPath
+            $siblingDir = Join-Path $tmpProjects $siblingSlug
             $null = New-Item -ItemType Directory -Path $siblingDir -Force
 
-            $evPrimary = script:New-AssistantEvent -Uuid 'd2-primary-01' -Cwd $script:TestRepoRoot -Branch $branch
-            $evSibling = script:New-AssistantEvent -Uuid 'd2-sibling-01' -Cwd $script:TestRepoRoot -Branch $branch
+            $branch = 'feature/ac3-test'
 
-            script:Write-TestJsonl -Path (Join-Path $primaryDir 'session.jsonl') -Events @($evPrimary)
-            script:Write-TestJsonl -Path (Join-Path $siblingDir 'session.jsonl') -Events @($evSibling)
+            # Primary event — cwd = real repo root
+            @(@{
+                type = 'assistant'; uuid = 'ac3-primary-01'; timestamp = '2026-01-01T00:00:00Z'
+                cwd = $script:TestRepoRoot; gitBranch = $branch
+                message = @{ usage = @{ input_tokens = 10; output_tokens = 5 }; content = @() }
+            }) | ForEach-Object { $_ | ConvertTo-Json -Compress -Depth 10 } |
+                Set-Content (Join-Path $primaryDir 'session.jsonl') -Encoding utf8NoBOM
 
-            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:TestRepoRoot -ProjectsRoot $tmp -RepoRoot $script:TestRepoRoot)
+            # Sibling event — cwd = sibling clone path (DIFFERENT from primary, same remote)
+            @(@{
+                type = 'assistant'; uuid = 'ac3-sibling-01'; timestamp = '2026-01-01T00:00:00Z'
+                cwd = $siblingCwdPath; gitBranch = $branch  # different path, same remote
+                message = @{ usage = @{ input_tokens = 10; output_tokens = 5 }; content = @() }
+            }) | ForEach-Object { $_ | ConvertTo-Json -Compress -Depth 10 } |
+                Set-Content (Join-Path $siblingDir 'session.jsonl') -Encoding utf8NoBOM
 
-            # Both dirs resolve to the same git remote identity — both events admitted.
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:TestRepoRoot -ProjectsRoot $tmpProjects -RepoRoot $script:TestRepoRoot)
+
+            # AC3: both slug dirs admitted because both resolve to the same git identity
             $result.Count | Should -Be 2
-            $uuids = @($result | ForEach-Object { $_['uuid'] } | Sort-Object)
-            $uuids | Should -Be @('d2-primary-01', 'd2-sibling-01')
-            Remove-Item -Recurse -Force $tmp
+            @($result | Where-Object { $_['uuid'] -eq 'ac3-primary-01' }).Count | Should -Be 1
+            @($result | Where-Object { $_['uuid'] -eq 'ac3-sibling-01' }).Count | Should -Be 1
+
+            Remove-Item -Recurse -Force $tmpProj
         }
 
         It 'excludes slug dir whose first-event cwd has unresolvable git identity (fail-closed per-candidate)' {
@@ -723,6 +747,53 @@ Describe 'Invoke-CostTranscriptWalk' {
             $result.Count | Should -Be 1
             $result[0]['uuid'] | Should -Be 'd2-worktree-hash-01'
             Remove-Item -Recurse -Force $tmp
+        }
+
+        It 'rejects slug dir whose first-event cwd resolves to a different git remote (AC4)' {
+            $tmpProj = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-ac4-$([System.Guid]::NewGuid())"
+            $tmpProjects = Join-Path $tmpProj 'projects'
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+
+            # Matching slug dir — events cwd points to the REAL repo root (same identity as target)
+            $matchSlug = Get-CostTranscriptSlug -CwdPath $script:TestRepoRoot
+            $matchDir = Join-Path $tmpProjects $matchSlug
+            $null = New-Item -ItemType Directory -Path $matchDir -Force
+
+            # Non-matching slug dir — events cwd points to a tmp git repo with a DIFFERENT remote
+            $otherRepoPath = Join-Path $tmpProj 'other-repo'
+            $null = New-Item -ItemType Directory -Path $otherRepoPath -Force
+            $null = & git init $otherRepoPath 2>&1
+            $null = & git -C $otherRepoPath remote add origin 'https://github.com/fake-org/different-repo-ac4-test'
+
+            $otherSlug = Get-CostTranscriptSlug -CwdPath $otherRepoPath
+            $otherDir = Join-Path $tmpProjects $otherSlug
+            $null = New-Item -ItemType Directory -Path $otherDir -Force
+
+            $branch = 'feature/ac4-test'
+
+            # Write matching event (should be admitted)
+            @(@{
+                type      = 'assistant'; uuid = 'ac4-match-01'; timestamp = '2026-01-01T00:00:00Z'
+                cwd = $script:TestRepoRoot; gitBranch = $branch
+                message = @{ usage = @{ input_tokens = 10; output_tokens = 5 }; content = @() }
+            }) | ForEach-Object { $_ | ConvertTo-Json -Compress -Depth 10 } |
+                Set-Content (Join-Path $matchDir 'session.jsonl') -Encoding utf8NoBOM
+
+            # Write non-matching event (should be REJECTED because different remote)
+            @(@{
+                type      = 'assistant'; uuid = 'ac4-reject-01'; timestamp = '2026-01-01T00:00:00Z'
+                cwd = $otherRepoPath; gitBranch = $branch
+                message = @{ usage = @{ input_tokens = 10; output_tokens = 5 }; content = @() }
+            }) | ForEach-Object { $_ | ConvertTo-Json -Compress -Depth 10 } |
+                Set-Content (Join-Path $otherDir 'session.jsonl') -Encoding utf8NoBOM
+
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:TestRepoRoot -ProjectsRoot $tmpProjects -RepoRoot $script:TestRepoRoot)
+
+            # AC4: different-remote slug dir must be rejected; only matching slug's event admitted
+            $result.Count | Should -Be 1
+            $result[0]['uuid'] | Should -Be 'ac4-match-01'
+
+            Remove-Item -Recurse -Force $tmpProj
         }
     }
 }

--- a/.github/scripts/Tests/cost-walker.Tests.ps1
+++ b/.github/scripts/Tests/cost-walker.Tests.ps1
@@ -140,7 +140,8 @@ Describe 'Invoke-CostTranscriptWalk' {
             Remove-Item -Recurse -Force $tmp
         }
 
-        It 'excludes assistant events with non-matching cwd' {
+        It 'admits assistant events whose branch matches even when cwd differs from ParentCwd' {
+            # D2: cwd-equality check was removed in s3; slug-dir identity is the admission gate.
             $tmp = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-test-$([System.Guid]::NewGuid())"
             $slug = 'test--repo'
             $slugDir = Join-Path $tmp $slug
@@ -152,7 +153,7 @@ Describe 'Invoke-CostTranscriptWalk' {
             script:Write-TestJsonl -Path (Join-Path $slugDir 'session.jsonl') -Events $events
 
             $result = @(Invoke-CostTranscriptWalk -Slug $slug -Branch $script:TestBranch -ParentCwd $script:TestCwd -ProjectsRoot $tmp)
-            $result.Count | Should -Be 0
+            $result.Count | Should -Be 1
             Remove-Item -Recurse -Force $tmp
         }
 
@@ -345,13 +346,15 @@ Describe 'Invoke-CostTranscriptWalk' {
             Remove-Item -Recurse -Force $tmp
         }
 
-        It 'handles event with absent cwd field as non-matching' {
+        It 'admits event with absent cwd field when branch matches (cwd check removed in s3)' {
+            # D2: Test-CostWalkerAssistantMatchesStrictFilter checks only gitBranch after s3.
+            # An event with no cwd field is admitted as long as branch matches.
             $tmp = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-test-$([System.Guid]::NewGuid())"
             $slug = 'test--repo'
             $slugDir = Join-Path $tmp $slug
             $null = New-Item -ItemType Directory -Path $slugDir -Force
 
-            # Event with no cwd field
+            # Event with no cwd field but with matching branch
             $events = @(
                 @{
                     type      = 'assistant'
@@ -364,7 +367,7 @@ Describe 'Invoke-CostTranscriptWalk' {
             script:Write-TestJsonl -Path (Join-Path $slugDir 'session.jsonl') -Events $events
 
             $result = @(Invoke-CostTranscriptWalk -Slug $slug -Branch $script:TestBranch -ParentCwd $script:TestCwd -ProjectsRoot $tmp)
-            $result.Count | Should -Be 0
+            $result.Count | Should -Be 1
             Remove-Item -Recurse -Force $tmp
         }
 
@@ -611,4 +614,115 @@ Describe 'Invoke-CostTranscriptWalk' {
                 Remove-Item -Recurse -Force $tmp
             }
         }
+
+    Context 'D2 — cross-clone attribution (identity matching)' {
+        BeforeAll {
+            # Resolve the actual repo root so identity resolution (git remote get-url origin)
+            # succeeds in tests. Tests that use RepoRoot use the real repo; tests that omit
+            # RepoRoot and provide only Slug rely on the backward-compat path.
+            $script:TestRepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        }
+
+        It 'admits events from two slug dirs that both resolve to the same git remote identity' {
+            # Both slug dirs contain events whose first-event cwd is the real repo root.
+            # git -C $TestRepoRoot remote get-url origin resolves to the same URL for both,
+            # so identity matching admits both dirs.
+            $tmp = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-d2-$([System.Guid]::NewGuid())"
+            $branch = 'feature/d2-cross-clone'
+
+            $primarySlug = Get-CostTranscriptSlug -CwdPath $script:TestRepoRoot
+            $primaryDir = Join-Path $tmp $primarySlug
+            $null = New-Item -ItemType Directory -Path $primaryDir -Force
+
+            # Second slug dir — different name (simulates a cross-clone slug) but also has
+            # events pointing to the real repo root so git resolves the same identity.
+            $siblingSlug = 'cross-clone-sibling-slug'
+            $siblingDir = Join-Path $tmp $siblingSlug
+            $null = New-Item -ItemType Directory -Path $siblingDir -Force
+
+            $evPrimary = script:New-AssistantEvent -Uuid 'd2-primary-01' -Cwd $script:TestRepoRoot -Branch $branch
+            $evSibling = script:New-AssistantEvent -Uuid 'd2-sibling-01' -Cwd $script:TestRepoRoot -Branch $branch
+
+            script:Write-TestJsonl -Path (Join-Path $primaryDir 'session.jsonl') -Events @($evPrimary)
+            script:Write-TestJsonl -Path (Join-Path $siblingDir 'session.jsonl') -Events @($evSibling)
+
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:TestRepoRoot -ProjectsRoot $tmp -RepoRoot $script:TestRepoRoot)
+
+            # Both dirs resolve to the same git remote identity — both events admitted.
+            $result.Count | Should -Be 2
+            $uuids = @($result | ForEach-Object { $_['uuid'] } | Sort-Object)
+            $uuids | Should -Be @('d2-primary-01', 'd2-sibling-01')
+            Remove-Item -Recurse -Force $tmp
+        }
+
+        It 'excludes slug dir whose first-event cwd has unresolvable git identity (fail-closed per-candidate)' {
+            # One matching slug dir (cwd = real repo root → identity resolves and matches).
+            # One non-matching slug dir (cwd = fake path → git fails → excluded, fail-closed).
+            $tmp = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-d2-$([System.Guid]::NewGuid())"
+            $branch = 'feature/d2-fail-closed-candidate'
+
+            $matchSlug = Get-CostTranscriptSlug -CwdPath $script:TestRepoRoot
+            $matchDir = Join-Path $tmp $matchSlug
+            $null = New-Item -ItemType Directory -Path $matchDir -Force
+
+            $nonMatchDir = Join-Path $tmp 'non-matching-slug'
+            $null = New-Item -ItemType Directory -Path $nonMatchDir -Force
+
+            $evMatch = script:New-AssistantEvent -Uuid 'd2-match-01' -Cwd $script:TestRepoRoot -Branch $branch
+            $evNonMatch = script:New-AssistantEvent -Uuid 'd2-nomatch-01' -Cwd 'C:\fake\nonexistent\path' -Branch $branch
+
+            script:Write-TestJsonl -Path (Join-Path $matchDir 'session.jsonl') -Events @($evMatch)
+            script:Write-TestJsonl -Path (Join-Path $nonMatchDir 'session.jsonl') -Events @($evNonMatch)
+
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:TestRepoRoot -ProjectsRoot $tmp -RepoRoot $script:TestRepoRoot)
+
+            # Only the matching dir's event is admitted; non-matching dir's event is excluded.
+            $result.Count | Should -Be 1
+            $result[0]['uuid'] | Should -Be 'd2-match-01'
+            Remove-Item -Recurse -Force $tmp
+        }
+
+        It 'returns empty when target identity is unresolvable and no Slug is given (fail-closed)' {
+            # When RepoRoot has no git remote AND Slug is omitted, identity resolution fails
+            # and the backward-compat path is inactive (no Slug) — result must be empty.
+            $tmp = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-d2-$([System.Guid]::NewGuid())"
+            $branch = 'feature/d2-fail-closed-target'
+
+            $slugDir = Join-Path $tmp 'some-slug'
+            $null = New-Item -ItemType Directory -Path $slugDir -Force
+
+            $ev = script:New-AssistantEvent -Uuid 'd2-target-fail-01' -Cwd 'C:\fake\path' -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $slugDir 'session.jsonl') -Events @($ev)
+
+            # RepoRoot points to a path with no git remote; Slug is omitted.
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd 'C:\fake\path' -ProjectsRoot $tmp -RepoRoot 'C:\fake\path')
+
+            # Identity resolution fails for target AND no Slug → fail-closed: empty result.
+            $result.Count | Should -Be 0
+            Remove-Item -Recurse -Force $tmp
+        }
+
+        It 'admits worktree slug dir with hash name when primary Slug is given' {
+            # Worktree session dirs use slug names like {slug}--claude-worktrees-{hash}.
+            # They are discovered via the worktree-glob path when the primary Slug is given.
+            $tmp = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-d2-$([System.Guid]::NewGuid())"
+            $slug = 'test--repo'
+            $branch = $script:TestBranch
+
+            $worktreeDir = Join-Path $tmp "$slug--claude-worktrees-deadbeef"
+            $null = New-Item -ItemType Directory -Path $worktreeDir -Force
+
+            # Event cwd is the worktree checkout path (a normal filesystem path, not the
+            # primary repo root); branch filter is what matters after s3 cwd-check removal.
+            $ev = script:New-AssistantEvent -Uuid 'd2-worktree-hash-01' -Cwd 'C:\Users\Test\.claude\worktrees\deadbeef' -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $worktreeDir 'session.jsonl') -Events @($ev)
+
+            $result = @(Invoke-CostTranscriptWalk -Slug $slug -Branch $branch -ParentCwd $script:TestCwd -ProjectsRoot $tmp)
+
+            # Worktree dir is discovered via the $Slug--claude-worktrees-* glob.
+            $result.Count | Should -Be 1
+            $result[0]['uuid'] | Should -Be 'd2-worktree-hash-01'
+            Remove-Item -Recurse -Force $tmp
+        }
+    }
 }

--- a/.github/scripts/cost-regime-checkpoints.yaml
+++ b/.github/scripts/cost-regime-checkpoints.yaml
@@ -1,2 +1,12 @@
 schema_version: 1
-checkpoints: []
+checkpoints:
+  - id: "cp-20260628-203154"
+    timestamp: "2026-06-28T20:31:54.7099274Z"
+    reason: "CE Gate S1 — #760 fix validation"
+    metrics:
+      orchestrator_overhead.cost_estimate_usd.mean: 0
+      port.dispatches.general_purpose.cost_estimate_usd.mean: 0
+      port.experience.cost_estimate_usd.mean: 0
+      port.review.cost_estimate_usd.mean: 0
+    exclusions:
+      recent_count: 0

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -1594,6 +1594,7 @@ function Invoke-FrameCreditLedger {
                     Slug      = $slug
                     Branch    = $costBranch
                     ParentCwd = $repoRoot
+                    RepoRoot  = $repoRoot  # D2: used by identity-based slug discovery
                 }
                 if ($null -ne $resolvedIssueNumber) {
                     $walkParameters['IssueNumber'] = [int]$resolvedIssueNumber

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -1678,10 +1678,19 @@ function Invoke-FrameCreditLedger {
                     if ($null -ne $priorYaml) {
                         $priorCostData = script:ConvertFrom-CostPatternYaml -Yaml $priorYaml
                     }
-                    # Fallback: if parse fails or comment has no data block, synthesize a
-                    # minimal flat shape so preservation logic has something to compare.
+                    # Fix #760-C3: a populated prior cost-pattern-data block must never be
+                    # clobbered by an empty/partial current walk.  A block that predates the
+                    # session_completeness field parses with a null 'completeness' (and a fully
+                    # unextractable body yields $null priorCostData).  In both cases the marker's
+                    # presence means a genuine render already exists — the old contract only wrote
+                    # the block on a populated render — so default any prior block lacking an
+                    # explicit completeness to 'complete'.  Resolve-CostDataPreservation then
+                    # preserves it instead of overwriting with the empty/partial current.
                     if ($null -eq $priorCostData) {
-                        $priorCostData = @{ completeness = 'unknown' }
+                        $priorCostData = @{ completeness = 'complete' }
+                    }
+                    elseif ([string]::IsNullOrWhiteSpace([string]$priorCostData['completeness'])) {
+                        $priorCostData['completeness'] = 'complete'
                     }
                 }
             }

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -1706,20 +1706,45 @@ function Invoke-FrameCreditLedger {
             # populated block is NEVER replaced by an empty one.
             $usePriorCostSection = $preservationResult['use_prior'] -eq $true
             if ($usePriorCostSection -and $null -ne $priorComment) {
-                # Extract the existing cost section (markdown + YAML) from the prior comment body.
-                # The section spans from the first cost heading/separator to end-of-comment or the
-                # next top-level section.  We use the raw YAML block as a safe fallback if a richer
-                # extraction is unavailable.
                 $priorYamlForSection = script:Get-CostPatternDataFromComment -Body $priorComment.body
+                $preservationNotice = $preservationResult['notice']
+                $noticeBlock = if ($null -ne $preservationNotice -and $preservationNotice -ne '') {
+                    "> [!NOTE]`n> $preservationNotice`n`n"
+                } else { '' }
                 if ($null -ne $priorYamlForSection) {
-                    $preservationNotice = $preservationResult['notice']
-                    $noticeBlock = if ($null -ne $preservationNotice -and $preservationNotice -ne '') {
-                        "> [!NOTE]`n> $preservationNotice`n`n"
-                    } else { '' }
-                    $costSection = $noticeBlock + "<!-- cost-pattern-data`n$priorYamlForSection`n-->"
+                    # Fix #760-F3: preserve the full visible section (heading + rendered markdown
+                    # table + YAML block) from the prior comment, not only the hidden YAML comment.
+                    # Without this, the human-readable Cost Pattern table disappears when preservation
+                    # fires, even though the underlying data (rolling-baseline YAML) survives.
+                    $sectionMatch = [regex]::Match(
+                        $priorComment.body,
+                        '(?ms)(?<section>^##\s+Cost Pattern\b.*?<!--\s*cost-pattern-data[\s\S]*?-->)'
+                    )
+                    $priorSection = if ($sectionMatch.Success) {
+                        $sectionMatch.Groups['section'].Value.TrimEnd()
+                    } else {
+                        # Fallback: visible heading unavailable — use YAML block only.
+                        "<!-- cost-pattern-data`n$priorYamlForSection`n-->"
+                    }
+                    $costSection = $noticeBlock + $priorSection
                 }
-                # If extraction failed, leave $costSection as-is (empty string) — better to emit
-                # nothing than to emit a broken or truncated block.
+                else {
+                    # Fix #760-F9: prior block exists (loose selector matched) but the strict
+                    # extractor could not parse its body (malformed block — missing closing -->,
+                    # no newline after marker, etc.).  C3 defaulted priorCostData to 'complete'
+                    # above, which correctly triggers use_prior=true, but without this fallback
+                    # the rebuild path left $costSection='' and erased the prior block — the
+                    # exact opposite of the D1 invariant.  Carry the raw block verbatim instead.
+                    $rawBlockMatch = [regex]::Match(
+                        $priorComment.body,
+                        '<!--\s*cost-pattern-data[\s\S]*?-->'
+                    )
+                    if ($rawBlockMatch.Success) {
+                        $costSection = $noticeBlock + $rawBlockMatch.Value
+                    }
+                    # else: truly no cost block in the body despite the selector match — leave
+                    # $costSection as-is (empty string). This path is not normally reachable.
+                }
             }
             else {
                 # 6f. Anomaly flags — only compute when not using prior (AC2: guard on use_prior)

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -1666,29 +1666,65 @@ function Invoke-FrameCreditLedger {
             }
             $completeness = Get-SessionCompleteness @completenessParameters
             $priorCostData = $null
+            $priorComment = $null
             if ($null -ne $script:PrComments) {
                 $priorComment = @($script:PrComments | Where-Object { $_.body -match '<!-- cost-pattern-data' }) | Select-Object -Last 1
                 if ($priorComment) {
-                    $priorCompleteness = @{ completeness = 'complete'; excluded_from_rolling_baseline = $false }
-                    $priorCostData = @{ completeness = $priorCompleteness }
+                    # Fix #760-D1-c: parse the actual prior comment body rather than using a
+                    # hardcoded stub, and use a flat shape so Resolve-CostDataPreservation can
+                    # read $Prior['completeness'] as a string (not a nested hashtable).
+                    $priorYaml = script:Get-CostPatternDataFromComment -Body $priorComment.body
+                    if ($null -ne $priorYaml) {
+                        $priorCostData = script:ConvertFrom-CostPatternYaml -Yaml $priorYaml
+                    }
+                    # Fallback: if parse fails or comment has no data block, synthesize a
+                    # minimal flat shape so preservation logic has something to compare.
+                    if ($null -eq $priorCostData) {
+                        $priorCostData = @{ completeness = 'unknown' }
+                    }
                 }
             }
-            # preservation result is computed for future use (D10 re-emission prevention);
-            # currently emitted to output pipeline for visibility — suppressed to avoid unused-var warning.
-            $null = Resolve-CostDataPreservation -Current $completeness -Prior $priorCostData
 
-            # 6f. Anomaly flags
-            $anomalyFlags = @()
-            if (-not $rollingResult.timed_out -and (script:Get-FCLRemainingCostBudgetSeconds -Stopwatch $costStopwatch -BudgetSeconds $costBudgetSeconds) -gt 0) {
-                try { $anomalyFlags = @(Get-CostAnomalyFlags -ThisRun $costAttribution -RollingHistory @($rollingResult.entries) -RegimeCheckpoint $checkpoint) }
-                catch { $anomalyFlags = @() }
+            # Fix #760-D1-b: wire the Resolve-CostDataPreservation result instead of discarding it.
+            # This drives the skip-when-absent gate below (AC1 + AC2).
+            $preservationResult = Resolve-CostDataPreservation -Current $completeness -Prior $priorCostData
+
+            # Fix #760-D1-a: skip-when-absent gate — if preservation says to use_prior, reuse the
+            # prior comment's cost section verbatim.  This fires when the projects root is absent
+            # (CI enforce on ubuntu-latest) AND the prior comment had a complete render, preventing
+            # an empty walk from overwriting a populated cost-pattern-data block.  Invariant: a
+            # populated block is NEVER replaced by an empty one.
+            $usePriorCostSection = $preservationResult['use_prior'] -eq $true
+            if ($usePriorCostSection -and $null -ne $priorComment) {
+                # Extract the existing cost section (markdown + YAML) from the prior comment body.
+                # The section spans from the first cost heading/separator to end-of-comment or the
+                # next top-level section.  We use the raw YAML block as a safe fallback if a richer
+                # extraction is unavailable.
+                $priorYamlForSection = script:Get-CostPatternDataFromComment -Body $priorComment.body
+                if ($null -ne $priorYamlForSection) {
+                    $preservationNotice = $preservationResult['notice']
+                    $noticeBlock = if ($null -ne $preservationNotice -and $preservationNotice -ne '') {
+                        "> [!NOTE]`n> $preservationNotice`n`n"
+                    } else { '' }
+                    $costSection = $noticeBlock + "<!-- cost-pattern-data`n$priorYamlForSection`n-->"
+                }
+                # If extraction failed, leave $costSection as-is (empty string) — better to emit
+                # nothing than to emit a broken or truncated block.
             }
+            else {
+                # 6f. Anomaly flags — only compute when not using prior (AC2: guard on use_prior)
+                $anomalyFlags = @()
+                if (-not $rollingResult.timed_out -and (script:Get-FCLRemainingCostBudgetSeconds -Stopwatch $costStopwatch -BudgetSeconds $costBudgetSeconds) -gt 0) {
+                    try { $anomalyFlags = @(Get-CostAnomalyFlags -ThisRun $costAttribution -RollingHistory @($rollingResult.entries) -RegimeCheckpoint $checkpoint) }
+                    catch { $anomalyFlags = @() }
+                }
 
-            # 6g. Render
-            if ((script:Get-FCLRemainingCostBudgetSeconds -Stopwatch $costStopwatch -BudgetSeconds $costBudgetSeconds) -gt 0) {
-                $costMarkdown = Format-CostPatternMarkdown -Attribution $costAttribution -Completeness $completeness -AnomalyFlags $anomalyFlags -RollingMeta $rollingResult -Pr $Pr -Branch ([string]$costBranch)
-                $costYaml = Format-CostPatternYaml -Attribution $costAttribution -Completeness $completeness -AnomalyFlags $anomalyFlags -Pr $Pr -Branch ([string]$costBranch)
-                $costSection = $costMarkdown + "`n" + $costYaml
+                # 6g. Render fresh cost section
+                if ((script:Get-FCLRemainingCostBudgetSeconds -Stopwatch $costStopwatch -BudgetSeconds $costBudgetSeconds) -gt 0) {
+                    $costMarkdown = Format-CostPatternMarkdown -Attribution $costAttribution -Completeness $completeness -AnomalyFlags $anomalyFlags -RollingMeta $rollingResult -Pr $Pr -Branch ([string]$costBranch)
+                    $costYaml = Format-CostPatternYaml -Attribution $costAttribution -Completeness $completeness -AnomalyFlags $anomalyFlags -Pr $Pr -Branch ([string]$costBranch)
+                    $costSection = $costMarkdown + "`n" + $costYaml
+                }
             }
         }
         catch {

--- a/.github/scripts/lib/cost-rolling-history.ps1
+++ b/.github/scripts/lib/cost-rolling-history.ps1
@@ -181,6 +181,23 @@ function script:ConvertFrom-CostPatternYaml {
                 $result['unmapped_session_count'] = [int](script:ConvertFrom-CostPatternYamlScalar -Value $Matches[1])
             }
 
+            # session_completeness (Fix #760-D1-c: needed by Resolve-CostDataPreservation)
+            if ($line -match '^session_completeness\s*:\s*(.+)$') {
+                $result['session_completeness'] = [string](script:ConvertFrom-CostPatternYamlScalar -Value $Matches[1])
+                # Populate completeness key so the flat shape Resolve-CostDataPreservation expects
+                # is satisfied when this parsed result is used as a Prior hashtable.
+                $result['completeness'] = $result['session_completeness']
+            }
+
+            # generated_at (Fix #760-D1-c: reconcile renderer field name to the name
+            # Resolve-CostDataPreservation reads; renderer emits generated_at, preservation
+            # reads rendered_at — map at the parse boundary so the renderer is unchanged)
+            if ($line -match '^generated_at\s*:\s*(.+)$') {
+                $parsedAt = [string](script:ConvertFrom-CostPatternYamlScalar -Value $Matches[1])
+                $result['generated_at'] = $parsedAt
+                $result['rendered_at'] = $parsedAt
+            }
+
             # cost_pattern_data block
             if ($line -match '^\s*cost_pattern_data\s*:\s*$') {
                 $j = $i + 1

--- a/.github/scripts/lib/cost-rolling-history.ps1
+++ b/.github/scripts/lib/cost-rolling-history.ps1
@@ -559,7 +559,7 @@ function Get-CostRollingHistory {
         return @{ timed_out = $true; entries = @() }
     }
 
-    $repoViewJson = & gh repo view --json owner, name 2>&1
+    $repoViewJson = & gh repo view --json 'owner,name' 2>&1
     if ($LASTEXITCODE -ne 0) {
         Write-Warning "cost-rolling-history: gh repo view failed: $repoViewJson"
         return @{ timed_out = $false; entries = @() }

--- a/.github/scripts/lib/cost-walker.ps1
+++ b/.github/scripts/lib/cost-walker.ps1
@@ -362,6 +362,16 @@ function Invoke-CostTranscriptWalk {
         }
     }
 
+    # Backward compat: include explicit slug dir when identity resolution is unavailable
+    # (e.g., tests without a real git repo). In production, identity matching already
+    # finds this dir; dedup guard prevents double-counting.
+    if (-not [string]::IsNullOrWhiteSpace($Slug)) {
+        $primarySlugDir = script:Resolve-CostWalkerPrimarySlugDir -ProjectsRoot $ProjectsRoot -Slug $Slug
+        if ($null -ne $primarySlugDir -and $slugDirs -notcontains $primarySlugDir) {
+            $slugDirs.Add($primarySlugDir)
+        }
+    }
+
     if ($slugDirs.Count -eq 0) {
         return $included
     }

--- a/.github/scripts/lib/cost-walker.ps1
+++ b/.github/scripts/lib/cost-walker.ps1
@@ -223,6 +223,50 @@ function script:Resolve-CostWalkerPrimarySlugDir {
     return $null
 }
 
+function script:Resolve-CostWalkerRepoIdentity {
+    <#
+    .SYNOPSIS
+        Normalize a git remote URL to a transport-agnostic host/path identity.
+    .DESCRIPTION
+        Fix #760-E1: collapse SSH, HTTPS, and credential-embedded URL forms to a
+        single comparable 'host/path' string so a session cloned over SSH matches
+        a ledger repo root configured over HTTPS (and vice versa).  Without this,
+        the same repo reached via different transports produces different raw URLs
+        and a session is silently excluded from attribution.
+
+        Handles:
+          - scp-like SSH:        git@github.com:owner/repo(.git)
+          - ssh:// scheme:       ssh://git@github.com/owner/repo(.git)
+          - credentialed HTTPS:  https://x-access-token:TOKEN@github.com/owner/repo
+          - plain HTTPS:         https://github.com/owner/repo(.git)
+        Returns $null for empty/whitespace input.
+    .OUTPUTS
+        [string] normalized 'host/path', or $null.
+    #>
+    param([string]$RawUrl)
+
+    if ([string]::IsNullOrWhiteSpace($RawUrl)) { return $null }
+
+    $u = $RawUrl.Trim()
+
+    # scp-like SSH form (no scheme, ':' separates host and path): git@host:owner/repo
+    if ($u -match '^[^/@]+@([^:/]+):(.+)$') {
+        $u = "$($Matches[1])/$($Matches[2])"
+    }
+    else {
+        # Strip URL scheme (https://, ssh://, git://, http://, ...)
+        $u = $u -replace '^[a-zA-Z][a-zA-Z0-9+.\-]*://', ''
+        # Strip userinfo (user@ or user:password@ / x-access-token:TOKEN@) before the host
+        $u = $u -replace '^[^/@]+@', ''
+    }
+
+    $u = $u.ToLowerInvariant().TrimEnd('/')
+    if ($u.EndsWith('.git')) { $u = $u.Substring(0, $u.Length - 4) }
+
+    if ([string]::IsNullOrWhiteSpace($u)) { return $null }
+    return $u
+}
+
 function script:Get-IdentityMatchedSlugDirs {
     param(
         [Parameter(Mandatory)][string]$ProjectsRoot,
@@ -233,9 +277,8 @@ function script:Get-IdentityMatchedSlugDirs {
     $targetIdentity = $null
     try {
         $rawUrl = @(& git -C $RepoRoot remote get-url origin 2>$null) | Select-Object -First 1
-        if ($global:LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($rawUrl)) {
-            $targetIdentity = ([string]$rawUrl).Trim().ToLowerInvariant().TrimEnd('/')
-            if ($targetIdentity.EndsWith('.git')) { $targetIdentity = $targetIdentity.Substring(0, $targetIdentity.Length - 4) }
+        if ($global:LASTEXITCODE -eq 0) {
+            $targetIdentity = script:Resolve-CostWalkerRepoIdentity -RawUrl ([string]$rawUrl)
         }
     } catch { }
 
@@ -276,9 +319,8 @@ function script:Get-IdentityMatchedSlugDirs {
         $candidateIdentity = $null
         try {
             $rawUrl = @(& git -C $firstCwd remote get-url origin 2>$null) | Select-Object -First 1
-            if ($global:LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($rawUrl)) {
-                $candidateIdentity = ([string]$rawUrl).Trim().ToLowerInvariant().TrimEnd('/')
-                if ($candidateIdentity.EndsWith('.git')) { $candidateIdentity = $candidateIdentity.Substring(0, $candidateIdentity.Length - 4) }
+            if ($global:LASTEXITCODE -eq 0) {
+                $candidateIdentity = script:Resolve-CostWalkerRepoIdentity -RawUrl ([string]$rawUrl)
             }
         } catch { }
 

--- a/.github/scripts/lib/cost-walker.ps1
+++ b/.github/scripts/lib/cost-walker.ps1
@@ -97,14 +97,13 @@ function script:Test-CostWalkerPhaseMarkerBranchAllowed {
 function script:Test-CostWalkerAssistantMatchesStrictFilter {
     param(
         [Parameter(Mandatory)]$TranscriptEvent,
-        [Parameter(Mandatory)][string]$NormalizedParentCwd,
+        [Parameter(Mandatory)][string]$NormalizedParentCwd,  # keep param for signature compat
         [Parameter(Mandatory)][string]$Branch
     )
 
     $eventBranch = $TranscriptEvent['gitBranch']
     if ($null -eq $eventBranch) { return $false }
-    if (-not (script:Test-CostWalkerEventCwdMatchesParent -TranscriptEvent $TranscriptEvent -NormalizedParentCwd $NormalizedParentCwd)) { return $false }
-
+    # D2: identity check is done at slug-dir level; per-event filter uses branch only.
     return [string]$eventBranch -eq $Branch
 }
 
@@ -224,6 +223,76 @@ function script:Resolve-CostWalkerPrimarySlugDir {
     return $null
 }
 
+function script:Get-IdentityMatchedSlugDirs {
+    param(
+        [Parameter(Mandatory)][string]$ProjectsRoot,
+        [Parameter(Mandatory)][string]$RepoRoot
+    )
+
+    # Resolve target repo identity once from the ledger's repo root.
+    $targetIdentity = $null
+    try {
+        $rawUrl = @(& git -C $RepoRoot remote get-url origin 2>$null) | Select-Object -First 1
+        if ($global:LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($rawUrl)) {
+            $targetIdentity = ([string]$rawUrl).Trim().ToLowerInvariant().TrimEnd('/')
+            if ($targetIdentity.EndsWith('.git')) { $targetIdentity = $targetIdentity.Substring(0, $targetIdentity.Length - 4) }
+        }
+    } catch { }
+
+    if ($null -eq $targetIdentity) {
+        # Can't resolve target identity — fail-closed: return empty list, no slug dirs admitted.
+        return [System.Collections.Generic.List[string]]::new()
+    }
+
+    $matched = [System.Collections.Generic.List[string]]::new()
+
+    $allDirs = @(Get-ChildItem -Path $ProjectsRoot -Directory -ErrorAction SilentlyContinue)
+    foreach ($dir in $allDirs) {
+        # Find the first event with a cwd field in any JSONL file in this slug dir.
+        $firstCwd = $null
+        $jsonls = @(Get-ChildItem -Path $dir.FullName -Filter '*.jsonl' -File -ErrorAction SilentlyContinue | Select-Object -First 5)
+        foreach ($jf in $jsonls) {
+            if ($null -ne $firstCwd) { break }
+            $lines = @(Get-Content -Path $jf.FullName -Encoding utf8 -ErrorAction SilentlyContinue | Select-Object -First 20)
+            foreach ($ln in $lines) {
+                $trimmed = $ln.Trim()
+                if ([string]::IsNullOrEmpty($trimmed)) { continue }
+                try {
+                    $ev = $trimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+                    if (-not [string]::IsNullOrEmpty([string]$ev['cwd'])) {
+                        $cwd = [string]$ev['cwd']
+                        if (-not $cwd.StartsWith($script:CostWalkerCopilotOtelCwdPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                            $firstCwd = $cwd
+                            break
+                        }
+                    }
+                } catch { }
+            }
+        }
+
+        if ($null -eq $firstCwd) { continue }  # fail-closed: no usable cwd found
+
+        # Resolve this slug dir's identity from the first-event cwd.
+        $candidateIdentity = $null
+        try {
+            $rawUrl = @(& git -C $firstCwd remote get-url origin 2>$null) | Select-Object -First 1
+            if ($global:LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($rawUrl)) {
+                $candidateIdentity = ([string]$rawUrl).Trim().ToLowerInvariant().TrimEnd('/')
+                if ($candidateIdentity.EndsWith('.git')) { $candidateIdentity = $candidateIdentity.Substring(0, $candidateIdentity.Length - 4) }
+            }
+        } catch { }
+
+        if ($null -eq $candidateIdentity) { continue }  # fail-closed: can't verify identity
+
+        if ($candidateIdentity -eq $targetIdentity) {
+            $matched.Add($dir.FullName)
+        }
+        # else: same-leaf different-repo → rejected (identity mismatch)
+    }
+
+    return $matched
+}
+
 function Invoke-CostTranscriptWalk {
     <#
     .SYNOPSIS
@@ -251,11 +320,12 @@ function Invoke-CostTranscriptWalk {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$Slug,
+        [AllowEmptyString()][string]$Slug = '',
         [Parameter(Mandatory)][string]$Branch,
         [Parameter(Mandatory)][string]$ParentCwd,
         [string]$ProjectsRoot = '',
-        [Nullable[int]]$IssueNumber = $null
+        [Nullable[int]]$IssueNumber = $null,
+        [string]$RepoRoot = ''
     )
 
     if (-not $ProjectsRoot) {
@@ -272,16 +342,24 @@ function Invoke-CostTranscriptWalk {
     # Collect all slug directories to search
     $slugDirs = [System.Collections.Generic.List[string]]::new()
 
-    $primaryDir = script:Resolve-CostWalkerPrimarySlugDir -ProjectsRoot $ProjectsRoot -Slug $Slug
-    if ($null -ne $primaryDir) {
-        $slugDirs.Add($primaryDir)
+    $resolvedRepoRoot = if (-not [string]::IsNullOrWhiteSpace($RepoRoot)) { $RepoRoot } else { $ParentCwd }
+
+    # D2: discover all slug dirs in ProjectsRoot that belong to the same git repo (identity match).
+    $identityDirs = script:Get-IdentityMatchedSlugDirs -ProjectsRoot $ProjectsRoot -RepoRoot $resolvedRepoRoot
+
+    foreach ($d in $identityDirs) {
+        $slugDirs.Add($d)
     }
 
-    # Worktree slug directories: {Slug}--claude-worktrees-*
-    $worktreeDirs = @(Get-ChildItem -Path $ProjectsRoot -Directory -ErrorAction SilentlyContinue |
-            Where-Object { $_.Name -like "$Slug--claude-worktrees-*" })
-    foreach ($wtd in $worktreeDirs) {
-        $slugDirs.Add($wtd.FullName)
+    # Also include worktree directories for the primary slug (backward compat / graceful fallback
+    # for worktree slugs that may not have first-event cwd pointing to the main repo root).
+    if (-not [string]::IsNullOrWhiteSpace($Slug)) {
+        $worktreeDirs = @(Get-ChildItem -Path $ProjectsRoot -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like "$Slug--claude-worktrees-*" } |
+            Where-Object { $slugDirs -notcontains $_.FullName })
+        foreach ($wtd in $worktreeDirs) {
+            $slugDirs.Add($wtd.FullName)
+        }
     }
 
     if ($slugDirs.Count -eq 0) {
@@ -331,7 +409,7 @@ function Invoke-CostTranscriptWalk {
                         }
 
                         if ($currentWindowIssue -ne $targetIssueNumber) { continue }
-                        if (-not (script:Test-CostWalkerEventCwdMatchesParent -TranscriptEvent $parsedEvent -NormalizedParentCwd $normalizedParentCwd)) { continue }
+                        # D2: identity check is done at slug-dir level; cwd guard removed.
                         if (-not (script:Test-CostWalkerPhaseMarkerBranchAllowed -Branch $parsedEvent['gitBranch'])) { continue }
 
                         $parsedEvent['_phase_marker_port'] = $currentWindowPortHint

--- a/.github/workflows/frame-enforce.yml
+++ b/.github/workflows/frame-enforce.yml
@@ -52,4 +52,10 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
         run: |
+          # TRIGGER LANDMINE (AC7 / issue #760): this workflow runs on ubuntu-latest where
+          # ~/.claude/projects is absent, producing an empty cost walk.  The skip-when-absent
+          # gate in frame-credit-ledger.ps1 guards against the resulting empty walk overwriting
+          # a populated cost-pattern-data block.  If you add a merge_group or post-merge push
+          # trigger to this workflow the gate MUST still be present in the script, otherwise
+          # a CI clobber will reappear for any run that lacks a local projects root.
           ./.github/scripts/frame-credit-ledger.ps1 -Pr $env:PR_NUMBER -Mode enforce

--- a/Documents/Planning/sequence.yaml
+++ b/Documents/Planning/sequence.yaml
@@ -4,4 +4,4 @@
 schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-umbrellas: [476, 571, 674, 662, 343, 693, 732]
+umbrellas: [476, 761, 571, 674, 662, 343, 693, 732]


### PR DESCRIPTION
## Summary

- **D1 (CI clobber)**: CI enforce run on `ubuntu-latest` walks an absent `~/.claude/projects` ΓåÆ empty ΓåÆ was overwriting the locally-populated `cost-pattern-data` block. Fixed by skip-when-absent gate + revived `Resolve-CostDataPreservation` (was structurally dead: result discarded, `$priorCostData` double-nested making completeness compare always-false). Added `frame-enforce.yml` trigger-landmine comment (AC7).
- **D2 (cross-clone attribution)**: walker used cwd-equality which blocked sessions run from sibling clones/worktrees. Fixed by resolving repo identity once via `git remote get-url origin` and filtering slug dirs by identity, dropping per-event cwd-equality check. Includes backward-compat primary-slug fallback for when identity resolution is unavailable.
- **Carried fix**: `gh repo view --json 'owner,name'` arg fix already on branch (comma+space was parsed as PS array).

## Slices

| Slice | Description | AC |
|-------|-------------|-----|
| s1 | D1 clobber fix ΓÇö skip gate + preservation wiring + key reconciliation | AC1, AC2, AC7 |
| s2 | D1 tests ΓÇö CI-contract preserve, preservation-fires, cold-start | AC1, AC2 |
| s3 | D2 cross-clone attribution ΓÇö identity-based slug discovery | AC3, AC4 |
| s4 | D2 + accuracy tests ΓÇö identity matching group, backward compat fix | AC3, AC4, AC5 |
| s5 | CE Gate (manual) | AC6 |
| review-fix | Close AC3/AC4 identity-mismatch gap + strengthen AC1 assertion (judge ruling) | AC1, AC3, AC4 |

## Test plan

- [x] Pester: 57 tests pass (cost-walker + cost-integration)
- [x] CI enforce run does not overwrite a populated `cost-pattern-data` block (skip gate)
- [x] `cost-regime-checkpoint.ps1` computes 4 non-zero metrics after warn-run
- [x] Cross-clone session events are attributed when both paths share a git remote identity (AC3)
- [x] Different-remote slug dir is rejected (AC4 ΓÇö new fixture with real git init)

Closes #760

<!-- pipeline-metrics
metrics_version: 4
frame_version: 1
credits:
  - port: implement-code
    adapter: skills/implementation-discipline/adapters/implement-code-adapter.md
    status: passed
    run_index: 1
    evidence: "s1 + s3 implement-code slices committed and parse-valid"
  - port: implement-test
    adapter: skills/test-driven-development/adapters/implement-test-adapter.md
    status: passed
    run_index: 1
    evidence: "57/57 Pester tests pass (s2 + s4 + review-fix)"
  - port: ce-gate-cli
    adapter: skills/customer-experience/adapters/ce-gate-cli.md
    status: passed
    run_index: 1
    evidence: "CE Gate S1: warn-run populated cost-pattern-data, CI enforce passed without clobber, checkpoint computed 4 non-empty metrics"
  - port: review
    adapter: standard
    status: passed
    run_index: 1
    evidence: "Full prosecution x3 -> defense -> judge completed; judge ruling: conditional-pass, revise (test-only); revisions applied in e07c9c5; suite 57/57"
    judge-score:
      ruling: passed
      findings: [T1-closed, T2-closed, T4-closed]
integrity_checks:
  - check: schema-version-pinned
    status: passed
-->

≡ƒñû Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cost reporting now reuses the previously posted cost-pattern section when the latest run is “unknown/inconclusive,” reducing noisy CI output.  
  * Transcript walking is improved for cross-clone/worktree scenarios by matching related repositories more reliably.

* **Bug Fixes**
  * Better preservation behavior for missing, malformed, or incomplete prior cost data (including safe handling of YAML completeness and notices).
  * Updated parsing to keep `session_completeness` and timestamp fields consistent for preserved and newly rendered results.
  * CI enforce behavior avoids overwriting existing cost-pattern data when local project data is absent.

* **Documentation**
  * Added clarifying workflow comments around the “skip-when-absent” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->