### PR TITLE
fix(#769): cost telemetry v4 emission reliability — CI-safe origin predicate, deterministic emit, file-based accumulator

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.35.11",
+  "version": "2.35.12",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "2.35.12",
+  "version": "2.35.13",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/scripts/Tests/Add-FCLCreditRow.Tests.ps1
+++ b/.github/scripts/Tests/Add-FCLCreditRow.Tests.ps1
@@ -1,0 +1,138 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Tests for Add-FCLCreditRow and Get-FCLAccumulatedCredits (issue #769 s-acc).
+#
+# Scripts under test:
+#   .github/scripts/lib/Add-FCLCreditRow.ps1
+#   .github/scripts/lib/Get-FCLAccumulatedCredits.ps1
+#
+# Coverage:
+#   1. Round-trip: Add-FCLCreditRow row -> Get-FCLAccumulatedCredits -> same data returned.
+#   2. Multiple rows: 3 rows added -> all 3 returned in order.
+#   3. Directory created when missing: remove .tmp/issue-{N} -> call Add-FCLCreditRow
+#      -> directory + file created.
+#   4. Get returns @() when no file: issue number with no file -> returns empty array.
+#   5. Idempotency (no-dedup): Add same row twice -> Get returns 2 rows.
+
+BeforeAll {
+    $script:RepoRoot  = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:AddScript = Join-Path $script:RepoRoot '.github/scripts/lib/Add-FCLCreditRow.ps1'
+    $script:GetScript = Join-Path $script:RepoRoot '.github/scripts/lib/Get-FCLAccumulatedCredits.ps1'
+
+    # Load both functions into this session.
+    . $script:AddScript
+    . $script:GetScript
+
+    # Unique test issue number unlikely to collide with real work.
+    $script:TestIssueNumber = 99999
+
+    # Canonical accumulator path for the test issue.
+    $script:AccumulatorDir  = Join-Path $script:RepoRoot ".tmp/issue-$($script:TestIssueNumber)"
+    $script:AccumulatorFile = Join-Path $script:AccumulatorDir 'fclcredits.jsonl'
+
+    # A minimal valid credit row pscustomobject.
+    $script:SampleRow = [pscustomobject]@{
+        port      = 'implement-code'
+        adapter   = 'skills/implementation-discipline/adapters/implement-code-adapter.md'
+        status    = 'passed'
+        run_index = 1
+        evidence  = 'Add-FCLCreditRow.Tests.ps1 -- test fixture'
+    }
+}
+
+AfterAll {
+    # Remove the test accumulator directory to avoid cross-test contamination.
+    if (Test-Path -LiteralPath $script:AccumulatorDir) {
+        Remove-Item -LiteralPath $script:AccumulatorDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Add-FCLCreditRow / Get-FCLAccumulatedCredits' {
+
+    BeforeEach {
+        # Start each test with a clean accumulator file.
+        if (Test-Path -LiteralPath $script:AccumulatorFile) {
+            Remove-Item -LiteralPath $script:AccumulatorFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context 'Case 1 - round-trip: single row survives Add -> Get cycle' {
+
+        It 'returns the same port and status after a single Add call' {
+            Add-FCLCreditRow -IssueNumber $script:TestIssueNumber -CreditRow $script:SampleRow
+
+            $rows = @(Get-FCLAccumulatedCredits -IssueNumber $script:TestIssueNumber)
+
+            $rows.Count          | Should -Be 1
+            $rows[0].port        | Should -Be 'implement-code'
+            $rows[0].status      | Should -Be 'passed'
+            $rows[0].adapter     | Should -Be 'skills/implementation-discipline/adapters/implement-code-adapter.md'
+        }
+    }
+
+    Context 'Case 2 - multiple rows: all 3 rows returned in append order' {
+
+        It 'returns 3 rows in the order they were appended' {
+            $row1 = [pscustomobject]@{ port = 'implement-code';   status = 'passed'; run_index = 1 }
+            $row2 = [pscustomobject]@{ port = 'implement-test';   status = 'failed'; run_index = 2 }
+            $row3 = [pscustomobject]@{ port = 'implement-refactor'; status = 'not-applicable'; run_index = 3 }
+
+            Add-FCLCreditRow -IssueNumber $script:TestIssueNumber -CreditRow $row1
+            Add-FCLCreditRow -IssueNumber $script:TestIssueNumber -CreditRow $row2
+            Add-FCLCreditRow -IssueNumber $script:TestIssueNumber -CreditRow $row3
+
+            $rows = @(Get-FCLAccumulatedCredits -IssueNumber $script:TestIssueNumber)
+
+            $rows.Count       | Should -Be 3
+            $rows[0].port     | Should -Be 'implement-code'
+            $rows[1].port     | Should -Be 'implement-test'
+            $rows[2].port     | Should -Be 'implement-refactor'
+        }
+    }
+
+    Context 'Case 3 - directory created when missing' {
+
+        It 'creates the directory and file when they do not exist' {
+            # Remove the entire directory first.
+            if (Test-Path -LiteralPath $script:AccumulatorDir) {
+                Remove-Item -LiteralPath $script:AccumulatorDir -Recurse -Force
+            }
+
+            $script:AccumulatorDir  | Should -Not -Exist
+
+            Add-FCLCreditRow -IssueNumber $script:TestIssueNumber -CreditRow $script:SampleRow
+
+            $script:AccumulatorDir  | Should -Exist
+            $script:AccumulatorFile | Should -Exist
+        }
+    }
+
+    Context 'Case 4 - Get returns empty array when no file exists' {
+
+        It 'returns an empty array when the accumulator file is absent' {
+            # Ensure no file exists for the test issue.
+            if (Test-Path -LiteralPath $script:AccumulatorFile) {
+                Remove-Item -LiteralPath $script:AccumulatorFile -Force
+            }
+
+            $rows = @(Get-FCLAccumulatedCredits -IssueNumber $script:TestIssueNumber)
+
+            $rows.Count | Should -Be 0
+        }
+    }
+
+    Context 'Case 5 - no dedup: same row added twice returns two rows' {
+
+        It 'returns 2 rows when the same row is appended twice' {
+            Add-FCLCreditRow -IssueNumber $script:TestIssueNumber -CreditRow $script:SampleRow
+            Add-FCLCreditRow -IssueNumber $script:TestIssueNumber -CreditRow $script:SampleRow
+
+            $rows = @(Get-FCLAccumulatedCredits -IssueNumber $script:TestIssueNumber)
+
+            # Each append is intentional; no deduplication at accumulator level.
+            $rows.Count | Should -Be 2
+            $rows[0].port | Should -Be $rows[1].port
+        }
+    }
+}

--- a/.github/scripts/Tests/Add-FCLCreditRow.Tests.ps1
+++ b/.github/scripts/Tests/Add-FCLCreditRow.Tests.ps1
@@ -136,3 +136,83 @@ Describe 'Add-FCLCreditRow / Get-FCLAccumulatedCredits' {
         }
     }
 }
+
+Describe 'Accumulator robustness (B4b/B5/P1-F2 fixes)' {
+
+    It 'Get-FCLAccumulatedCredits skips malformed JSONL and returns valid rows' {
+        $issue = 99998
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $dir = Join-Path $repoRoot ".tmp/issue-$issue"
+        if (Test-Path $dir) { Remove-Item -Recurse -Force $dir }
+
+        # Add first valid row
+        $row1 = [pscustomobject]@{ port = 'test'; status = 'passed' }
+        Add-FCLCreditRow -IssueNumber $issue -CreditRow $row1
+
+        # Inject a corrupt line directly into the file
+        $file = Join-Path $dir 'fclcredits.jsonl'
+        Add-Content -Path $file -Value 'THIS IS NOT JSON {{{' -Encoding utf8NoBOM
+
+        # Add second valid row
+        $row2 = [pscustomobject]@{ port = 'impl'; status = 'passed' }
+        Add-FCLCreditRow -IssueNumber $issue -CreditRow $row2
+
+        # Must get 2 valid rows; the corrupt line is skipped with a warning
+        $results = Get-FCLAccumulatedCredits -IssueNumber $issue -WarningAction SilentlyContinue
+        @($results).Count | Should -Be 2
+        @($results)[0].port | Should -Be 'test'
+        @($results)[1].port | Should -Be 'impl'
+
+        Remove-Item -Recurse -Force $dir
+    }
+
+    It 'Get-FCLAccumulatedCredits returns zero rows for empty-but-present file (no parse error)' {
+        $issue = 99997
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $dir = Join-Path $repoRoot ".tmp/issue-$issue"
+        if (Test-Path $dir) { Remove-Item -Recurse -Force $dir }
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+
+        # Create an empty file (whitespace-only content)
+        Set-Content -Path (Join-Path $dir 'fclcredits.jsonl') -Value '' -Encoding utf8NoBOM
+
+        # With @() wrapper: empty file must yield 0 rows, not throw
+        $rows = @(Get-FCLAccumulatedCredits -IssueNumber $issue)
+        $rows.Count | Should -Be 0
+
+        Remove-Item -Recurse -Force $dir
+    }
+
+    It 'Get-FCLAccumulatedCredits returns exactly 1 row for single-row file (no scalar collapse)' {
+        $issue = 99996
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $dir = Join-Path $repoRoot ".tmp/issue-$issue"
+        if (Test-Path $dir) { Remove-Item -Recurse -Force $dir }
+
+        $row = [pscustomobject]@{ port = 'singleton'; status = 'passed' }
+        Add-FCLCreditRow -IssueNumber $issue -CreditRow $row
+
+        # With @() wrapper: single row must yield exactly 1 element
+        $rows = @(Get-FCLAccumulatedCredits -IssueNumber $issue)
+        $rows.Count | Should -Be 1
+        $rows[0].port | Should -Be 'singleton'
+
+        Remove-Item -Recurse -Force $dir
+    }
+
+    It 'Add-FCLCreditRow rejects IssueNumber 0' {
+        { Add-FCLCreditRow -IssueNumber 0 -CreditRow ([pscustomobject]@{ port = 'x' }) } | Should -Throw
+    }
+
+    It 'Add-FCLCreditRow rejects negative IssueNumber' {
+        { Add-FCLCreditRow -IssueNumber -1 -CreditRow ([pscustomobject]@{ port = 'x' }) } | Should -Throw
+    }
+
+    It 'Get-FCLAccumulatedCredits rejects IssueNumber 0' {
+        { Get-FCLAccumulatedCredits -IssueNumber 0 } | Should -Throw
+    }
+
+    It 'Get-FCLAccumulatedCredits rejects negative IssueNumber' {
+        { Get-FCLAccumulatedCredits -IssueNumber -1 } | Should -Throw
+    }
+}

--- a/.github/scripts/Tests/Get-FCLOriginContext.Tests.ps1
+++ b/.github/scripts/Tests/Get-FCLOriginContext.Tests.ps1
@@ -1,0 +1,228 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Tests for Get-FCLOriginContext (issue #769, slice s1).
+
+.DESCRIPTION
+    Verifies the CI-safe orchestrated-origin predicate:
+      - PRIMARY: GITHUB_HEAD_REF branch-name matching
+      - FALLBACK: PR body linked-issue signals
+      - Detached-HEAD CI artifact ('HEAD') falls through to body fallback
+      - Non-orchestrated refs return IsOrchestratedOrigin=$false
+
+    Also covers the builder repro (New-PipelineMetricsV4Block) and its
+    throw conditions, as required by the s1 Requirement Contract.
+#>
+
+BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:PredicatePath = Join-Path $script:RepoRoot '.github/scripts/lib/Get-FCLOriginContext.ps1'
+    $script:CorePath     = Join-Path $script:RepoRoot '.github/scripts/lib/frame-credit-ledger-core.ps1'
+
+    if (Test-Path $script:PredicatePath) {
+        . $script:PredicatePath
+    }
+    if (Test-Path $script:CorePath) {
+        . $script:CorePath
+    }
+}
+
+# ===========================================================================
+# Get-FCLOriginContext — origin predicate tests
+# ===========================================================================
+
+Describe 'Get-FCLOriginContext — branch signal (PRIMARY)' {
+
+    It 'Test 1: feature/issue-769-foo HeadRef returns IsOrchestratedOrigin=$true with LinkedIssueNumber=769 via branch' {
+        # Arrange
+        $headRef = 'feature/issue-769-foo'
+
+        # Act
+        $ctx = Get-FCLOriginContext -HeadRef $headRef
+
+        # Assert
+        $ctx                   | Should -Not -BeNullOrEmpty
+        $ctx.IsOrchestratedOrigin | Should -Be $true
+        $ctx.LinkedIssueNumber    | Should -Be 769
+        $ctx.DetectionMethod      | Should -Be 'branch'
+    }
+
+    It 'Test 4: dependabot/npm-and-yarn/foo HeadRef returns IsOrchestratedOrigin=$false' {
+        # Arrange
+        $headRef = 'dependabot/npm-and-yarn/foo'
+
+        # Act
+        $ctx = Get-FCLOriginContext -HeadRef $headRef
+
+        # Assert
+        $ctx.IsOrchestratedOrigin | Should -Be $false
+        $ctx.DetectionMethod      | Should -Be 'none'
+    }
+}
+
+Describe 'Get-FCLOriginContext — detached-HEAD CI simulation (M3)' {
+
+    It 'Test 2: HeadRef=HEAD (detached-HEAD CI artifact) with body fallback containing plan-issue-769 returns IsOrchestratedOrigin=$true via body' {
+        # Arrange: simulate CI where rev-parse yields literal "HEAD"
+        $headRef = 'HEAD'
+        $prBody  = "## Summary`n`nFixes the bug.`n`n<!-- plan-issue-769 -->`n"
+
+        # Act
+        $ctx = Get-FCLOriginContext -HeadRef $headRef -PrBody $prBody
+
+        # Assert: must NOT match on 'HEAD' string; must fall through to body
+        $ctx.IsOrchestratedOrigin | Should -Be $true
+        $ctx.LinkedIssueNumber    | Should -Be 769
+        $ctx.DetectionMethod      | Should -Be 'body'
+    }
+
+    It 'Test 5: HeadRef=HEAD with no body signals returns IsOrchestratedOrigin=$false' {
+        # Arrange
+        $headRef = 'HEAD'
+        $prBody  = "## Summary`n`nA regular PR with no linked issue signals."
+
+        # Act
+        $ctx = Get-FCLOriginContext -HeadRef $headRef -PrBody $prBody
+
+        # Assert
+        $ctx.IsOrchestratedOrigin | Should -Be $false
+        $ctx.DetectionMethod      | Should -Be 'none'
+    }
+}
+
+Describe 'Get-FCLOriginContext — body fallback signals' {
+
+    It 'Test 3: null HeadRef with plan-issue-769 in body returns IsOrchestratedOrigin=$true via body' {
+        # Arrange
+        $prBody = "## Summary`n`nThis PR implements the fix.`n`n<!-- plan-issue-769 -->`n"
+
+        # Act
+        $ctx = Get-FCLOriginContext -HeadRef $null -PrBody $prBody
+
+        # Assert
+        $ctx.IsOrchestratedOrigin | Should -Be $true
+        $ctx.LinkedIssueNumber    | Should -Be 769
+        $ctx.DetectionMethod      | Should -Be 'body'
+    }
+
+    It 'body fallback: Fixes #769 keyword pattern returns IsOrchestratedOrigin=$true via body' {
+        $prBody = "Fixes #769`n`nMore description."
+        $ctx = Get-FCLOriginContext -HeadRef $null -PrBody $prBody
+
+        $ctx.IsOrchestratedOrigin | Should -Be $true
+        $ctx.LinkedIssueNumber    | Should -Be 769
+        $ctx.DetectionMethod      | Should -Be 'body'
+    }
+
+    It 'body fallback: issue_id: 769 pattern returns IsOrchestratedOrigin=$true via body' {
+        $prBody = "## Summary`n`nissue_id: 769`n`nDescription."
+        $ctx = Get-FCLOriginContext -HeadRef $null -PrBody $prBody
+
+        $ctx.IsOrchestratedOrigin | Should -Be $true
+        $ctx.LinkedIssueNumber    | Should -Be 769
+        $ctx.DetectionMethod      | Should -Be 'body'
+    }
+
+    It 'body fallback: empty HeadRef with no body signals returns IsOrchestratedOrigin=$false' {
+        $ctx = Get-FCLOriginContext -HeadRef '' -PrBody ''
+
+        $ctx.IsOrchestratedOrigin | Should -Be $false
+        $ctx.DetectionMethod      | Should -Be 'none'
+    }
+}
+
+Describe 'Get-FCLOriginContext — branch signal prioritizes over body' {
+
+    It 'branch takes priority: feature/issue-100 HeadRef with conflicting body returns LinkedIssueNumber=100 from branch' {
+        # Arrange: branch says 100, body says 999
+        $headRef = 'feature/issue-100-my-feature'
+        $prBody  = "<!-- plan-issue-999 -->`n"
+
+        # Act
+        $ctx = Get-FCLOriginContext -HeadRef $headRef -PrBody $prBody
+
+        # Assert: branch wins
+        $ctx.IsOrchestratedOrigin | Should -Be $true
+        $ctx.LinkedIssueNumber    | Should -Be 100
+        $ctx.DetectionMethod      | Should -Be 'branch'
+    }
+}
+
+# ===========================================================================
+# New-PipelineMetricsV4Block — builder repro and throw conditions (s1 AC1)
+# ===========================================================================
+
+Describe 'New-PipelineMetricsV4Block — builder repro (s1 AC1)' {
+
+    It 'Test 6: valid hand-fed credit row produces a block with metrics_version: 4' {
+        # Arrange: hand-fed credit rows as required by the s1 builder-repro
+        $credits = @(
+            [pscustomobject]@{
+                port        = 'implement-test'
+                adapter     = 'skills/test-driven-development/adapters/implement-test-adapter.md'
+                status      = 'passed'
+                run_index   = 1
+                evidence    = 'Get-FCLOriginContext.Tests.ps1 — all tests green (s1 builder repro)'
+            }
+        )
+        $v3Base = "pr_number: 769`nbranch: feature/issue-769-v4-emission-reliability"
+
+        # Act
+        $block = New-PipelineMetricsV4Block `
+            -V3BaseYaml $v3Base `
+            -Credits $credits
+
+        # Assert
+        $block | Should -Not -BeNullOrEmpty
+
+        # Exactly one opener and one closer
+        $openerCount = ([regex]::Matches($block, [regex]::Escape('<!-- pipeline-metrics'))).Count
+        $openerCount | Should -Be 1
+
+        # Must carry metrics_version: 4
+        $block | Should -Match '(?m)^metrics_version:\s*4\s*$'
+
+        # Must carry frame_version: 1
+        $block | Should -Match '(?m)^frame_version:\s*1\s*$'
+
+        # Credit row must be present
+        $block | Should -Match 'port: implement-test'
+        $block | Should -Match 'status: passed'
+
+        # Round-trip: wrapper must parse back as v4
+        $prBody = "## PR`n`n$block`n"
+        $parsed = Read-PRMetricsBlock -PrBody $prBody
+        $parsed.MetricsVersion | Should -Be 4
+        @($parsed.Credits).Count | Should -BeGreaterOrEqual 1
+    }
+
+    It 'Test 7: empty V3BaseYaml throws the expected error' {
+        # Arrange + Act + Assert: line :2829-2831 of frame-credit-ledger-core.ps1
+        {
+            New-PipelineMetricsV4Block -V3BaseYaml ''
+        } | Should -Throw -ExpectedMessage '*-V3BaseYaml must not be null or empty*'
+    }
+
+    It 'Test 8: V3BaseYaml containing <!-- pipeline-metrics opener throws the expected error' {
+        # Arrange: pre-existing opener in V3BaseYaml triggers double-wrap guard (:2833-2835)
+        $yamlWithOpener = "<!-- pipeline-metrics`nmetrics_version: 3`nfoo: bar"
+
+        # Act + Assert
+        {
+            New-PipelineMetricsV4Block -V3BaseYaml $yamlWithOpener
+        } | Should -Throw -ExpectedMessage '*already contains a <!-- pipeline-metrics*'
+    }
+
+    It 'builder repro: ExistingPRBody with v4 block throws (initial-creation-only guard, :2817-2822)' {
+        # Arrange: pre-existing v4 block in ExistingPRBody
+        $existingBody = "## PR`n`n<!-- pipeline-metrics`nmetrics_version: 4`nframe_version: 1`n-->`n"
+
+        # Act + Assert
+        {
+            New-PipelineMetricsV4Block `
+                -V3BaseYaml 'pr_number: 769' `
+                -ExistingPRBody $existingBody
+        } | Should -Throw -ExpectedMessage '*already has a v4 pipeline-metrics block*'
+    }
+}

--- a/.github/scripts/Tests/Get-FCLOriginContext.Tests.ps1
+++ b/.github/scripts/Tests/Get-FCLOriginContext.Tests.ps1
@@ -106,8 +106,17 @@ Describe 'Get-FCLOriginContext — body fallback signals' {
         $ctx.DetectionMethod      | Should -Be 'body'
     }
 
-    It 'body fallback: Fixes #769 keyword pattern returns IsOrchestratedOrigin=$true via body' {
+    It 'body fallback: Fixes #769 keyword pattern NO LONGER returns IsOrchestratedOrigin=$true (keyword-linked leg removed)' {
         $prBody = "Fixes #769`n`nMore description."
+        $ctx = Get-FCLOriginContext -HeadRef $null -PrBody $prBody
+
+        # keyword-linked pattern was removed (B4a fix) — must NOT classify as orchestrated
+        $ctx.IsOrchestratedOrigin | Should -Be $false
+        $ctx.DetectionMethod      | Should -Be 'none'
+    }
+
+    It 'body fallback: PR with Fixes #N AND plan-issue comment marker is orchestrated (plan-issue signal survives removal of keyword leg)' {
+        $prBody = "Fixes #769`n`n<!-- plan-issue-769 -->`n"
         $ctx = Get-FCLOriginContext -HeadRef $null -PrBody $prBody
 
         $ctx.IsOrchestratedOrigin | Should -Be $true

--- a/.github/scripts/Tests/cost-integration.Tests.ps1
+++ b/.github/scripts/Tests/cost-integration.Tests.ps1
@@ -780,3 +780,244 @@ Describe 'frame-credit-ledger cost integration' {
         }
     }
 }
+
+# ===========================================================================
+# Issue #769 AC3 — Origin-gated 3-state taxonomy integration tests
+#
+# Validates that the orchestrator correctly routes the missing-block short-
+# circuit to the 🛑 FAILED or "not measured (non-orchestrated)" state based
+# on the CI-safe origin predicate (Get-FCLOriginContext).
+# ===========================================================================
+Describe 'frame-credit-ledger origin-gated taxonomy (issue #769 AC3)' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:OrchestratorPath = Join-Path $script:RepoRoot '.github/scripts/frame-credit-ledger.ps1'
+
+        # Empty PR body: no pipeline-metrics block. Used to exercise the null short-circuit.
+        $script:EmptyBody = '## Summary' + [Environment]::NewLine + 'A PR with no pipeline-metrics block.'
+
+        # Pre-v4 body for the pre-v4 short-circuit test.
+        $script:PreV4BodyForTaxonomy = @'
+## Summary
+
+A pre-v4 PR body.
+
+<!-- pipeline-metrics
+metrics_version: 3
+some_legacy_field: value
+-->
+'@
+
+        # Parse-error body: block exists but YAML is malformed.
+        $script:ParseErrorBody = @'
+## Summary
+
+A PR with a malformed pipeline-metrics block.
+
+<!-- pipeline-metrics
+: missing key
+-->
+'@
+
+        # ---------------------------------------------------------------------------
+        # InvokeWithOriginControl: runs Invoke-FrameCreditLedger in-process with full
+        # mock wiring. Accepts:
+        #   -PrBody        : the PR body text
+        #   -HeadRef       : simulates $env:GITHUB_HEAD_REF (CI-safe branch name)
+        #   -SuppressFailed: simulates $env:FCL_SUPPRESS_FAILED_POSTS=1
+        # Returns @{ Comment = '...'; ExitCode = 0 }.
+        # ---------------------------------------------------------------------------
+        $script:InvokeWithOriginControl = {
+            param(
+                [string]$PrBody = '',
+                [string]$HeadRef = '',
+                [bool]$SuppressFailed = $false
+            )
+
+            $capturedRepoRoot = $script:RepoRoot
+            $capturedHeadRef = $HeadRef
+            $capturedSuppressFailed = $SuppressFailed
+            $bodyJson = (@{ body = $PrBody; comments = @() } | ConvertTo-Json -Compress -Depth 5)
+
+            $previousNoSleep = $env:FRAME_CREDIT_LEDGER_TEST_NO_SLEEP
+            $previousHeadRef = $env:GITHUB_HEAD_REF
+            $previousSuppress = $env:FCL_SUPPRESS_FAILED_POSTS
+            try {
+                $env:FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'
+                $env:GITHUB_HEAD_REF = $capturedHeadRef
+                $env:FCL_SUPPRESS_FAILED_POSTS = if ($capturedSuppressFailed) { '1' } else { '' }
+
+                . $script:OrchestratorPath -Pr 769 -Mode 'warn'
+
+                function git {
+                    param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+                    $joined = $Args -join ' '
+                    if ($joined -match 'rev-parse --show-toplevel') {
+                        $global:LASTEXITCODE = 0; return $capturedRepoRoot
+                    }
+                    if ($joined -match 'config --get remote\.origin\.url') {
+                        $global:LASTEXITCODE = 0; return 'https://github.com/example/example.git'
+                    }
+                    if ($joined -match 'rev-parse --abbrev-ref HEAD') {
+                        # Return the HeadRef when asked for branch name (for cost walker compat).
+                        $global:LASTEXITCODE = 0
+                        return if ([string]::IsNullOrWhiteSpace($capturedHeadRef)) { 'HEAD' } else { $capturedHeadRef }
+                    }
+                    $global:LASTEXITCODE = 0; return ''
+                }
+
+                $script:_PostedComments = [System.Collections.Generic.List[string]]::new()
+
+                function gh {
+                    param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+                    $joined = $Args -join ' '
+                    if ($joined -match 'pr view \d+ --json baseRefOid') {
+                        $global:LASTEXITCODE = 0; return '{"baseRefOid":"abc123"}'
+                    }
+                    if ($joined -match 'pr view \d+ --json body') {
+                        $global:LASTEXITCODE = 0; return $bodyJson
+                    }
+                    if ($joined -match 'issue view \d+ --json comments') {
+                        $global:LASTEXITCODE = 0; return '{"comments":[]}'
+                    }
+                    if ($joined -match '(issue|pr) comment \d+ --body') {
+                        # Capture the comment body for assertion in off-switch test.
+                        $bodyArgIdx = ($Args | Select-Object -SkipLast 0) | ForEach-Object { $_ } | Select-String -Pattern '^--body$' -List
+                        $script:_PostedComments.Add([string]($Args[-1])) | Out-Null
+                        $global:LASTEXITCODE = 0; return 'https://github.com/example/example/pull/769#issuecomment-1'
+                    }
+                    if ($joined -match 'api repos/[^/]+/[^/]+ ') {
+                        $global:LASTEXITCODE = 0; return '{"owner":{"login":"example"},"name":"example"}'
+                    }
+                    if ($joined -match 'api -X PATCH repos/[^/]+/[^/]+/issues/comments/\d+') {
+                        $global:LASTEXITCODE = 0; return '{"html_url":"https://github.com/example/example/pull/769#issuecomment-2"}'
+                    }
+                    if ($joined -match 'pr edit \d+ --body-file') {
+                        $global:LASTEXITCODE = 0; return ''
+                    }
+                    $global:LASTEXITCODE = 0; return ''
+                }
+
+                # Stub cost lib to avoid real walker invocations.
+                function Get-CostTranscriptSlug { param([string]$CwdPath) return '' }
+                function Invoke-CostTranscriptWalk { param([string]$Slug, [string]$Branch, [string]$ParentCwd, [Nullable[int]]$IssueNumber = $null) return @() }
+                function Invoke-CostCopilotWalk { param([string]$Branch, [string]$RepoRoot, [string]$OtelJsonlPath, [string]$WorkspaceFolderBasename = '') return @() }
+                function Get-CostAttribution { param([object[]]$Events, [string]$RateTablePath = '') return @{ ports = @{}; orchestrator_overhead = @{}; dispatches = @{}; totals = @{ total_cost_usd = 0.0 } } }
+                function Get-CostRollingHistory { param([int]$TimeoutSeconds = 10) return @{ timed_out = $false; entries = @() } }
+                function Get-MostRecentRegimeCheckpoint { param([string]$Path) return $null }
+                function Get-SessionCompleteness { param([object[]]$Events, [string]$ExcludeReason = '', [string]$Branch = '') return @{ completeness = 'unknown'; excluded_from_rolling_baseline = $true; exclude_reason = 'no-events' } }
+                function Resolve-CostDataPreservation { param($Current, $Prior) return @{ use_prior = $false; notice = '' } }
+                function Get-CostAnomalyFlags { param($ThisRun, [object[]]$RollingHistory, $RegimeCheckpoint) return @() }
+                function Format-CostPatternMarkdown { param($Attribution, $Completeness, [object[]]$AnomalyFlags, $RollingMeta, [int]$Pr, [string]$Branch) return '## Cost Pattern' }
+                function Format-CostPatternYaml { param($Attribution, $Completeness, [object[]]$AnomalyFlags, [int]$Pr, [string]$Branch) return "<!-- cost-pattern-data`npr: $Pr`n-->" }
+
+                $script:FrameCreditLedgerRepoRoot = $capturedRepoRoot
+                $result = Invoke-FrameCreditLedger -Pr 769 -Mode 'warn'
+
+                return @{
+                    ExitCode         = 0
+                    Comment          = if ($null -ne $result.Comment) { [string]$result.Comment } else { '' }
+                    PostedComments   = @($script:_PostedComments)
+                }
+            }
+            finally {
+                $env:FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = $previousNoSleep
+                $env:GITHUB_HEAD_REF = $previousHeadRef
+                $env:FCL_SUPPRESS_FAILED_POSTS = $previousSuppress
+            }
+        }
+    }
+
+    Context 'Missing block — orchestrated-origin → 🛑 FAILED' {
+
+        It 'GITHUB_HEAD_REF=feature/issue-769 and no block → comment contains 🛑 FAILED' {
+            $result = & $script:InvokeWithOriginControl `
+                -PrBody $script:EmptyBody `
+                -HeadRef 'feature/issue-769-v4-emission-reliability'
+
+            $result.ExitCode | Should -Be 0
+            $result.Comment | Should -Match '🛑'
+            $result.Comment | Should -Match 'FAILED'
+            $result.Comment | Should -Not -Match 'non-orchestrated'
+            $result.Comment | Should -Not -Match 'not measured'
+        }
+    }
+
+    Context 'Missing block — non-orchestrated → "not measured (non-orchestrated)"' {
+
+        It 'GITHUB_HEAD_REF=topic/no-issue and no block → quiet "not measured" comment' {
+            $result = & $script:InvokeWithOriginControl `
+                -PrBody $script:EmptyBody `
+                -HeadRef 'topic/no-issue-slug'
+
+            $result.ExitCode | Should -Be 0
+            $result.Comment | Should -Match 'not measured \(non-orchestrated\)'
+            $result.Comment | Should -Not -Match '🛑'
+            $result.Comment | Should -Not -Match 'FAILED'
+        }
+    }
+
+    Context 'Pre-v4 block → pre-v4 state (origin-agnostic)' {
+
+        It 'pre-v4 block renders pre-v4 state regardless of orchestrated-origin' {
+            # Even on orchestrated-origin branch, the pre-v4 path renders the pre-v4 comment.
+            $result = & $script:InvokeWithOriginControl `
+                -PrBody $script:PreV4BodyForTaxonomy `
+                -HeadRef 'feature/issue-769-pre-v4-test'
+
+            $result.ExitCode | Should -Be 0
+            $result.Comment | Should -Match '(?i)pre-v4 metrics detected'
+            $result.Comment | Should -Not -Match 'non-orchestrated'
+            $result.Comment | Should -Not -Match '🛑'
+        }
+    }
+
+    Context 'Parse-error → 🛑 FAILED (origin-agnostic)' {
+
+        It 'parse-error block renders FAILED regardless of origin (parse errors always signal failure)' {
+            # Even on non-orchestrated branch, parse-error is a genuine failure.
+            $result = & $script:InvokeWithOriginControl `
+                -PrBody $script:ParseErrorBody `
+                -HeadRef 'topic/no-issue-slug'
+
+            $result.ExitCode | Should -Be 0
+            # Parse-error comment uses ⚠️ (not 🛑) — the parse-error path is unchanged;
+            # the ⚠️ serves as the failure signal here.
+            $result.Comment | Should -Match '(?i)could not be parsed'
+            $result.Comment | Should -Not -Match 'not measured'
+        }
+    }
+
+    Context 'Off-switch (FCL_SUPPRESS_FAILED_POSTS=1) — FAILED posts suppressed, non-FAILED not suppressed' {
+
+        It 'off-switch active: FAILED-state post not fired; comment still returned' {
+            # When off-switch is active and origin is orchestrated + block absent,
+            # Find-OrUpsertComment must NOT be called (no posted comments),
+            # but the result.Comment must still be set to the FAILED comment text.
+            $result = & $script:InvokeWithOriginControl `
+                -PrBody $script:EmptyBody `
+                -HeadRef 'feature/issue-769-off-switch-test' `
+                -SuppressFailed $true
+
+            $result.ExitCode | Should -Be 0
+            # Comment still populated (return value carries the composed text)
+            $result.Comment | Should -Match '🛑'
+            # No post was fired — PostedComments must be empty
+            $result.PostedComments.Count | Should -Be 0 -Because 'off-switch suppresses FAILED-state gh comment calls'
+        }
+
+        It 'off-switch active: non-orchestrated "not measured" post still fires (not suppressed)' {
+            # Off-switch only suppresses FAILED-state posts; non-orchestrated posts always fire.
+            $result = & $script:InvokeWithOriginControl `
+                -PrBody $script:EmptyBody `
+                -HeadRef 'topic/no-issue-non-orchestrated' `
+                -SuppressFailed $true
+
+            $result.ExitCode | Should -Be 0
+            $result.Comment | Should -Match 'not measured \(non-orchestrated\)'
+            # The non-orchestrated comment must have been posted
+            $result.PostedComments.Count | Should -BeGreaterOrEqual 1 -Because 'non-FAILED posts are not suppressed by off-switch'
+        }
+    }
+}

--- a/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
+++ b/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
@@ -18,13 +18,20 @@
 #      -> builder throws -> sentinel emitted correctly.
 
 BeforeAll {
-    $script:RepoRoot    = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
-    $script:ScriptPath  = Join-Path $script:RepoRoot '.github/scripts/emit-pipeline-metrics-v4.ps1'
-    $script:CoreLibPath = Join-Path $script:RepoRoot '.github/scripts/lib/frame-credit-ledger-core.ps1'
+    $script:RepoRoot     = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:CoreLibPath  = Join-Path $script:RepoRoot '.github/scripts/lib/frame-credit-ledger-core.ps1'
+    $script:EmitCorePath = Join-Path $script:RepoRoot '.github/scripts/lib/emit-pipeline-metrics-v4-core.ps1'
 
-    # Load core lib so helpers are available to test assertions.
+    # Load core lib so helpers (New-/Test-/Read-PipelineMetricsV4Block) are
+    # available to test assertions.
     if (Test-Path $script:CoreLibPath) {
         . $script:CoreLibPath
+    }
+
+    # Dot-source the emit core so Invoke-PipelineMetricsV4Emit can be called
+    # in-process (no child pwsh spawn — #257 script-safety contract).
+    if (Test-Path $script:EmitCorePath) {
+        . $script:EmitCorePath
     }
 
     # Minimal valid v3 base YAML (no pipeline-metrics wrapper, no metrics_version line).
@@ -53,8 +60,9 @@ BeforeAll {
         )
     }
 
-    # Helper: invoke the script in a child process and return @{ ExitCode; BodyContent }.
-    # Uses pwsh -File so $ErrorActionPreference = 'Stop' and exit codes propagate correctly.
+    # Helper: invoke the emit core in-process and return @{ ExitCode; BodyContent }.
+    # Dot-source + in-process call pattern (#257) — Invoke-PipelineMetricsV4Emit
+    # returns an ExitCode object instead of calling exit, so no child pwsh is spawned.
     $script:InvokeScript = {
         param(
             [string]$BodyFile,
@@ -65,59 +73,14 @@ BeforeAll {
             [string]$RichBody = ''
         )
 
-        # Serialize credits to a temp JSON file so the child process can reload them.
-        $creditsJson  = if ($Credits.Count -gt 0)            { $Credits | ConvertTo-Json -Depth 5 }            else { '[]' }
-        $samplesJson  = if ($DispatchCostSamples.Count -gt 0) { $DispatchCostSamples | ConvertTo-Json -Depth 5 } else { '[]' }
-
-        $creditsTemp  = [System.IO.Path]::GetTempFileName()
-        $samplesTemp  = [System.IO.Path]::GetTempFileName()
-        $richBodyTemp = [System.IO.Path]::GetTempFileName()
-        Set-Content -Path $creditsTemp  -Value $creditsJson -Encoding utf8NoBOM
-        Set-Content -Path $samplesTemp  -Value $samplesJson -Encoding utf8NoBOM
-        # Store RichBody in a file to avoid quoting issues in the wrapper here-string.
-        Set-Content -Path $richBodyTemp -Value $RichBody    -Encoding utf8NoBOM
-
-        # Escape paths for use inside single-quoted strings in the wrapper.
-        $safeBodyFile    = $BodyFile              -replace "'", "''"
-        $safeScript      = $script:ScriptPath     -replace "'", "''"
-        $safeCredTemp    = $creditsTemp            -replace "'", "''"
-        $safeSampTemp    = $samplesTemp            -replace "'", "''"
-        $safeV3          = $V3BaseYaml             -replace "'", "''"
-        $safeRichTemp    = $richBodyTemp           -replace "'", "''"
-
-        $wrapperContent = @"
-#Requires -Version 7.0
-`$ErrorActionPreference = 'Stop'
-`$creditsRaw  = Get-Content -LiteralPath '$safeCredTemp'   -Raw | ConvertFrom-Json
-`$samplesRaw  = Get-Content -LiteralPath '$safeSampTemp'   -Raw | ConvertFrom-Json
-`$richBodyVal = Get-Content -LiteralPath '$safeRichTemp'   -Raw
-# Trim the trailing newline that Set-Content appends so the value matches what callers pass.
-`$richBodyVal = `$richBodyVal -replace '\r?\n$', ''
-`$credits  = if (`$null -eq `$creditsRaw  -or @(`$creditsRaw).Count  -eq 0)  { @() } else { @(`$creditsRaw  | ForEach-Object { [pscustomobject]`$_ }) }
-`$samples  = if (`$null -eq `$samplesRaw -or @(`$samplesRaw).Count -eq 0) { @() } else { @(`$samplesRaw | ForEach-Object { [pscustomobject]`$_ }) }
-& '$safeScript' ``
-    -BodyFile '$safeBodyFile' ``
-    -V3BaseYaml '$safeV3' ``
-    -Credits `$credits ``
-    -DispatchCostSamples `$samples ``
-    -IssueNumber $IssueNumber ``
-    -RichBody `$richBodyVal
-exit `$LASTEXITCODE
-"@
-        $wrapperTemp = [System.IO.Path]::GetTempFileName() + '.ps1'
-        Set-Content -Path $wrapperTemp -Value $wrapperContent -Encoding utf8NoBOM
-
-        try {
-            $proc = Start-Process -FilePath 'pwsh' `
-                -ArgumentList @('-NonInteractive', '-NoProfile', '-File', $wrapperTemp) `
-                -Wait -PassThru -NoNewWindow
-            $exitCode = $proc.ExitCode
-        } finally {
-            Remove-Item -LiteralPath $wrapperTemp   -ErrorAction SilentlyContinue
-            Remove-Item -LiteralPath $creditsTemp   -ErrorAction SilentlyContinue
-            Remove-Item -LiteralPath $samplesTemp   -ErrorAction SilentlyContinue
-            Remove-Item -LiteralPath $richBodyTemp  -ErrorAction SilentlyContinue
-        }
+        $emitResult = Invoke-PipelineMetricsV4Emit `
+            -BodyFile            $BodyFile `
+            -V3BaseYaml          $V3BaseYaml `
+            -Credits             $Credits `
+            -DispatchCostSamples $DispatchCostSamples `
+            -IssueNumber         $IssueNumber `
+            -RichBody            $RichBody `
+            -WarningAction       SilentlyContinue
 
         $bodyContent = ''
         if (Test-Path -LiteralPath $BodyFile) {
@@ -125,7 +88,7 @@ exit `$LASTEXITCODE
         }
 
         return [pscustomobject]@{
-            ExitCode    = $exitCode
+            ExitCode    = $emitResult.ExitCode
             BodyContent = $bodyContent
         }
     }

--- a/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
+++ b/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
@@ -304,6 +304,10 @@ Describe 'emit-pipeline-metrics-v4.ps1' {
 
                 $result.ExitCode    | Should -Not -Be 0
                 $result.BodyContent | Should -Match $script:SentinelRegex
+                # CR-NEW-1 / CR-DUP-1: the fallback must strip the embedded metrics
+                # block from RichBody so downstream readers cannot mistake the failure
+                # body for a real v4 emission.
+                $result.BodyContent | Should -Not -Match '<!--\s*pipeline-metrics'
             } finally {
                 Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
             }

--- a/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
+++ b/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
@@ -274,4 +274,46 @@ Describe 'emit-pipeline-metrics-v4.ps1' {
             }
         }
     }
+
+    Context 'Case 6 (s-acc) - harvest hook: file-based accumulator provides credits when -Credits is empty' {
+
+        It 'produces a valid v4 body with the credit from fclcredits.jsonl when -Credits is empty and -IssueNumber matches' {
+            # Arrange: pre-populate the accumulator file for test issue 99999.
+            $repoRoot        = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+            $accDir          = Join-Path $repoRoot '.tmp/issue-99999'
+            $accFile         = Join-Path $accDir 'fclcredits.jsonl'
+            New-Item -ItemType Directory -Force -Path $accDir | Out-Null
+
+            # Write the same shape as Build-ImplementCodeCreditRow returns.
+            $creditRow = [pscustomobject]@{
+                port               = 'implement-code'
+                adapter            = 'skills/implementation-discipline/adapters/implement-code-adapter.md'
+                status             = 'passed'
+                run_index          = 1
+                evidence           = 'emit-pipeline-metrics-v4.Tests.ps1 -- s-acc harvest fixture'
+                'terminal-step-id' = 5
+            }
+            $creditRow | ConvertTo-Json -Compress -Depth 10 | Set-Content -Path $accFile -Encoding utf8NoBOM
+
+            $bodyFile = & $script:TempBodyFile
+            try {
+                # Act: call with empty -Credits and -IssueNumber 99999.
+                $result = & $script:InvokeScript `
+                    -BodyFile    $bodyFile `
+                    -V3BaseYaml  $script:ValidV3Base `
+                    -Credits     @() `
+                    -IssueNumber 99999
+
+                # Assert: harvest ran, body is valid v4.
+                $result.ExitCode    | Should -Be 0
+                $result.BodyContent | Should -Match 'metrics_version: 4'
+                $result.BodyContent | Should -Match 'implement-code'
+                $result.BodyContent | Should -Not -Match $script:SentinelRegex
+            } finally {
+                Remove-Item -LiteralPath $bodyFile  -ErrorAction SilentlyContinue
+                Remove-Item -LiteralPath $accFile   -ErrorAction SilentlyContinue
+                Remove-Item -LiteralPath $accDir    -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }

--- a/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
+++ b/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
@@ -61,30 +61,38 @@ BeforeAll {
             [string]$V3BaseYaml = '',
             [pscustomobject[]]$Credits = @(),
             [pscustomobject[]]$DispatchCostSamples = @(),
-            [int]$IssueNumber = 0
+            [int]$IssueNumber = 0,
+            [string]$RichBody = ''
         )
 
         # Serialize credits to a temp JSON file so the child process can reload them.
         $creditsJson  = if ($Credits.Count -gt 0)            { $Credits | ConvertTo-Json -Depth 5 }            else { '[]' }
         $samplesJson  = if ($DispatchCostSamples.Count -gt 0) { $DispatchCostSamples | ConvertTo-Json -Depth 5 } else { '[]' }
 
-        $creditsTemp = [System.IO.Path]::GetTempFileName()
-        $samplesTemp = [System.IO.Path]::GetTempFileName()
-        Set-Content -Path $creditsTemp -Value $creditsJson -Encoding utf8NoBOM
-        Set-Content -Path $samplesTemp -Value $samplesJson -Encoding utf8NoBOM
+        $creditsTemp  = [System.IO.Path]::GetTempFileName()
+        $samplesTemp  = [System.IO.Path]::GetTempFileName()
+        $richBodyTemp = [System.IO.Path]::GetTempFileName()
+        Set-Content -Path $creditsTemp  -Value $creditsJson -Encoding utf8NoBOM
+        Set-Content -Path $samplesTemp  -Value $samplesJson -Encoding utf8NoBOM
+        # Store RichBody in a file to avoid quoting issues in the wrapper here-string.
+        Set-Content -Path $richBodyTemp -Value $RichBody    -Encoding utf8NoBOM
 
         # Escape paths for use inside single-quoted strings in the wrapper.
-        $safeBodyFile  = $BodyFile      -replace "'", "''"
-        $safeScript    = $script:ScriptPath -replace "'", "''"
-        $safeCredTemp  = $creditsTemp   -replace "'", "''"
-        $safeSampTemp  = $samplesTemp   -replace "'", "''"
-        $safeV3        = $V3BaseYaml    -replace "'", "''"
+        $safeBodyFile    = $BodyFile              -replace "'", "''"
+        $safeScript      = $script:ScriptPath     -replace "'", "''"
+        $safeCredTemp    = $creditsTemp            -replace "'", "''"
+        $safeSampTemp    = $samplesTemp            -replace "'", "''"
+        $safeV3          = $V3BaseYaml             -replace "'", "''"
+        $safeRichTemp    = $richBodyTemp           -replace "'", "''"
 
         $wrapperContent = @"
 #Requires -Version 7.0
 `$ErrorActionPreference = 'Stop'
-`$creditsRaw = Get-Content -LiteralPath '$safeCredTemp' -Raw | ConvertFrom-Json
-`$samplesRaw = Get-Content -LiteralPath '$safeSampTemp' -Raw | ConvertFrom-Json
+`$creditsRaw  = Get-Content -LiteralPath '$safeCredTemp'   -Raw | ConvertFrom-Json
+`$samplesRaw  = Get-Content -LiteralPath '$safeSampTemp'   -Raw | ConvertFrom-Json
+`$richBodyVal = Get-Content -LiteralPath '$safeRichTemp'   -Raw
+# Trim the trailing newline that Set-Content appends so the value matches what callers pass.
+`$richBodyVal = `$richBodyVal -replace '\r?\n$', ''
 `$credits  = if (`$null -eq `$creditsRaw  -or @(`$creditsRaw).Count  -eq 0)  { @() } else { @(`$creditsRaw  | ForEach-Object { [pscustomobject]`$_ }) }
 `$samples  = if (`$null -eq `$samplesRaw -or @(`$samplesRaw).Count -eq 0) { @() } else { @(`$samplesRaw | ForEach-Object { [pscustomobject]`$_ }) }
 & '$safeScript' ``
@@ -92,7 +100,8 @@ BeforeAll {
     -V3BaseYaml '$safeV3' ``
     -Credits `$credits ``
     -DispatchCostSamples `$samples ``
-    -IssueNumber $IssueNumber
+    -IssueNumber $IssueNumber ``
+    -RichBody `$richBodyVal
 exit `$LASTEXITCODE
 "@
         $wrapperTemp = [System.IO.Path]::GetTempFileName() + '.ps1'
@@ -104,9 +113,10 @@ exit `$LASTEXITCODE
                 -Wait -PassThru -NoNewWindow
             $exitCode = $proc.ExitCode
         } finally {
-            Remove-Item -LiteralPath $wrapperTemp  -ErrorAction SilentlyContinue
-            Remove-Item -LiteralPath $creditsTemp  -ErrorAction SilentlyContinue
-            Remove-Item -LiteralPath $samplesTemp  -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $wrapperTemp   -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $creditsTemp   -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $samplesTemp   -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $richBodyTemp  -ErrorAction SilentlyContinue
         }
 
         $bodyContent = ''
@@ -269,6 +279,61 @@ Describe 'emit-pipeline-metrics-v4.ps1' {
 
                 $result.ExitCode    | Should -Not -Be 0
                 $result.BodyContent | Should -Match $script:SentinelRegex
+            } finally {
+                Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'Case 7 - RichBody merging: success path appends v4 block after rich body content' {
+
+        It 'body file contains Closes #769 before the pipeline-metrics block when RichBody is provided' {
+            $richBodyContent = "## Summary`n`nCloses #769`n"
+            $bodyFile = & $script:TempBodyFile
+            try {
+                $result = & $script:InvokeScript `
+                    -BodyFile    $bodyFile `
+                    -V3BaseYaml  $script:ValidV3Base `
+                    -Credits     @($script:ValidCredit) `
+                    -RichBody    $richBodyContent
+
+                $result.ExitCode    | Should -Be 0
+                $result.BodyContent | Should -Match 'Closes #769'
+                $result.BodyContent | Should -Match '<!-- pipeline-metrics'
+                $result.BodyContent | Should -Match 'metrics_version: 4'
+                $result.BodyContent | Should -Not -Match $script:SentinelRegex
+
+                # Ordering: "Closes #769" must appear before "<!-- pipeline-metrics"
+                $closesIndex  = $result.BodyContent.IndexOf('Closes #769')
+                $metricsIndex = $result.BodyContent.IndexOf('<!-- pipeline-metrics')
+                $closesIndex  | Should -BeLessThan $metricsIndex
+            } finally {
+                Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'Case 8 - RichBody preserved in fallback: rich content survives emit failure' {
+
+        It 'body file contains Closes #769 before the sentinel when RichBody is provided and builder throws' {
+            # Empty V3BaseYaml forces builder throw (Case 1), so RichBody must survive in fallback.
+            $richBodyContent = "## Summary`n`nCloses #769`n"
+            $bodyFile = & $script:TempBodyFile
+            try {
+                $result = & $script:InvokeScript `
+                    -BodyFile    $bodyFile `
+                    -V3BaseYaml  '' `
+                    -Credits     @($script:ValidCredit) `
+                    -RichBody    $richBodyContent
+
+                $result.ExitCode    | Should -Not -Be 0
+                $result.BodyContent | Should -Match 'Closes #769'
+                $result.BodyContent | Should -Match $script:SentinelRegex
+
+                # Ordering: "Closes #769" must appear before the sentinel
+                $closesIndex   = $result.BodyContent.IndexOf('Closes #769')
+                $sentinelIndex = $result.BodyContent.IndexOf($script:SentinelToken)
+                $closesIndex   | Should -BeLessThan $sentinelIndex
             } finally {
                 Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
             }

--- a/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
+++ b/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
@@ -1,0 +1,277 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Tests for emit-pipeline-metrics-v4.ps1 (issue #769 s2).
+#
+# Script under test: .github/scripts/emit-pipeline-metrics-v4.ps1
+#
+# Coverage:
+#   1. Success: valid V3BaseYaml + credit row -> BodyFile contains
+#      metrics_version: 4 and the credit; exit 0.
+#   2. Builder-throw (empty V3BaseYaml) -> BodyFile contains cost-capture-failed sentinel;
+#      exit non-zero.
+#   3. Empty credits -> Test-PipelineMetricsV4Block rejects -> sentinel emitted;
+#      exit non-zero.
+#   4. Sentinel token mismatch (M21): sentinel does NOT match pipeline-metrics pattern;
+#      Test-PipelineMetricsV4Block does not count it.
+#   5. v3-base opener injection (M7): V3BaseYaml containing pipeline-metrics opener
+#      -> builder throws -> sentinel emitted correctly.
+
+BeforeAll {
+    $script:RepoRoot    = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:ScriptPath  = Join-Path $script:RepoRoot '.github/scripts/emit-pipeline-metrics-v4.ps1'
+    $script:CoreLibPath = Join-Path $script:RepoRoot '.github/scripts/lib/frame-credit-ledger-core.ps1'
+
+    # Load core lib so helpers are available to test assertions.
+    if (Test-Path $script:CoreLibPath) {
+        . $script:CoreLibPath
+    }
+
+    # Minimal valid v3 base YAML (no pipeline-metrics wrapper, no metrics_version line).
+    $script:ValidV3Base = 'pr_number: 42'
+
+    # Sentinel token (stored to avoid parser confusion with HTML comment syntax in test titles).
+    $script:SentinelToken  = '<!-- cost-capture-failed -->'
+    $script:SentinelRegex  = [regex]::Escape($script:SentinelToken)
+
+    # A valid credit row pscustomobject shaped as Build-ImplementCodeCreditRow returns.
+    $script:ValidCredit = [pscustomobject]@{
+        port               = 'implement-code'
+        adapter            = 'skills/implementation-discipline/adapters/implement-code-adapter.md'
+        status             = 'passed'
+        run_index          = 1
+        evidence           = 'emit-pipeline-metrics-v4.Tests.ps1 -- success fixture'
+        'terminal-step-id' = 2
+    }
+
+    # Helper: create a unique temp body file path (not yet created -- the script creates it).
+    # Stored as a scriptblock so It-blocks can invoke it via & $script:TempBodyFile.
+    $script:TempBodyFile = {
+        return [System.IO.Path]::Combine(
+            [System.IO.Path]::GetTempPath(),
+            "emit-v4-test-$([System.Guid]::NewGuid().ToString('N')).md"
+        )
+    }
+
+    # Helper: invoke the script in a child process and return @{ ExitCode; BodyContent }.
+    # Uses pwsh -File so $ErrorActionPreference = 'Stop' and exit codes propagate correctly.
+    $script:InvokeScript = {
+        param(
+            [string]$BodyFile,
+            [string]$V3BaseYaml = '',
+            [pscustomobject[]]$Credits = @(),
+            [pscustomobject[]]$DispatchCostSamples = @(),
+            [int]$IssueNumber = 0
+        )
+
+        # Serialize credits to a temp JSON file so the child process can reload them.
+        $creditsJson  = if ($Credits.Count -gt 0)            { $Credits | ConvertTo-Json -Depth 5 }            else { '[]' }
+        $samplesJson  = if ($DispatchCostSamples.Count -gt 0) { $DispatchCostSamples | ConvertTo-Json -Depth 5 } else { '[]' }
+
+        $creditsTemp = [System.IO.Path]::GetTempFileName()
+        $samplesTemp = [System.IO.Path]::GetTempFileName()
+        Set-Content -Path $creditsTemp -Value $creditsJson -Encoding utf8NoBOM
+        Set-Content -Path $samplesTemp -Value $samplesJson -Encoding utf8NoBOM
+
+        # Escape paths for use inside single-quoted strings in the wrapper.
+        $safeBodyFile  = $BodyFile      -replace "'", "''"
+        $safeScript    = $script:ScriptPath -replace "'", "''"
+        $safeCredTemp  = $creditsTemp   -replace "'", "''"
+        $safeSampTemp  = $samplesTemp   -replace "'", "''"
+        $safeV3        = $V3BaseYaml    -replace "'", "''"
+
+        $wrapperContent = @"
+#Requires -Version 7.0
+`$ErrorActionPreference = 'Stop'
+`$creditsRaw = Get-Content -LiteralPath '$safeCredTemp' -Raw | ConvertFrom-Json
+`$samplesRaw = Get-Content -LiteralPath '$safeSampTemp' -Raw | ConvertFrom-Json
+`$credits  = if (`$null -eq `$creditsRaw  -or @(`$creditsRaw).Count  -eq 0)  { @() } else { @(`$creditsRaw  | ForEach-Object { [pscustomobject]`$_ }) }
+`$samples  = if (`$null -eq `$samplesRaw -or @(`$samplesRaw).Count -eq 0) { @() } else { @(`$samplesRaw | ForEach-Object { [pscustomobject]`$_ }) }
+& '$safeScript' ``
+    -BodyFile '$safeBodyFile' ``
+    -V3BaseYaml '$safeV3' ``
+    -Credits `$credits ``
+    -DispatchCostSamples `$samples ``
+    -IssueNumber $IssueNumber
+exit `$LASTEXITCODE
+"@
+        $wrapperTemp = [System.IO.Path]::GetTempFileName() + '.ps1'
+        Set-Content -Path $wrapperTemp -Value $wrapperContent -Encoding utf8NoBOM
+
+        try {
+            $proc = Start-Process -FilePath 'pwsh' `
+                -ArgumentList @('-NonInteractive', '-NoProfile', '-File', $wrapperTemp) `
+                -Wait -PassThru -NoNewWindow
+            $exitCode = $proc.ExitCode
+        } finally {
+            Remove-Item -LiteralPath $wrapperTemp  -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $creditsTemp  -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $samplesTemp  -ErrorAction SilentlyContinue
+        }
+
+        $bodyContent = ''
+        if (Test-Path -LiteralPath $BodyFile) {
+            $bodyContent = Get-Content -LiteralPath $BodyFile -Raw
+        }
+
+        return [pscustomobject]@{
+            ExitCode    = $exitCode
+            BodyContent = $bodyContent
+        }
+    }
+}
+
+Describe 'emit-pipeline-metrics-v4.ps1' {
+
+    Context 'Case 3 - success: valid V3BaseYaml plus credit row' {
+
+        It 'writes metrics_version 4 and the credit row to BodyFile, exits 0' {
+            $bodyFile = & $script:TempBodyFile
+            try {
+                $result = & $script:InvokeScript `
+                    -BodyFile $bodyFile `
+                    -V3BaseYaml $script:ValidV3Base `
+                    -Credits @($script:ValidCredit)
+
+                $result.ExitCode    | Should -Be 0
+                $result.BodyContent | Should -Match 'metrics_version: 4'
+                $result.BodyContent | Should -Match 'implement-code'
+                $result.BodyContent | Should -Not -Match $script:SentinelRegex
+            } finally {
+                Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'round-trips through Read-PRMetricsBlock and reports MetricsVersion=4 with credits' {
+            $bodyFile = & $script:TempBodyFile
+            try {
+                $result = & $script:InvokeScript `
+                    -BodyFile $bodyFile `
+                    -V3BaseYaml $script:ValidV3Base `
+                    -Credits @($script:ValidCredit)
+
+                $result.ExitCode | Should -Be 0
+
+                $parsed = Read-PRMetricsBlock -PrBody $result.BodyContent
+                $parsed                  | Should -Not -BeNullOrEmpty
+                $parsed.MetricsVersion   | Should -Be 4
+                @($parsed.Credits).Count | Should -BeGreaterThan 0
+                ($parsed.Credits | Where-Object { $_.Port -eq 'implement-code' }) | Should -Not -BeNullOrEmpty
+            } finally {
+                Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'Case 1 - builder throws: empty V3BaseYaml' {
+
+        It 'writes cost-capture-failed sentinel to BodyFile and exits non-zero' {
+            $bodyFile = & $script:TempBodyFile
+            try {
+                $result = & $script:InvokeScript `
+                    -BodyFile $bodyFile `
+                    -V3BaseYaml '' `
+                    -Credits @($script:ValidCredit)
+
+                $result.ExitCode    | Should -Not -Be 0
+                $result.BodyContent | Should -Match $script:SentinelRegex
+            } finally {
+                Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'fallback body contains metrics_emission_failed when no V3BaseYaml and no Credits' {
+            $bodyFile = & $script:TempBodyFile
+            try {
+                $result = & $script:InvokeScript `
+                    -BodyFile $bodyFile `
+                    -V3BaseYaml '' `
+                    -Credits @()
+
+                $result.ExitCode    | Should -Not -Be 0
+                $result.BodyContent | Should -Match 'metrics_emission_failed'
+                $result.BodyContent | Should -Match $script:SentinelRegex
+            } finally {
+                Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'Case 2 - empty credits: Test-PipelineMetricsV4Block rejects' {
+
+        It 'writes sentinel when credits array is empty and Test- reports invalid' {
+            # New-PipelineMetricsV4Block with valid V3BaseYaml but no credits
+            # produces a block with no credits[] section, which Test- rejects (no credits).
+            $bodyFile = & $script:TempBodyFile
+            try {
+                $result = & $script:InvokeScript `
+                    -BodyFile $bodyFile `
+                    -V3BaseYaml $script:ValidV3Base `
+                    -Credits @()
+
+                $result.ExitCode    | Should -Not -Be 0
+                $result.BodyContent | Should -Match $script:SentinelRegex
+            } finally {
+                Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'M21 - sentinel token does not match pipeline-metrics pattern' {
+
+        It 'sentinel token does not match the pipeline-metrics regex' {
+            $script:SentinelToken | Should -Not -Match '<!--\s*pipeline-metrics'
+        }
+
+        It 'Test-PipelineMetricsV4Block counts sentinel as zero pipeline-metrics markers' {
+            # Build a body containing only the sentinel (no real pipeline-metrics block).
+            # The function must report DetectedMarkerCount=0 (sentinel is not counted).
+            $bodyWithSentinelOnly = "Some PR text.`n`n$($script:SentinelToken)`n`nMore text."
+
+            $testResult = Test-PipelineMetricsV4Block -PRBody $bodyWithSentinelOnly
+            $testResult.Valid               | Should -Be $false
+            $testResult.DetectedMarkerCount | Should -Be 0
+        }
+
+        It 'body with sentinel alongside a valid v4 block still reports exactly 1 marker' {
+            # Sentinel plus a real v4 block: marker count must remain 1 (M21).
+            $bodyFile = & $script:TempBodyFile
+            try {
+                $result = & $script:InvokeScript `
+                    -BodyFile $bodyFile `
+                    -V3BaseYaml $script:ValidV3Base `
+                    -Credits @($script:ValidCredit)
+
+                $result.ExitCode | Should -Be 0
+
+                # Append sentinel and re-validate.
+                $bodyWithBoth = $result.BodyContent + "`n`n$($script:SentinelToken)"
+                $testResult = Test-PipelineMetricsV4Block -PRBody $bodyWithBoth
+                $testResult.DetectedMarkerCount | Should -Be 1
+            } finally {
+                Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'M7 - v3-base containing pipeline-metrics opener causes builder throw then sentinel' {
+
+        It 'emits sentinel when V3BaseYaml contains the pipeline-metrics opener' {
+            # Injecting a pipeline-metrics opener into V3BaseYaml causes
+            # New-PipelineMetricsV4Block to throw its double-wrap guard.
+            $poisonedBase = "pr_number: 42`n<!-- pipeline-metrics`nsome_field: value`n-->"
+            $bodyFile = & $script:TempBodyFile
+            try {
+                $result = & $script:InvokeScript `
+                    -BodyFile $bodyFile `
+                    -V3BaseYaml $poisonedBase `
+                    -Credits @($script:ValidCredit)
+
+                $result.ExitCode    | Should -Not -Be 0
+                $result.BodyContent | Should -Match $script:SentinelRegex
+            } finally {
+                Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
+++ b/.github/scripts/Tests/emit-pipeline-metrics-v4.Tests.ps1
@@ -242,6 +242,9 @@ Describe 'emit-pipeline-metrics-v4.ps1' {
 
                 $result.ExitCode    | Should -Not -Be 0
                 $result.BodyContent | Should -Match $script:SentinelRegex
+                # The poisoned opener must be absent from the fallback body (CR5):
+                # reusing the poisoned V3BaseYaml would re-ship the double marker.
+                $result.BodyContent | Should -Not -Match '<!--\s*pipeline-metrics'
             } finally {
                 Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
             }
@@ -270,6 +273,37 @@ Describe 'emit-pipeline-metrics-v4.ps1' {
                 $closesIndex  = $result.BodyContent.IndexOf('Closes #769')
                 $metricsIndex = $result.BodyContent.IndexOf('<!-- pipeline-metrics')
                 $closesIndex  | Should -BeLessThan $metricsIndex
+            } finally {
+                Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'fails into the sentinel path when RichBody already contains a v4 pipeline-metrics block (CR3 double-marker guard)' {
+            # A RichBody that already carries its own v4 pipeline-metrics block would,
+            # when composed with the freshly-built v4 block, produce a double-marker
+            # body. Validating the COMPOSED final body (CR3) must catch this and fail
+            # into the sentinel fallback rather than shipping two markers.
+            $richWithMarker = @(
+                '## Summary'
+                ''
+                'Closes #769'
+                ''
+                '<!-- pipeline-metrics'
+                'metrics_version: 4'
+                'pr_number: 42'
+                '-->'
+            ) -join "`n"
+
+            $bodyFile = & $script:TempBodyFile
+            try {
+                $result = & $script:InvokeScript `
+                    -BodyFile   $bodyFile `
+                    -V3BaseYaml $script:ValidV3Base `
+                    -Credits    @($script:ValidCredit) `
+                    -RichBody   $richWithMarker
+
+                $result.ExitCode    | Should -Not -Be 0
+                $result.BodyContent | Should -Match $script:SentinelRegex
             } finally {
                 Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue
             }

--- a/.github/scripts/Tests/frame-credit-ledger-core.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-core.Tests.ps1
@@ -1580,7 +1580,7 @@ Describe 'Compose-MissingMetricsShortCircuitComment (C-Behavior-1: distinct bran
 
     It 'renders missing-marker-specific text (NOT the pre-v4 or parse-error phrasing)' {
         $marker = '<!-- frame-credit-ledger-PR-429 -->'
-        $out = Compose-MissingMetricsShortCircuitComment -MarkerToken $marker
+        $out = Compose-MissingMetricsShortCircuitComment -MarkerToken $marker -IsOrchestrated $true
 
         $out | Should -Not -BeNullOrEmpty
         $out | Should -Match ([regex]::Escape($marker))
@@ -1625,6 +1625,20 @@ Describe 'Compose-MissingMetricsShortCircuitComment — origin-gated taxonomy (i
         $out | Should -Match 'not measured \(non-orchestrated\)'
         $out | Should -Not -Match '🛑'
         $out | Should -Not -Match 'FAILED'
+    }
+}
+
+Describe 'Compose-MissingMetricsShortCircuitComment — default IsOrchestrated is $false (P2-F4 fix)' {
+
+    It 'default call (no -IsOrchestrated arg) renders not-measured (default is now $false)' {
+        $marker = '<!-- frame-credit-ledger-PR-pf4 -->'
+        $result = Compose-MissingMetricsShortCircuitComment -MarkerToken $marker
+
+        $result | Should -Not -BeNullOrEmpty
+        $result | Should -Match ([regex]::Escape($marker))
+        $result | Should -Match 'non-orchestrated'
+        $result | Should -Not -Match '🛑'
+        $result | Should -Not -Match 'FAILED'
     }
 }
 

--- a/.github/scripts/Tests/frame-credit-ledger-core.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-core.Tests.ps1
@@ -1597,6 +1597,38 @@ Describe 'Compose-MissingMetricsShortCircuitComment (C-Behavior-1: distinct bran
 }
 
 # ---------------------------------------------------------------------------
+# Issue #769 — Origin-gated 3-state taxonomy
+# Tests: Compose-MissingMetricsShortCircuitComment renders 🛑 FAILED for
+# orchestrated-origin and "not measured (non-orchestrated)" for non-orchestrated.
+# ---------------------------------------------------------------------------
+Describe 'Compose-MissingMetricsShortCircuitComment — origin-gated taxonomy (issue #769 AC3)' {
+
+    It 'IsOrchestrated=$true renders 🛑 FAILED heading and never "not measured"' {
+        $marker = '<!-- frame-credit-ledger-PR-769 -->'
+        $out = Compose-MissingMetricsShortCircuitComment -MarkerToken $marker -IsOrchestrated $true
+
+        $out | Should -Not -BeNullOrEmpty
+        $out | Should -Match ([regex]::Escape($marker))
+        $out | Should -Match '🛑'
+        $out | Should -Match 'FAILED'
+        $out | Should -Match 'no pipeline-metrics block found'
+        $out | Should -Not -Match 'non-orchestrated'
+        $out | Should -Not -Match 'not measured'
+    }
+
+    It 'IsOrchestrated=$false renders "not measured (non-orchestrated)" and never 🛑 FAILED' {
+        $marker = '<!-- frame-credit-ledger-PR-769 -->'
+        $out = Compose-MissingMetricsShortCircuitComment -MarkerToken $marker -IsOrchestrated $false
+
+        $out | Should -Not -BeNullOrEmpty
+        $out | Should -Match ([regex]::Escape($marker))
+        $out | Should -Match 'not measured \(non-orchestrated\)'
+        $out | Should -Not -Match '🛑'
+        $out | Should -Not -Match 'FAILED'
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Issue #441 Step 3 — v4 extended schema parser tests (RED until GREEN lands)
 # Tests: status:not-persisted, per-port fields, run_index, mode.synthetic-backfill,
 #        and last-wins-by-run_index selection.

--- a/.github/scripts/Tests/frame-credit-ledger-suppress-failed-posts.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-suppress-failed-posts.Tests.ps1
@@ -1,0 +1,224 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Issue #769 — CR7 regression: the FCL_SUPPRESS_FAILED_POSTS off-switch must be
+# honored INSIDE the worker runspace.
+#
+# Background (the bug this guards):
+#   $_suppressFailedPosts was assigned only at top-level script scope (from
+#   $env:FCL_SUPPRESS_FAILED_POSTS). But Invoke-FrameCreditLedger runs inside a
+#   cloned worker runspace (New-FCLInitialSessionStateClone), which carries only
+#   functions + GLOBAL-scope variables + 5 named cost vars. A *script*-scoped
+#   $_suppressFailedPosts is therefore NOT carried into the worker, so the
+#   consumer (`if ($_isOrchestrated -and $_suppressFailedPosts)`) read $null and
+#   the off-switch was dead — a FAILED comment got posted even with the env var
+#   set. The fix recomputes the flag from the (process-global) environment inside
+#   Invoke-FrameCreditLedger, so it survives the runspace boundary.
+#
+# These tests drive the FULL orchestrator in a child pwsh process (so the real
+# worker-runspace dispatch path executes, exactly where the bug lived). They use
+# the same gh-mock + harness pattern as frame-credit-ledger-fail-open.Tests.ps1.
+#
+# IMPORTANT — why upsert state is tracked via a FILE, not a $global: var:
+#   The comment upsert happens INSIDE the cloned worker runspace. A $global:
+#   variable set in the harness is COPIED into the worker's initial session state,
+#   so the worker mutates its OWN copy and the mutation never propagates back to
+#   the harness. A file write, by contrast, crosses the runspace boundary. The
+#   gh mock therefore appends to a probe file (path passed via env var) whenever
+#   it posts/patches a comment; the parent test reads that file to decide whether
+#   a FAILED comment was posted. (This is the same isolation property the CR7 fix
+#   itself relies on for env vars.)
+#
+# Scenario shape (the missing-pipeline-metrics short-circuit, line ~1267):
+#   * orchestrated origin       -> via $env:GITHUB_HEAD_REF = feature/issue-769-*
+#   * PR body with NO metrics    -> $metrics is $null -> FAILED short-circuit path
+#   * FCL_SUPPRESS_FAILED_POSTS  -> toggles whether the FAILED comment is posted
+
+BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:OrchestratorPath = Join-Path $script:RepoRoot '.github/scripts/frame-credit-ledger.ps1'
+
+    # A PR body with NO <!-- pipeline-metrics ... --> block. This drives
+    # Read-PRMetricsBlock to return $null, which enters the missing-metrics
+    # short-circuit where the suppression off-switch is consulted.
+    #
+    # IMPORTANT: this body must NOT contain orchestration body-signals
+    # (issue_id: N / <!-- plan-issue-N -->) so that orchestrated-origin is
+    # determined SOLELY by $env:GITHUB_HEAD_REF in these tests.
+    $script:NoMetricsBody = @'
+## Summary
+
+A PR body with no pipeline-metrics marker block at all.
+'@
+
+    # Harness: invoke the orchestrator in a child pwsh process. The gh mock records
+    # comment posts to a FILE (path injected via $env:CR7_UPSERT_PROBE_FILE) so the
+    # record survives the worker-runspace boundary. The parent reads that file.
+    $script:InvokeOrchestratorWithUpsertProbe = {
+        param(
+            [int]$Pr = 769,
+            [string]$Mode = 'warn',
+            [hashtable]$Env = @{},
+            [int]$TimeoutSeconds = 60,
+            [string]$MockBootstrap = ''
+        )
+
+        $harnessPath = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString('N') + '.harness.ps1')
+        $probeFile = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString('N') + '.upsert-probe.txt')
+
+        # The probe-file path is always injected; merge it with caller env.
+        $effectiveEnv = @{ CR7_UPSERT_PROBE_FILE = $probeFile }
+        foreach ($k in $Env.Keys) { $effectiveEnv[$k] = $Env[$k] }
+
+        $envLines = foreach ($key in $effectiveEnv.Keys) {
+            "`$env:$key = '$($effectiveEnv[$key] -replace "'", "''")'"
+        }
+        $envPrelude = ($envLines -join "`n")
+
+        $harness = @"
+`$ErrorActionPreference = 'Continue'
+$envPrelude
+`$orchestratorPath = '$($script:OrchestratorPath -replace "'", "''")'
+if (-not (Test-Path -LiteralPath `$orchestratorPath -PathType Leaf)) {
+    [Console]::Error.WriteLine("ORCHESTRATOR_NOT_FOUND: `$orchestratorPath")
+    exit 127
+}
+$MockBootstrap
+
+& `$orchestratorPath -Pr $Pr -Mode $Mode
+exit `$LASTEXITCODE
+"@
+        Set-Content -Path $harnessPath -Value $harness -Encoding UTF8
+
+        $stdoutPath = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString('N') + '.stdout.txt')
+        $stderrPath = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString('N') + '.stderr.txt')
+
+        $proc = Start-Process -FilePath 'pwsh' `
+            -ArgumentList @('-NoProfile', '-NonInteractive', '-File', $harnessPath) `
+            -RedirectStandardOutput $stdoutPath `
+            -RedirectStandardError $stderrPath `
+            -PassThru `
+            -WindowStyle Hidden
+
+        $waited = $proc.WaitForExit($TimeoutSeconds * 1000)
+        $probeContent = (Test-Path $probeFile) ? (Get-Content $probeFile -Raw) : ''
+
+        if (-not $waited) {
+            try { $proc.Kill($true) } catch {}
+            return @{
+                ExitCode     = -1
+                Stdout       = (Test-Path $stdoutPath) ? (Get-Content $stdoutPath -Raw) : ''
+                Stderr       = (Test-Path $stderrPath) ? (Get-Content $stderrPath -Raw) : ''
+                TimedOut     = $true
+                UpsertCalled = $false
+                UpsertFailed = $false
+            }
+        }
+
+        return @{
+            ExitCode     = $proc.ExitCode
+            Stdout       = (Test-Path $stdoutPath) ? (Get-Content $stdoutPath -Raw) : ''
+            Stderr       = (Test-Path $stderrPath) ? (Get-Content $stderrPath -Raw) : ''
+            TimedOut     = $false
+            UpsertCalled = (-not [string]::IsNullOrEmpty($probeContent))
+            UpsertFailed = ($probeContent -match 'FAILED')
+        }
+    }
+
+    # gh-mock bootstrap returning a fixed body (no metrics block). Records each
+    # comment POST/PATCH by APPENDING the posted body to the probe file named by
+    # $env:CR7_UPSERT_PROBE_FILE — a file write crosses the worker-runspace
+    # boundary where a $global: variable mutation would not.
+    $script:NewGhMockBootstrap = {
+        param([string]$BodyJson)
+
+        return @"
+function global:gh {
+    param([Parameter(ValueFromRemainingArguments = `$true)]`$Args)
+    `$joined = `$Args -join ' '
+
+    if (`$joined -match 'pr view \d+ --json baseRefOid') {
+        `$global:LASTEXITCODE = 0
+        return '{"baseRefOid":"abc123"}'
+    }
+
+    if (`$joined -match 'pr view \d+ --json body') {
+        `$global:LASTEXITCODE = 0
+        return '$BodyJson'
+    }
+
+    if (`$joined -match '(issue|pr) view \d+ --json comments') {
+        `$global:LASTEXITCODE = 0
+        return '{"comments":[]}'
+    }
+
+    if (`$joined -match 'api repos/') {
+        `$global:LASTEXITCODE = 0
+        return '{"full_name":"example/example"}'
+    }
+
+    if (`$joined -match '(issue|pr) comment \d+ --body') {
+        `$idx = [Array]::IndexOf(`$Args, '--body')
+        `$body = ''
+        if (`$idx -ge 0 -and `$idx + 1 -lt `$Args.Count) { `$body = [string]`$Args[`$idx + 1] }
+        if (`$env:CR7_UPSERT_PROBE_FILE) {
+            Add-Content -LiteralPath `$env:CR7_UPSERT_PROBE_FILE -Value `$body -Encoding UTF8
+        }
+        `$global:LASTEXITCODE = 0
+        return 'https://github.com/example/example/pull/769#issuecomment-1'
+    }
+
+    if (`$joined -match 'api -X PATCH repos/[^/]+/[^/]+/issues/comments/\d+') {
+        if (`$env:CR7_UPSERT_PROBE_FILE) {
+            Add-Content -LiteralPath `$env:CR7_UPSERT_PROBE_FILE -Value 'PATCHED' -Encoding UTF8
+        }
+        `$global:LASTEXITCODE = 0
+        return '{"html_url":"https://github.com/example/example/pull/769#issuecomment-2"}'
+    }
+
+    `$global:LASTEXITCODE = 0
+    return ''
+}
+"@
+    }
+}
+
+Describe 'frame-credit-ledger FCL_SUPPRESS_FAILED_POSTS off-switch (issue #769 CR7)' {
+
+    Context 'orchestrated-origin PR with a missing pipeline-metrics block' {
+
+        It 'does NOT post a FAILED comment when FCL_SUPPRESS_FAILED_POSTS=1 (suppression honored inside the worker runspace)' {
+            $bodyJson = (@{ body = $script:NoMetricsBody } | ConvertTo-Json -Compress)
+            $bootstrap = & $script:NewGhMockBootstrap -BodyJson $bodyJson
+
+            $result = & $script:InvokeOrchestratorWithUpsertProbe `
+                -Pr 769 -Mode 'warn' `
+                -Env @{
+                    FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'
+                    GITHUB_HEAD_REF                   = 'feature/issue-769-v4-emission-reliability'
+                    FCL_SUPPRESS_FAILED_POSTS         = '1'
+                } `
+                -MockBootstrap $bootstrap
+
+            $result.ExitCode | Should -Be 0 -Because 'warn-mode invariant: a missing metrics block must not block PR creation'
+            $result.UpsertCalled | Should -BeFalse -Because 'CR7: with FCL_SUPPRESS_FAILED_POSTS=1, the FAILED post is suppressed even inside the worker runspace (the flag must be recomputed from the env inside Invoke-FrameCreditLedger)'
+        }
+
+        It 'DOES post a FAILED comment when FCL_SUPPRESS_FAILED_POSTS is unset (control: proves the test exercises the FAILED path)' {
+            $bodyJson = (@{ body = $script:NoMetricsBody } | ConvertTo-Json -Compress)
+            $bootstrap = & $script:NewGhMockBootstrap -BodyJson $bodyJson
+
+            $result = & $script:InvokeOrchestratorWithUpsertProbe `
+                -Pr 769 -Mode 'warn' `
+                -Env @{
+                    FRAME_CREDIT_LEDGER_TEST_NO_SLEEP = '1'
+                    GITHUB_HEAD_REF                   = 'feature/issue-769-v4-emission-reliability'
+                } `
+                -MockBootstrap $bootstrap
+
+            $result.ExitCode | Should -Be 0 -Because 'warn-mode invariant: a missing metrics block must not block PR creation'
+            $result.UpsertCalled | Should -BeTrue -Because 'control: an orchestrated-origin PR with no metrics block posts a FAILED comment when the off-switch is not set'
+            $result.UpsertFailed | Should -BeTrue -Because 'control: the posted comment is the orchestrated FAILED short-circuit notice'
+        }
+    }
+}

--- a/.github/scripts/Tests/naming-register-policy.Tests.ps1
+++ b/.github/scripts/Tests/naming-register-policy.Tests.ps1
@@ -115,14 +115,14 @@ Describe "Register: bidirectional binding to vocab-seed" {
         }
     }
 
-    It "vocab-seed contains exactly 48 data rows" {
-        $extractedTerms.Count | Should -Be 48
+    It "vocab-seed contains exactly 50 data rows" {
+        $extractedTerms.Count | Should -Be 50
     }
 
     It "every vocab-seed term has a register entry" {
         $registerTerms = @($register | Select-Object -ExpandProperty term)
         $missing = $extractedTerms | Where-Object { $registerTerms -notcontains $_ }
-        $missing | Should -BeNullOrEmpty -Because "all 48 vocab-seed terms must have register entries; missing: $($missing -join ', ')"
+        $missing | Should -BeNullOrEmpty -Because "all 50 vocab-seed terms must have register entries; missing: $($missing -join ', ')"
     }
 
     It "register has no terms absent from vocab-seed (no orphan entries)" {
@@ -130,8 +130,8 @@ Describe "Register: bidirectional binding to vocab-seed" {
         $missing | Should -BeNullOrEmpty -Because "register must not contain terms absent from vocab-seed; orphans: $($missing -join ', ')"
     }
 
-    It "register entry count matches vocab-seed term count (48)" {
-        $register | Should -HaveCount 48
+    It "register entry count matches vocab-seed term count (50)" {
+        $register | Should -HaveCount 50
     }
 }
 

--- a/.github/scripts/Tests/script-safety-contract.Tests.ps1
+++ b/.github/scripts/Tests/script-safety-contract.Tests.ps1
@@ -85,6 +85,7 @@ Describe 'script safety contract' {
                 # cost-integration.Tests.ps1 — CONVERTED in s5: all spawn-based Its now use InvokeOrchestratorInProcess (in-process pattern)
                 'frame-credit-ledger-fail-open.Tests.ps1',          # IRREDUCIBLE: 9 exit-code-contract Its that require subprocess to verify exit codes
                 'frame-credit-ledger-orchestrator.Tests.ps1',       # kept 9 real-spawn smoke layer per s2 decision
+                'frame-credit-ledger-suppress-failed-posts.Tests.ps1', # IRREDUCIBLE (#769 CR7): the off-switch bug lives in the cloned worker runspace; only a real subprocess exercises the runspace-isolation path an in-process dot-source call would mask
                 'frame-spine-core.Tests.ps1',                       # IRREDUCIBLE: 1 spawn tests -CommentBodyStdin CLI switch (stdin-pipe contract; cannot simulate in-process without production code changes)
                 'get-issue-drift.Tests.ps1',                        # IRREDUCIBLE: 1 spawn tests get-issue-drift.ps1 wrapper CLI surface (JSON output shape of the wrapper script)
                 'hub-artifact-paths-coverage.Tests.ps1',            # CLI integration tests: exercises -Diff mode against live repo; requires sub-process invocation

--- a/.github/scripts/emit-pipeline-metrics-v4.ps1
+++ b/.github/scripts/emit-pipeline-metrics-v4.ps1
@@ -4,32 +4,21 @@
     Emit a canonical v4 pipeline-metrics PR body (issue #769 s2).
 
 .DESCRIPTION
-    Builds a complete PR body containing the v4 <!-- pipeline-metrics --> block
-    and writes it to -BodyFile.  Called BEFORE gh pr create with the output
-    path as the --body-file argument.
+    Thin CLI wrapper. Dot-sources lib/emit-pipeline-metrics-v4-core.ps1 and calls
+    Invoke-PipelineMetricsV4Emit, then translates the returned ExitCode to a
+    process exit code. All logic lives in the core library so tests can dot-source
+    it and call the function in-process (the #257 script-safety contract forbids
+    spawning a child pwsh per test).
 
-    Three outcome cases (M5):
-      Case 1 — New-PipelineMetricsV4Block throws (empty/invalid -V3BaseYaml,
-                or pre-existing v4 block): writes fallback body with
-                <!-- cost-capture-failed --> sentinel, exits non-zero.
-      Case 2 — Block built but Test-PipelineMetricsV4Block reports invalid
-                (empty credits, ≠1 marker): writes fallback body with sentinel,
-                exits non-zero.
-      Case 3 — Success: writes full body, exits 0.
-
-    Critical invariants (M8, M21):
-      - The <!-- cost-capture-failed --> sentinel is written in the catch block
-        and guarded in finally so any abnormal exit also ships it.
-      - The sentinel token does NOT match <!--\s*pipeline-metrics.
-      - The sentinel, when present, does not inflate the pipeline-metrics
-        marker count inside Test-PipelineMetricsV4Block.
+    Called BEFORE gh pr create with the output path as the --body-file argument.
+    See lib/emit-pipeline-metrics-v4-core.ps1 for the three outcome cases (M5)
+    and the M8/M21 sentinel invariants.
 
 .PARAMETER BodyFile
     Path to write the completed PR body file.
 
 .PARAMETER V3BaseYaml
     v3 base fields as plain YAML (no pipeline-metrics wrapper).
-    Required for New-PipelineMetricsV4Block to succeed.
 
 .PARAMETER Credits
     Array of credit-row pscustomobjects from the frame accumulator.
@@ -38,19 +27,15 @@
     Array of dispatch-cost-sample pscustomobjects.
 
 .PARAMETER IssueNumber
-    Issue number forwarded to the s-acc harvest hook.  When > 0 and Credits
-    is empty, s-acc will inject a Get-FCLAccumulatedCredits harvest call here.
-    This script does NOT implement the harvest — the parameter reserves the
-    injection point.
+    When > 0 and Credits is empty, harvest credits from the s-acc file-based
+    accumulator (.tmp/issue-{N}/fclcredits.jsonl).
 
 .PARAMETER RichBody
     Optional full markdown PR body already composed by the conductor (summary,
-    changed files, Closes #N, review table, etc.).  When provided, the v4 block
-    is appended to this rich body so the final file contains both the human-
-    readable PR content AND the metrics block.  When omitted, the script writes
-    only the v4 block (backwards-compatible behaviour for unit tests).
-    On failure the rich body is still written followed by the sentinel so
-    Closes #N always survives in the shipped PR body.
+    changed files, Closes #N, review table, etc.). When provided, the v4 block is
+    appended to it so the final file contains both the human-readable PR content
+    AND the metrics block. On failure the rich body is still written followed by
+    the sentinel so Closes #N always survives in the shipped PR body.
 #>
 [CmdletBinding()]
 param(
@@ -62,99 +47,14 @@ param(
     [string]$RichBody = ''
 )
 
-$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib/emit-pipeline-metrics-v4-core.ps1')
 
-# Track whether the sentinel has already been written so the finally block
-# does not duplicate it on the normal-success path.
-$script:sentinelWritten = $false
+$result = Invoke-PipelineMetricsV4Emit `
+    -BodyFile $BodyFile `
+    -V3BaseYaml $V3BaseYaml `
+    -Credits $Credits `
+    -DispatchCostSamples $DispatchCostSamples `
+    -IssueNumber $IssueNumber `
+    -RichBody $RichBody
 
-# ---------------------------------------------------------------------------
-# Library dot-sources
-# ---------------------------------------------------------------------------
-$coreScript = Join-Path $PSScriptRoot 'lib/frame-credit-ledger-core.ps1'
-. $coreScript
-
-$originScript = Join-Path $PSScriptRoot 'lib/Get-FCLOriginContext.ps1'
-. $originScript
-
-# ---------------------------------------------------------------------------
-# Main body
-# ---------------------------------------------------------------------------
-try {
-    # s-acc: harvest from file-based accumulator when Credits not provided
-    if ($IssueNumber -gt 0 -and $Credits.Count -eq 0) {
-        $accScript = Join-Path $PSScriptRoot 'lib/Get-FCLAccumulatedCredits.ps1'
-        if (Test-Path -LiteralPath $accScript) {
-            . $accScript
-            $Credits = @(Get-FCLAccumulatedCredits -IssueNumber $IssueNumber)
-        } else {
-            Write-Warning "harvest script not found at $accScript — proceeding with explicitly-passed credits only"
-        }
-    }
-
-    # Build v4 block (Case 1 throw surface: empty V3BaseYaml or pre-existing v4)
-    $v4Body = New-PipelineMetricsV4Block `
-        -V3BaseYaml $V3BaseYaml `
-        -Credits $Credits `
-        -DispatchCostSamples $DispatchCostSamples
-
-    # Validate (Case 2 surface: empty credits or ≠1 marker)
-    $testResult = Test-PipelineMetricsV4Block -PRBody $v4Body
-    if (-not $testResult.Valid) {
-        throw "Test-PipelineMetricsV4Block validation failed: $($testResult.FailureReason)"
-    }
-
-    # Case 3 — success: compose final body (rich content + v4 block)
-    $finalBody = if ([string]::IsNullOrWhiteSpace($RichBody)) {
-        $v4Body  # backwards-compat: no rich body passed
-    } else {
-        "$RichBody`n`n$v4Body"
-    }
-
-    $script:sentinelWritten = $true
-    Set-Content -Path $BodyFile -Value $finalBody -Encoding utf8NoBOM
-    exit 0
-}
-catch {
-    # Case 1 or 2: write fallback body + sentinel
-    $fallbackBase = if ([string]::IsNullOrWhiteSpace($RichBody)) {
-        if (-not [string]::IsNullOrWhiteSpace($V3BaseYaml)) {
-            $V3BaseYaml
-        } else {
-            'metrics_emission_failed: true'
-        }
-    } else {
-        $RichBody
-    }
-    $fallbackBody = "$fallbackBase`n`n<!-- cost-capture-failed -->"
-
-    Set-Content -Path $BodyFile -Value $fallbackBody -Encoding utf8NoBOM
-    $script:sentinelWritten = $true
-
-    Write-Error "emit-pipeline-metrics-v4.ps1 failed: $_"
-    exit 1
-}
-finally {
-    # Sentinel durability guard: catches abnormal exits that occur between
-    # try-start and catch (rare in PS7 but guard it per M8).
-    # Only writes the sentinel when:
-    #   - It was not already written by the catch block, AND
-    #   - The body file exists (i.e. a partial write landed), AND
-    #   - The sentinel is not already present in the file content.
-    if (-not $script:sentinelWritten -and (Test-Path -LiteralPath $BodyFile)) {
-        try {
-            $existing = Get-Content -LiteralPath $BodyFile -Raw
-            if ($existing -notmatch [regex]::Escape('<!-- cost-capture-failed -->')) {
-                # Content present but no sentinel and not a clean success exit —
-                # append sentinel to mark the body as unreliable.
-                $existing += "`n`n<!-- cost-capture-failed -->"
-                Set-Content -Path $BodyFile -Value $existing -Encoding utf8NoBOM
-            }
-        }
-        catch {
-            # Best-effort: if we cannot read/write the file, emit a warning and
-            # let the caller detect the missing sentinel via the non-zero exit.
-            Write-Warning "emit-pipeline-metrics-v4.ps1 finally: could not write sentinel — $_"
-        }
-    }
-}
+exit $result.ExitCode

--- a/.github/scripts/emit-pipeline-metrics-v4.ps1
+++ b/.github/scripts/emit-pipeline-metrics-v4.ps1
@@ -42,6 +42,15 @@
     is empty, s-acc will inject a Get-FCLAccumulatedCredits harvest call here.
     This script does NOT implement the harvest — the parameter reserves the
     injection point.
+
+.PARAMETER RichBody
+    Optional full markdown PR body already composed by the conductor (summary,
+    changed files, Closes #N, review table, etc.).  When provided, the v4 block
+    is appended to this rich body so the final file contains both the human-
+    readable PR content AND the metrics block.  When omitted, the script writes
+    only the v4 block (backwards-compatible behaviour for unit tests).
+    On failure the rich body is still written followed by the sentinel so
+    Closes #N always survives in the shipped PR body.
 #>
 [CmdletBinding()]
 param(
@@ -49,7 +58,8 @@ param(
     [string]$V3BaseYaml = '',
     [pscustomobject[]]$Credits = @(),
     [pscustomobject[]]$DispatchCostSamples = @(),
-    [int]$IssueNumber = 0
+    [int]$IssueNumber = 0,
+    [string]$RichBody = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -77,6 +87,8 @@ try {
         if (Test-Path -LiteralPath $accScript) {
             . $accScript
             $Credits = @(Get-FCLAccumulatedCredits -IssueNumber $IssueNumber)
+        } else {
+            Write-Warning "harvest script not found at $accScript — proceeding with explicitly-passed credits only"
         }
     }
 
@@ -92,19 +104,29 @@ try {
         throw "Test-PipelineMetricsV4Block validation failed: $($testResult.FailureReason)"
     }
 
-    # Case 3 — success; mark sentinel as "not needed" so finally does not append it.
+    # Case 3 — success: compose final body (rich content + v4 block)
+    $finalBody = if ([string]::IsNullOrWhiteSpace($RichBody)) {
+        $v4Body  # backwards-compat: no rich body passed
+    } else {
+        "$RichBody`n`n$v4Body"
+    }
+
     $script:sentinelWritten = $true
-    Set-Content -Path $BodyFile -Value $v4Body -Encoding utf8NoBOM
+    Set-Content -Path $BodyFile -Value $finalBody -Encoding utf8NoBOM
     exit 0
 }
 catch {
     # Case 1 or 2: write fallback body + sentinel
-    $fallbackBody = if (-not [string]::IsNullOrWhiteSpace($V3BaseYaml)) {
-        $V3BaseYaml
+    $fallbackBase = if ([string]::IsNullOrWhiteSpace($RichBody)) {
+        if (-not [string]::IsNullOrWhiteSpace($V3BaseYaml)) {
+            $V3BaseYaml
+        } else {
+            'metrics_emission_failed: true'
+        }
     } else {
-        'metrics_emission_failed: true'
+        $RichBody
     }
-    $fallbackBody += "`n`n<!-- cost-capture-failed -->"
+    $fallbackBody = "$fallbackBase`n`n<!-- cost-capture-failed -->"
 
     Set-Content -Path $BodyFile -Value $fallbackBody -Encoding utf8NoBOM
     $script:sentinelWritten = $true

--- a/.github/scripts/emit-pipeline-metrics-v4.ps1
+++ b/.github/scripts/emit-pipeline-metrics-v4.ps1
@@ -1,0 +1,132 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Emit a canonical v4 pipeline-metrics PR body (issue #769 s2).
+
+.DESCRIPTION
+    Builds a complete PR body containing the v4 <!-- pipeline-metrics --> block
+    and writes it to -BodyFile.  Called BEFORE gh pr create with the output
+    path as the --body-file argument.
+
+    Three outcome cases (M5):
+      Case 1 — New-PipelineMetricsV4Block throws (empty/invalid -V3BaseYaml,
+                or pre-existing v4 block): writes fallback body with
+                <!-- cost-capture-failed --> sentinel, exits non-zero.
+      Case 2 — Block built but Test-PipelineMetricsV4Block reports invalid
+                (empty credits, ≠1 marker): writes fallback body with sentinel,
+                exits non-zero.
+      Case 3 — Success: writes full body, exits 0.
+
+    Critical invariants (M8, M21):
+      - The <!-- cost-capture-failed --> sentinel is written in the catch block
+        and guarded in finally so any abnormal exit also ships it.
+      - The sentinel token does NOT match <!--\s*pipeline-metrics.
+      - The sentinel, when present, does not inflate the pipeline-metrics
+        marker count inside Test-PipelineMetricsV4Block.
+
+.PARAMETER BodyFile
+    Path to write the completed PR body file.
+
+.PARAMETER V3BaseYaml
+    v3 base fields as plain YAML (no pipeline-metrics wrapper).
+    Required for New-PipelineMetricsV4Block to succeed.
+
+.PARAMETER Credits
+    Array of credit-row pscustomobjects from the frame accumulator.
+
+.PARAMETER DispatchCostSamples
+    Array of dispatch-cost-sample pscustomobjects.
+
+.PARAMETER IssueNumber
+    Issue number forwarded to the s-acc harvest hook.  When > 0 and Credits
+    is empty, s-acc will inject a Get-FCLAccumulatedCredits harvest call here.
+    This script does NOT implement the harvest — the parameter reserves the
+    injection point.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$BodyFile,
+    [string]$V3BaseYaml = '',
+    [pscustomobject[]]$Credits = @(),
+    [pscustomobject[]]$DispatchCostSamples = @(),
+    [int]$IssueNumber = 0
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Track whether the sentinel has already been written so the finally block
+# does not duplicate it on the normal-success path.
+$script:sentinelWritten = $false
+
+# ---------------------------------------------------------------------------
+# Library dot-sources
+# ---------------------------------------------------------------------------
+$coreScript = Join-Path $PSScriptRoot 'lib/frame-credit-ledger-core.ps1'
+. $coreScript
+
+$originScript = Join-Path $PSScriptRoot 'lib/Get-FCLOriginContext.ps1'
+. $originScript
+
+# ---------------------------------------------------------------------------
+# Main body
+# ---------------------------------------------------------------------------
+try {
+    # s-acc: harvest from Get-FCLAccumulatedCredits here (when IssueNumber > 0 and Credits empty)
+    # (s-acc will inject: if ($IssueNumber -gt 0 -and $Credits.Count -eq 0) { ... })
+
+    # Build v4 block (Case 1 throw surface: empty V3BaseYaml or pre-existing v4)
+    $v4Body = New-PipelineMetricsV4Block `
+        -V3BaseYaml $V3BaseYaml `
+        -Credits $Credits `
+        -DispatchCostSamples $DispatchCostSamples
+
+    # Validate (Case 2 surface: empty credits or ≠1 marker)
+    $testResult = Test-PipelineMetricsV4Block -PRBody $v4Body
+    if (-not $testResult.Valid) {
+        throw "Test-PipelineMetricsV4Block validation failed: $($testResult.FailureReason)"
+    }
+
+    # Case 3 — success; mark sentinel as "not needed" so finally does not append it.
+    $script:sentinelWritten = $true
+    Set-Content -Path $BodyFile -Value $v4Body -Encoding utf8NoBOM
+    exit 0
+}
+catch {
+    # Case 1 or 2: write fallback body + sentinel
+    $fallbackBody = if (-not [string]::IsNullOrWhiteSpace($V3BaseYaml)) {
+        $V3BaseYaml
+    } else {
+        'metrics_emission_failed: true'
+    }
+    $fallbackBody += "`n`n<!-- cost-capture-failed -->"
+
+    Set-Content -Path $BodyFile -Value $fallbackBody -Encoding utf8NoBOM
+    $script:sentinelWritten = $true
+
+    Write-Error "emit-pipeline-metrics-v4.ps1 failed: $_"
+    exit 1
+}
+finally {
+    # Sentinel durability guard: catches abnormal exits that occur between
+    # try-start and catch (rare in PS7 but guard it per M8).
+    # Only writes the sentinel when:
+    #   - It was not already written by the catch block, AND
+    #   - The body file exists (i.e. a partial write landed), AND
+    #   - The sentinel is not already present in the file content.
+    if (-not $script:sentinelWritten -and (Test-Path -LiteralPath $BodyFile)) {
+        try {
+            $existing = Get-Content -LiteralPath $BodyFile -Raw
+            if ($existing -notmatch [regex]::Escape('<!-- cost-capture-failed -->')) {
+                # Content present but no sentinel and not a clean success exit —
+                # append sentinel to mark the body as unreliable.
+                $existing += "`n`n<!-- cost-capture-failed -->"
+                Set-Content -Path $BodyFile -Value $existing -Encoding utf8NoBOM
+            }
+        }
+        catch {
+            # Best-effort: if we cannot read/write the file, emit a warning and
+            # let the caller detect the missing sentinel via the non-zero exit.
+            Write-Warning "emit-pipeline-metrics-v4.ps1 finally: could not write sentinel — $_"
+        }
+    }
+}

--- a/.github/scripts/emit-pipeline-metrics-v4.ps1
+++ b/.github/scripts/emit-pipeline-metrics-v4.ps1
@@ -71,8 +71,14 @@ $originScript = Join-Path $PSScriptRoot 'lib/Get-FCLOriginContext.ps1'
 # Main body
 # ---------------------------------------------------------------------------
 try {
-    # s-acc: harvest from Get-FCLAccumulatedCredits here (when IssueNumber > 0 and Credits empty)
-    # (s-acc will inject: if ($IssueNumber -gt 0 -and $Credits.Count -eq 0) { ... })
+    # s-acc: harvest from file-based accumulator when Credits not provided
+    if ($IssueNumber -gt 0 -and $Credits.Count -eq 0) {
+        $accScript = Join-Path $PSScriptRoot 'lib/Get-FCLAccumulatedCredits.ps1'
+        if (Test-Path -LiteralPath $accScript) {
+            . $accScript
+            $Credits = @(Get-FCLAccumulatedCredits -IssueNumber $IssueNumber)
+        }
+    }
 
     # Build v4 block (Case 1 throw surface: empty V3BaseYaml or pre-existing v4)
     $v4Body = New-PipelineMetricsV4Block `

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -80,6 +80,16 @@ catch {
     $script:CostLibLoadFailed = $true
 }
 
+# Origin predicate dot-source (CI-safe; fail-open: if absent, $_isOrchestrated defaults to $false)
+$_originPredicatePath = Join-Path $PSScriptRoot 'lib/Get-FCLOriginContext.ps1'
+if (Test-Path $_originPredicatePath) {
+    . $_originPredicatePath
+}
+
+# Off-switch: suppress only FAILED-state posts by default.
+# Set $env:FCL_SUPPRESS_FAILED_POSTS=1 to activate.
+$_suppressFailedPosts = ($env:FCL_SUPPRESS_FAILED_POSTS -eq '1')
+
 # ---------------------------------------------------------------------------
 # Read a single scalar field from an adapter's frontmatter block.
 # ---------------------------------------------------------------------------
@@ -1234,6 +1244,18 @@ function Invoke-FrameCreditLedger {
     # 3. Parse pipeline-metrics block.
     $metrics = Read-PRMetricsBlock -PrBody $prBody
 
+    # 3a. Compute orchestrated-origin context using the CI-safe predicate (s1).
+    # PRIMARY: $env:GITHUB_HEAD_REF (populated on pull_request events; never 'HEAD').
+    # FALLBACK: PR body linked-issue signals.
+    # If Get-FCLOriginContext is unavailable (predicate not dot-sourced), default
+    # to $false — safe: fails quiet, never produces false-FAILED posts.
+    $_isOrchestrated = $false
+    if (Get-Command 'Get-FCLOriginContext' -ErrorAction SilentlyContinue) {
+        $_prHeadRef = $env:GITHUB_HEAD_REF
+        $_originCtx = Get-FCLOriginContext -HeadRef $_prHeadRef -PrBody $prBody
+        $_isOrchestrated = [bool]$_originCtx.IsOrchestratedOrigin
+    }
+
     # 4. Non-v4 short-circuit. Read-PRMetricsBlock returns one of three
     # non-v4 shapes that we must distinguish so the posted comment is
     # honest about what actually happened:
@@ -1243,12 +1265,20 @@ function Invoke-FrameCreditLedger {
     # Any other non-4 shape we have not seen before falls through to the
     # pre-v4 comment as a conservative default.
     if ($null -eq $metrics) {
-        $comment = Compose-MissingMetricsShortCircuitComment -MarkerToken $marker
-        try {
-            $null = Find-OrUpsertComment -Type 'pr' -Number $Pr -Marker $marker -Body $comment
+        # Taxonomy decision: FAILED only for orchestrated-origin; quiet for non-orchestrated.
+        $comment = Compose-MissingMetricsShortCircuitComment -MarkerToken $marker -IsOrchestrated $_isOrchestrated
+        # FAILED-state posts are gated by off-switch; non-orchestrated posts always fire.
+        $postComment = $true
+        if ($_isOrchestrated -and $_suppressFailedPosts) {
+            $postComment = $false
         }
-        catch {
-            [Console]::Error.WriteLine("frame-credit-ledger: upsert failed: $($_.Exception.Message)")
+        if ($postComment) {
+            try {
+                $null = Find-OrUpsertComment -Type 'pr' -Number $Pr -Marker $marker -Body $comment
+            }
+            catch {
+                [Console]::Error.WriteLine("frame-credit-ledger: upsert failed: $($_.Exception.Message)")
+            }
         }
 
         return @{

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -80,10 +80,22 @@ catch {
     $script:CostLibLoadFailed = $true
 }
 
-# Origin predicate dot-source (CI-safe; fail-open: if absent, $_isOrchestrated defaults to $false)
-$_originPredicatePath = Join-Path $PSScriptRoot 'lib/Get-FCLOriginContext.ps1'
-if (Test-Path $_originPredicatePath) {
-    . $_originPredicatePath
+# Origin predicate dot-source (CI-safe; fail-open: if absent OR malformed,
+# $_isOrchestrated defaults to $false at the consumer site via the
+# Get-Command guard). Wrapped in the same fail-open try/catch as the sibling
+# library loaders above: a present-but-malformed Get-FCLOriginContext.ps1 would
+# otherwise throw at parse/load time and abort the script BEFORE the warn-mode
+# exit 0 fail-open path, defeating the warn-only contract.
+try {
+    $_originPredicatePath = Join-Path $PSScriptRoot 'lib/Get-FCLOriginContext.ps1'
+    if (Test-Path $_originPredicatePath) {
+        . $_originPredicatePath
+    }
+}
+catch {
+    [Console]::Error.WriteLine("frame-credit-ledger: origin predicate load failed (orchestrated-origin detection disabled): $($_.Exception.Message)")
+    # Non-fatal: leave Get-FCLOriginContext undefined; the consumer guards the
+    # call with Get-Command and defaults `$_isOrchestrated = $false`.
 }
 
 # Off-switch: suppress only FAILED-state posts by default.
@@ -1209,6 +1221,16 @@ function Invoke-FrameCreditLedger {
     )
 
     $marker = "<!-- frame-credit-ledger-$Pr -->"
+
+    # Off-switch (worker-runspace safe): recompute from the process environment
+    # INSIDE the function. The top-level $_suppressFailedPosts (set near the lib
+    # dot-sources) is script-scoped and is NOT carried into the cloned worker
+    # runspace by New-FCLInitialSessionStateClone (it copies functions, global
+    # vars, and the 5 named cost vars only). Env vars are process-global and DO
+    # cross the runspace boundary (same mechanism as $env:GITHUB_HEAD_REF below),
+    # so reading the env var here makes the off-switch effective inside the worker.
+    # Truthiness convention matches the top-level assignment: strictly '1'.
+    $_suppressFailedPosts = ($env:FCL_SUPPRESS_FAILED_POSTS -eq '1')
 
     # 1. Resolve baseRefOid (best-effort; failure is non-fatal in warn mode).
     $baseRefOid = Get-FrameCreditLedgerBaseRefOid -Pr $Pr

--- a/.github/scripts/lib/Add-FCLCreditRow.ps1
+++ b/.github/scripts/lib/Add-FCLCreditRow.ps1
@@ -21,7 +21,7 @@
 function Add-FCLCreditRow {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][int]$IssueNumber,
+        [Parameter(Mandatory)][ValidateRange(1, [int]::MaxValue)][int]$IssueNumber,
         [Parameter(Mandatory)][pscustomobject]$CreditRow
     )
 

--- a/.github/scripts/lib/Add-FCLCreditRow.ps1
+++ b/.github/scripts/lib/Add-FCLCreditRow.ps1
@@ -1,0 +1,35 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Add-FCLCreditRow — appends a credit row to the file-based accumulator.
+
+.DESCRIPTION
+    Appends the JSON-serialized credit row to .tmp/issue-{N}/fclcredits.jsonl,
+    creating the directory if needed. The file is the authoritative in-flight
+    accumulator for emit-pipeline-metrics-v4.ps1.
+
+    Path resolution: this script lives at .github/scripts/lib/, so the repo
+    root is three levels up ($PSScriptRoot/../../..). The accumulator file is
+    at <repo-root>/.tmp/issue-{N}/fclcredits.jsonl.
+
+.PARAMETER IssueNumber
+    The GitHub issue number associated with the current work session.
+
+.PARAMETER CreditRow
+    A pscustomobject credit row as returned by Build-*CreditRow builders.
+#>
+function Add-FCLCreditRow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$IssueNumber,
+        [Parameter(Mandatory)][pscustomobject]$CreditRow
+    )
+
+    # .github/scripts/lib is 3 levels from repo root
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $dir = Join-Path $repoRoot ".tmp/issue-$IssueNumber"
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    $file = Join-Path $dir 'fclcredits.jsonl'
+    $json = $CreditRow | ConvertTo-Json -Compress -Depth 10
+    Add-Content -Path $file -Value $json -Encoding utf8NoBOM
+}

--- a/.github/scripts/lib/Get-FCLAccumulatedCredits.ps1
+++ b/.github/scripts/lib/Get-FCLAccumulatedCredits.ps1
@@ -7,12 +7,18 @@
     Returns the deserialized credit rows from .tmp/issue-{N}/fclcredits.jsonl.
     Returns an empty array when the file does not exist (fail-open behavior).
 
+    Malformed JSONL lines are skipped with a warning rather than aborting the
+    run (B4b fix: corrupt accumulator line does not poison the whole session).
+
+    Always returns an array type — never $null or a scalar (B5 fix).
+
     Path resolution: this script lives at .github/scripts/lib/, so the repo
     root is three levels up ($PSScriptRoot/../../..). The accumulator file is
     at <repo-root>/.tmp/issue-{N}/fclcredits.jsonl.
 
 .PARAMETER IssueNumber
     The GitHub issue number associated with the current work session.
+    Must be >= 1.
 
 .OUTPUTS
     [pscustomobject[]] — zero or more credit row objects in append order.
@@ -21,7 +27,7 @@ function Get-FCLAccumulatedCredits {
     [CmdletBinding()]
     [OutputType([pscustomobject[]])]
     param(
-        [Parameter(Mandatory)][int]$IssueNumber
+        [Parameter(Mandatory)][ValidateRange(1, [int]::MaxValue)][int]$IssueNumber
     )
 
     # .github/scripts/lib is 3 levels from repo root
@@ -32,5 +38,14 @@ function Get-FCLAccumulatedCredits {
         return @()
     }
 
-    return Get-Content -Path $file | ForEach-Object { $_ | ConvertFrom-Json }
+    $rows = [System.Collections.Generic.List[object]]::new()
+    foreach ($line in (Get-Content -Path $file)) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        try {
+            $rows.Add(($line | ConvertFrom-Json))
+        } catch {
+            Write-Warning "Get-FCLAccumulatedCredits: skipping malformed JSONL row: $_"
+        }
+    }
+    return @($rows)
 }

--- a/.github/scripts/lib/Get-FCLAccumulatedCredits.ps1
+++ b/.github/scripts/lib/Get-FCLAccumulatedCredits.ps1
@@ -1,0 +1,36 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Get-FCLAccumulatedCredits — reads all credit rows from the file-based accumulator.
+
+.DESCRIPTION
+    Returns the deserialized credit rows from .tmp/issue-{N}/fclcredits.jsonl.
+    Returns an empty array when the file does not exist (fail-open behavior).
+
+    Path resolution: this script lives at .github/scripts/lib/, so the repo
+    root is three levels up ($PSScriptRoot/../../..). The accumulator file is
+    at <repo-root>/.tmp/issue-{N}/fclcredits.jsonl.
+
+.PARAMETER IssueNumber
+    The GitHub issue number associated with the current work session.
+
+.OUTPUTS
+    [pscustomobject[]] — zero or more credit row objects in append order.
+#>
+function Get-FCLAccumulatedCredits {
+    [CmdletBinding()]
+    [OutputType([pscustomobject[]])]
+    param(
+        [Parameter(Mandatory)][int]$IssueNumber
+    )
+
+    # .github/scripts/lib is 3 levels from repo root
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $file = Join-Path $repoRoot ".tmp/issue-$IssueNumber/fclcredits.jsonl"
+
+    if (-not (Test-Path -LiteralPath $file)) {
+        return @()
+    }
+
+    return Get-Content -Path $file | ForEach-Object { $_ | ConvertFrom-Json }
+}

--- a/.github/scripts/lib/Get-FCLOriginContext.ps1
+++ b/.github/scripts/lib/Get-FCLOriginContext.ps1
@@ -15,7 +15,7 @@
 #             frame-credit-ledger.ps1:469-484 (Resolve-FCLLinkedIssueNumber
 #             body leg), but exposed as a public function importable by
 #             external scripts.
-#             Patterns: close/fix/resolve #N, issue_id: N, <!-- plan-issue-N -->
+#             Patterns: issue_id: N, <!-- plan-issue-N --> (close/fix/resolve #N excluded — see B4a)
 #
 # Usage (dot-source and call):
 #   . (Join-Path $PSScriptRoot 'Get-FCLOriginContext.ps1')
@@ -87,16 +87,16 @@ function Get-FCLOriginContext {
     }
 
     # -----------------------------------------------------------------------
-    # FALLBACK: PR body linked-issue signals
-    # Mirrors frame-credit-ledger.ps1:469-484 (Resolve-FCLLinkedIssueNumber
-    # body leg). Patterns in priority order:
-    #   1. close/fix/resolve/ref/references/issue #N (keyword-linked)
-    #   2. issue_id: N
-    #   3. <!-- plan-issue-N --> or <!-- design-issue-N -->
+    # FALLBACK: PR body orchestration-specific signals.
+    # Only patterns that are unambiguous orchestration markers:
+    #   1. issue_id: N — explicit machine-format field in PR body
+    #   2. <!-- plan-issue-N --> or <!-- design-issue-N --> — orchestration comment markers
+    # NOTE: close/fix/resolve/ref #N patterns are intentionally EXCLUDED — these are
+    #   standard GitHub issue-linking prose that any contributor writes and do NOT
+    #   indicate the PR was produced by Agent Orchestra orchestration.
     # -----------------------------------------------------------------------
     if (-not [string]::IsNullOrWhiteSpace($PrBody)) {
         $bodyPatterns = @(
-            '(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|ref(?:s|erences)?|issue)\s+(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#(?<issue>\d+)\b',
             '(?im)^\s*issue_id\s*:\s*(?<issue>\d+)\s*$',
             '(?im)<!--\s*(?:plan|design)-issue-(?<issue>\d+)\s*-->'
         )

--- a/.github/scripts/lib/Get-FCLOriginContext.ps1
+++ b/.github/scripts/lib/Get-FCLOriginContext.ps1
@@ -1,0 +1,127 @@
+#Requires -Version 7.0
+# ===========================================================================
+# Get-FCLOriginContext.ps1 — CI-safe orchestrated-origin predicate
+#
+# Issue: #769 (cost-telemetry v4 emission reliability), slice s1
+#
+# Determines whether a PR is "orchestrated-origin" using CI-safe signals:
+#   PRIMARY:  $env:GITHUB_HEAD_REF — populated by GitHub Actions on
+#             pull_request events as the source branch name.
+#             Matched against ^feature/issue-\d+.
+#             NOTE: Do NOT use `git rev-parse --abbrev-ref HEAD` — in CI
+#             detached-HEAD checkouts that yields the literal string "HEAD",
+#             not the branch name (M3 bug in frame-credit-ledger.ps1:1311).
+#   FALLBACK: PR body linked-issue signals — mirrors the body-fallback in
+#             frame-credit-ledger.ps1:469-484 (Resolve-FCLLinkedIssueNumber
+#             body leg), but exposed as a public function importable by
+#             external scripts.
+#             Patterns: close/fix/resolve #N, issue_id: N, <!-- plan-issue-N -->
+#
+# Usage (dot-source and call):
+#   . (Join-Path $PSScriptRoot 'Get-FCLOriginContext.ps1')
+#   $ctx = Get-FCLOriginContext -HeadRef $env:GITHUB_HEAD_REF -PrBody $prBody
+#   if ($ctx.IsOrchestratedOrigin) { ... }
+# ===========================================================================
+
+function Get-FCLOriginContext {
+    <#
+    .SYNOPSIS
+        Classifies a PR as orchestrated-origin using CI-safe signals.
+
+    .DESCRIPTION
+        Returns a [pscustomobject] with three properties:
+          IsOrchestratedOrigin [bool]   — true when the PR is feature/issue-* origin
+          LinkedIssueNumber    [int?]   — the issue number if resolved; $null otherwise
+          DetectionMethod      [string] — 'branch' | 'body' | 'none'
+
+        Signal priority:
+          1. HeadRef matching ^feature/issue-(\d+) → DetectionMethod='branch'
+             The literal string 'HEAD' (detached-HEAD CI checkout) is treated as
+             absent and falls through to the body fallback.
+          2. PrBody containing linked-issue signals → DetectionMethod='body'
+          3. Neither → IsOrchestratedOrigin=$false, DetectionMethod='none'
+
+    .PARAMETER HeadRef
+        The PR source branch name. Pass $env:GITHUB_HEAD_REF in CI, or the
+        branch name directly. Omit or pass $null/$empty to skip branch matching.
+
+    .PARAMETER PrBody
+        The PR body text for fallback linked-issue parsing. Omit or pass
+        $null/$empty to skip body parsing.
+
+    .EXAMPLE
+        # In a GitHub Actions step:
+        $ctx = Get-FCLOriginContext -HeadRef $env:GITHUB_HEAD_REF -PrBody $prBody
+        if (-not $ctx.IsOrchestratedOrigin) {
+            Write-Host "not measured (non-orchestrated)"
+            exit 0
+        }
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [AllowEmptyString()][AllowNull()][string]$HeadRef,
+        [AllowEmptyString()][AllowNull()][string]$PrBody
+    )
+
+    # -----------------------------------------------------------------------
+    # PRIMARY: branch-name match via GITHUB_HEAD_REF
+    # Excludes the literal 'HEAD' string (detached-HEAD CI artifact).
+    # Pattern: ^feature/issue-(\d+) — same convention as Resolve-FCLLinkedIssueNumber.
+    # -----------------------------------------------------------------------
+    $branchPattern = '^feature/issue-(?<issue>\d+)(?:-|$)'
+    if (-not [string]::IsNullOrWhiteSpace($HeadRef) -and $HeadRef -ne 'HEAD') {
+        $branchMatch = [regex]::Match($HeadRef, $branchPattern)
+        if ($branchMatch.Success) {
+            $issueNum = $null
+            $parsed = 0
+            if ([int]::TryParse($branchMatch.Groups['issue'].Value, [ref]$parsed) -and $parsed -gt 0) {
+                $issueNum = $parsed
+            }
+            return [pscustomobject]@{
+                IsOrchestratedOrigin = $true
+                LinkedIssueNumber    = $issueNum
+                DetectionMethod      = 'branch'
+            }
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # FALLBACK: PR body linked-issue signals
+    # Mirrors frame-credit-ledger.ps1:469-484 (Resolve-FCLLinkedIssueNumber
+    # body leg). Patterns in priority order:
+    #   1. close/fix/resolve/ref/references/issue #N (keyword-linked)
+    #   2. issue_id: N
+    #   3. <!-- plan-issue-N --> or <!-- design-issue-N -->
+    # -----------------------------------------------------------------------
+    if (-not [string]::IsNullOrWhiteSpace($PrBody)) {
+        $bodyPatterns = @(
+            '(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|ref(?:s|erences)?|issue)\s+(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#(?<issue>\d+)\b',
+            '(?im)^\s*issue_id\s*:\s*(?<issue>\d+)\s*$',
+            '(?im)<!--\s*(?:plan|design)-issue-(?<issue>\d+)\s*-->'
+        )
+
+        foreach ($pattern in $bodyPatterns) {
+            $match = [regex]::Match($PrBody, $pattern)
+            if (-not $match.Success) { continue }
+
+            $parsed = 0
+            if ([int]::TryParse($match.Groups['issue'].Value, [ref]$parsed) -and $parsed -gt 0) {
+                return [pscustomobject]@{
+                    IsOrchestratedOrigin = $true
+                    LinkedIssueNumber    = $parsed
+                    DetectionMethod      = 'body'
+                }
+            }
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Neither signal matched — non-orchestrated origin.
+    # -----------------------------------------------------------------------
+    return [pscustomobject]@{
+        IsOrchestratedOrigin = $false
+        LinkedIssueNumber    = $null
+        DetectionMethod      = 'none'
+    }
+}

--- a/.github/scripts/lib/emit-pipeline-metrics-v4-core.ps1
+++ b/.github/scripts/lib/emit-pipeline-metrics-v4-core.ps1
@@ -1,0 +1,160 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Core library for emit-pipeline-metrics-v4 (issue #769 s2).
+
+.DESCRIPTION
+    Invoke-PipelineMetricsV4Emit builds a canonical v4 <!-- pipeline-metrics -->
+    PR body and writes it to -BodyFile, returning a result object
+    ([pscustomobject] with ExitCode/SentinelWritten) instead of calling `exit`.
+
+    The thin wrapper emit-pipeline-metrics-v4.ps1 dot-sources this file, calls the
+    function, and translates ExitCode to a process exit code. Tests dot-source
+    this file and call the function in-process — the dot-source + in-process call
+    pattern mandated by the #257 script-safety contract (no child pwsh per test).
+
+    Three outcome cases (M5):
+      Case 1 — New-PipelineMetricsV4Block throws (empty/invalid -V3BaseYaml, or
+               pre-existing v4 block): writes fallback body with
+               <!-- cost-capture-failed --> sentinel, returns ExitCode=1.
+      Case 2 — Block built but Test-PipelineMetricsV4Block reports invalid
+               (empty credits, ≠1 marker): writes fallback body with sentinel,
+               returns ExitCode=1.
+      Case 3 — Success: writes full body, returns ExitCode=0.
+
+    Critical invariants (M8, M21):
+      - The <!-- cost-capture-failed --> sentinel is written in the catch block
+        and guarded in finally so any abnormal exit also ships it.
+      - The sentinel token does NOT match <!--\s*pipeline-metrics.
+      - The sentinel, when present, does not inflate the pipeline-metrics
+        marker count inside Test-PipelineMetricsV4Block.
+#>
+
+# ---------------------------------------------------------------------------
+# Library dot-sources (siblings in lib/)
+# ---------------------------------------------------------------------------
+. (Join-Path $PSScriptRoot 'frame-credit-ledger-core.ps1')
+. (Join-Path $PSScriptRoot 'Get-FCLOriginContext.ps1')
+
+function Invoke-PipelineMetricsV4Emit {
+    <#
+    .SYNOPSIS
+        Build and write the v4 pipeline-metrics PR body; return ExitCode/SentinelWritten.
+
+    .PARAMETER BodyFile
+        Path to write the completed PR body file.
+
+    .PARAMETER V3BaseYaml
+        v3 base fields as plain YAML (no pipeline-metrics wrapper).
+
+    .PARAMETER Credits
+        Array of credit-row pscustomobjects from the frame accumulator.
+
+    .PARAMETER DispatchCostSamples
+        Array of dispatch-cost-sample pscustomobjects.
+
+    .PARAMETER IssueNumber
+        When > 0 and Credits is empty, harvest credits from the s-acc
+        file-based accumulator (.tmp/issue-{N}/fclcredits.jsonl).
+
+    .PARAMETER RichBody
+        Optional full markdown PR body already composed by the conductor. When
+        provided, the v4 block is appended to it so the final file carries both
+        the human-readable PR content AND the metrics block. On failure the rich
+        body is still written followed by the sentinel so Closes #N always
+        survives in the shipped PR body.
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string]$BodyFile,
+        [string]$V3BaseYaml = '',
+        [pscustomobject[]]$Credits = @(),
+        [pscustomobject[]]$DispatchCostSamples = @(),
+        [int]$IssueNumber = 0,
+        [string]$RichBody = ''
+    )
+
+    $ErrorActionPreference = 'Stop'
+
+    # Track whether the sentinel has already been written so the finally block
+    # does not duplicate it on the normal-success path.
+    $sentinelWritten = $false
+
+    try {
+        # s-acc: harvest from file-based accumulator when Credits not provided.
+        if ($IssueNumber -gt 0 -and $Credits.Count -eq 0) {
+            $accScript = Join-Path $PSScriptRoot 'Get-FCLAccumulatedCredits.ps1'
+            if (Test-Path -LiteralPath $accScript) {
+                . $accScript
+                $Credits = @(Get-FCLAccumulatedCredits -IssueNumber $IssueNumber)
+            } else {
+                Write-Warning "harvest script not found at $accScript — proceeding with explicitly-passed credits only"
+            }
+        }
+
+        # Build v4 block (Case 1 throw surface: empty V3BaseYaml or pre-existing v4).
+        $v4Body = New-PipelineMetricsV4Block `
+            -V3BaseYaml $V3BaseYaml `
+            -Credits $Credits `
+            -DispatchCostSamples $DispatchCostSamples
+
+        # Validate (Case 2 surface: empty credits or ≠1 marker).
+        $testResult = Test-PipelineMetricsV4Block -PRBody $v4Body
+        if (-not $testResult.Valid) {
+            throw "Test-PipelineMetricsV4Block validation failed: $($testResult.FailureReason)"
+        }
+
+        # Case 3 — success: compose final body (rich content + v4 block).
+        $finalBody = if ([string]::IsNullOrWhiteSpace($RichBody)) {
+            $v4Body  # backwards-compat: no rich body passed
+        } else {
+            "$RichBody`n`n$v4Body"
+        }
+
+        $sentinelWritten = $true
+        Set-Content -Path $BodyFile -Value $finalBody -Encoding utf8NoBOM
+        return [pscustomobject]@{ ExitCode = 0; SentinelWritten = $false }
+    }
+    catch {
+        # Case 1 or 2: write fallback body + sentinel.
+        $fallbackBase = if ([string]::IsNullOrWhiteSpace($RichBody)) {
+            if (-not [string]::IsNullOrWhiteSpace($V3BaseYaml)) {
+                $V3BaseYaml
+            } else {
+                'metrics_emission_failed: true'
+            }
+        } else {
+            $RichBody
+        }
+        $fallbackBody = "$fallbackBase`n`n<!-- cost-capture-failed -->"
+
+        Set-Content -Path $BodyFile -Value $fallbackBody -Encoding utf8NoBOM
+        $sentinelWritten = $true
+
+        # Non-terminating warning keeps this function safe for in-process test
+        # callers; the load-bearing failure signals are ExitCode=1 + the sentinel.
+        Write-Warning "emit-pipeline-metrics-v4 failed: $_"
+        return [pscustomobject]@{ ExitCode = 1; SentinelWritten = $true }
+    }
+    finally {
+        # Sentinel durability guard: catches abnormal exits that occur between
+        # try-start and the catch (rare in PS7 but guard it per M8).
+        # Only writes the sentinel when:
+        #   - It was not already written by the catch block, AND
+        #   - The body file exists (i.e. a partial write landed), AND
+        #   - The sentinel is not already present in the file content.
+        if (-not $sentinelWritten -and (Test-Path -LiteralPath $BodyFile)) {
+            try {
+                $existing = Get-Content -LiteralPath $BodyFile -Raw
+                if ($existing -notmatch [regex]::Escape('<!-- cost-capture-failed -->')) {
+                    $existing += "`n`n<!-- cost-capture-failed -->"
+                    Set-Content -Path $BodyFile -Value $existing -Encoding utf8NoBOM
+                }
+            }
+            catch {
+                Write-Warning "emit-pipeline-metrics-v4 finally: could not write sentinel — $_"
+            }
+        }
+    }
+}

--- a/.github/scripts/lib/emit-pipeline-metrics-v4-core.ps1
+++ b/.github/scripts/lib/emit-pipeline-metrics-v4-core.ps1
@@ -10,17 +10,17 @@
 
     The thin wrapper emit-pipeline-metrics-v4.ps1 dot-sources this file, calls the
     function, and translates ExitCode to a process exit code. Tests dot-source
-    this file and call the function in-process — the dot-source + in-process call
+    this file and call the function in-process -- the dot-source + in-process call
     pattern mandated by the #257 script-safety contract (no child pwsh per test).
 
     Three outcome cases (M5):
-      Case 1 — New-PipelineMetricsV4Block throws (empty/invalid -V3BaseYaml, or
+      Case 1 -- New-PipelineMetricsV4Block throws (empty/invalid -V3BaseYaml, or
                pre-existing v4 block): writes fallback body with
                <!-- cost-capture-failed --> sentinel, returns ExitCode=1.
-      Case 2 — Block built but Test-PipelineMetricsV4Block reports invalid
-               (empty credits, ≠1 marker): writes fallback body with sentinel,
+      Case 2 -- Block built but Test-PipelineMetricsV4Block reports invalid
+               (empty credits, != 1 marker): writes fallback body with sentinel,
                returns ExitCode=1.
-      Case 3 — Success: writes full body, returns ExitCode=0.
+      Case 3 -- Success: writes full body, returns ExitCode=0.
 
     Critical invariants (M8, M21):
       - The <!-- cost-capture-failed --> sentinel is written in the catch block
@@ -89,7 +89,7 @@ function Invoke-PipelineMetricsV4Emit {
                 . $accScript
                 $Credits = @(Get-FCLAccumulatedCredits -IssueNumber $IssueNumber)
             } else {
-                Write-Warning "harvest script not found at $accScript — proceeding with explicitly-passed credits only"
+                Write-Warning "harvest script not found at $accScript -- proceeding with explicitly-passed credits only"
             }
         }
 
@@ -99,27 +99,35 @@ function Invoke-PipelineMetricsV4Emit {
             -Credits $Credits `
             -DispatchCostSamples $DispatchCostSamples
 
-        # Validate (Case 2 surface: empty credits or ≠1 marker).
-        $testResult = Test-PipelineMetricsV4Block -PRBody $v4Body
-        if (-not $testResult.Valid) {
-            throw "Test-PipelineMetricsV4Block validation failed: $($testResult.FailureReason)"
-        }
-
-        # Case 3 — success: compose final body (rich content + v4 block).
+        # Compose final body FIRST (rich content + v4 block) so validation runs
+        # against the body we actually ship. A RichBody that already contains a
+        # pipeline-metrics block would otherwise produce a double-marker body that
+        # passes a v4-block-only check but fails the composed-body check.
         $finalBody = if ([string]::IsNullOrWhiteSpace($RichBody)) {
             $v4Body  # backwards-compat: no rich body passed
         } else {
             "$RichBody`n`n$v4Body"
         }
 
+        # Validate (Case 2 surface: empty credits or != 1 marker), against the
+        # composed final body so a duplicate marker fails into the sentinel fallback.
+        $testResult = Test-PipelineMetricsV4Block -PRBody $finalBody
+        if (-not $testResult.Valid) {
+            throw "Test-PipelineMetricsV4Block validation failed: $($testResult.FailureReason)"
+        }
+
+        # Case 3 -- success.
         $sentinelWritten = $true
-        Set-Content -Path $BodyFile -Value $finalBody -Encoding utf8NoBOM
+        Set-Content -LiteralPath $BodyFile -Value $finalBody -Encoding utf8NoBOM
         return [pscustomobject]@{ ExitCode = 0; SentinelWritten = $false }
     }
     catch {
         # Case 1 or 2: write fallback body + sentinel.
         $fallbackBase = if ([string]::IsNullOrWhiteSpace($RichBody)) {
-            if (-not [string]::IsNullOrWhiteSpace($V3BaseYaml)) {
+            # Only reuse V3BaseYaml when it does NOT carry a pipeline-metrics opener;
+            # reusing a poisoned base would re-ship the double-marker content that
+            # caused the failure in the first place.
+            if (-not [string]::IsNullOrWhiteSpace($V3BaseYaml) -and $V3BaseYaml -notmatch '<!--\s*pipeline-metrics') {
                 $V3BaseYaml
             } else {
                 'metrics_emission_failed: true'
@@ -129,7 +137,7 @@ function Invoke-PipelineMetricsV4Emit {
         }
         $fallbackBody = "$fallbackBase`n`n<!-- cost-capture-failed -->"
 
-        Set-Content -Path $BodyFile -Value $fallbackBody -Encoding utf8NoBOM
+        Set-Content -LiteralPath $BodyFile -Value $fallbackBody -Encoding utf8NoBOM
         $sentinelWritten = $true
 
         # Non-terminating warning keeps this function safe for in-process test
@@ -149,11 +157,11 @@ function Invoke-PipelineMetricsV4Emit {
                 $existing = Get-Content -LiteralPath $BodyFile -Raw
                 if ($existing -notmatch [regex]::Escape('<!-- cost-capture-failed -->')) {
                     $existing += "`n`n<!-- cost-capture-failed -->"
-                    Set-Content -Path $BodyFile -Value $existing -Encoding utf8NoBOM
+                    Set-Content -LiteralPath $BodyFile -Value $existing -Encoding utf8NoBOM
                 }
             }
             catch {
-                Write-Warning "emit-pipeline-metrics-v4 finally: could not write sentinel — $_"
+                Write-Warning "emit-pipeline-metrics-v4 finally: could not write sentinel -- $_"
             }
         }
     }

--- a/.github/scripts/lib/emit-pipeline-metrics-v4-core.ps1
+++ b/.github/scripts/lib/emit-pipeline-metrics-v4-core.ps1
@@ -123,7 +123,23 @@ function Invoke-PipelineMetricsV4Emit {
     }
     catch {
         # Case 1 or 2: write fallback body + sentinel.
-        $fallbackBase = if ([string]::IsNullOrWhiteSpace($RichBody)) {
+
+        # Strip any embedded pipeline-metrics block from RichBody before using it
+        # as the fallback base.  If RichBody was the source of the double-marker
+        # (CR-NEW-1), writing it back unchanged would leave a stale metrics block in
+        # the failure body, confusing downstream consumers despite the failure
+        # sentinel that follows.
+        $sanitizedRichBody = if ([string]::IsNullOrWhiteSpace($RichBody)) {
+            ''
+        } else {
+            [regex]::Replace(
+                $RichBody,
+                '(?s)\s*<!--\s*pipeline-metrics.*?-->\s*',
+                ''
+            ).Trim()
+        }
+
+        $fallbackBase = if ([string]::IsNullOrWhiteSpace($sanitizedRichBody)) {
             # Only reuse V3BaseYaml when it does NOT carry a pipeline-metrics opener;
             # reusing a poisoned base would re-ship the double-marker content that
             # caused the failure in the first place.
@@ -133,7 +149,7 @@ function Invoke-PipelineMetricsV4Emit {
                 'metrics_emission_failed: true'
             }
         } else {
-            $RichBody
+            $sanitizedRichBody
         }
         $fallbackBody = "$fallbackBase`n`n<!-- cost-capture-failed -->"
 

--- a/.github/scripts/lib/frame-credit-ledger-core.ps1
+++ b/.github/scripts/lib/frame-credit-ledger-core.ps1
@@ -2064,7 +2064,7 @@ function Compose-MissingMetricsShortCircuitComment {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$MarkerToken,
-        [bool]$IsOrchestrated = $true
+        [bool]$IsOrchestrated = $false
     )
 
     if (-not $IsOrchestrated) {

--- a/.github/scripts/lib/frame-credit-ledger-core.ps1
+++ b/.github/scripts/lib/frame-credit-ledger-core.ps1
@@ -2054,14 +2054,36 @@ function Compose-ParseErrorShortCircuitComment {
 # Render the short-circuit comment for the case where the PR body has no
 # pipeline-metrics marker block at all (Read-PRMetricsBlock returned $null).
 # Distinct from pre-v4 and parse-error.
+#
+# -IsOrchestrated: when $true the PR is confirmed orchestrated-origin, so the
+# absent block is a genuine 🛑 FAILED signal. When $false the PR is not
+# orchestrated-origin, so the absent block is expected — render a quiet
+# "not measured (non-orchestrated)" notice instead.
 function Compose-MissingMetricsShortCircuitComment {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseApprovedVerbs', '', Justification = 'Public helper name retained for compatibility with existing tests and callers.')]
     [CmdletBinding()]
-    param([Parameter(Mandatory)][string]$MarkerToken)
+    param(
+        [Parameter(Mandatory)][string]$MarkerToken,
+        [bool]$IsOrchestrated = $true
+    )
 
+    if (-not $IsOrchestrated) {
+        # Non-orchestrated origin: absent block is expected. Quiet notice only.
+        $lines = @(
+            $MarkerToken,
+            '**Frame credit ledger — not measured (non-orchestrated)**',
+            '',
+            'This PR was not opened from a `feature/issue-*` branch and does not contain linked-issue signals in the PR body, so no orchestrated pipeline-metrics block is expected. Port-by-port credit reporting is not applicable for non-orchestrated PRs.',
+            '',
+            '(Hook ran in `warn` mode; PR creation was not blocked.)'
+        )
+        return ($lines -join [Environment]::NewLine)
+    }
+
+    # Orchestrated origin: the absent block is a genuine failure.
     $lines = @(
         $MarkerToken,
-        '⚠️ **Frame credit ledger — no pipeline-metrics block found in the PR body**',
+        '🛑 **FAILED — Frame credit ledger — no pipeline-metrics block found in the PR body**',
         '',
         'The frame credit-ledger hook reads `metrics_version: 4` frame credits emitted inside an HTML-comment marker block (`<!-- pipeline-metrics ... -->`). This PR''s body does not contain that block, so port-by-port credit reporting is unavailable.',
         '',

--- a/.github/workflows/cost-pattern-presence-check.yml
+++ b/.github/workflows/cost-pattern-presence-check.yml
@@ -15,23 +15,47 @@ concurrency:
   group: cost-pattern-presence-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check-cost-pattern:
+    # NOTE: github.head_ref is null on issue_comment events; the startsWith() arm
+    # covers pull_request events only. On issue_comment events only the cost-reduction
+    # label arm fires. This is a known backstop-completeness gap (B6/P2-F3).
     if: |
       contains(github.event.pull_request.labels.*.name, 'cost-reduction') ||
       startsWith(github.head_ref, 'feature/issue-') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.issue.labels.*.name, 'cost-reduction'))
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR body for v4 pipeline-metrics block
+      - name: Check PR body for v4 pipeline-metrics block with non-empty credits
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           pr_body=$(gh pr view "$PR_NUMBER" --json body --jq '.body')
+
+          # pre-v4 block: marker present but not v4 — taxonomy state: pre-v4 (distinct from FAILED)
           if echo "$pr_body" | grep -q '<!-- pipeline-metrics'; then
-            echo "v4 block present"
-          else
-            echo "::warning::PR body missing <!-- pipeline-metrics block (cost-capture-failed or not emitted)"
-            exit 1
+            if ! echo "$pr_body" | grep -qE '^metrics_version:[[:space:]]*4[[:space:]]*$'; then
+              echo "::notice::Pre-v4 pipeline-metrics block detected — not a failure, migration in progress"
+              exit 0
+            fi
+            # v4 block present — check credits
+            if ! echo "$pr_body" | grep -qE '^[[:space:]]*-[[:space:]]+port:[[:space:]]+[^[:space:]]'; then
+              echo "::warning::v4 block found but credits[] is empty (cost-capture-failed or accumulation missed)"
+              exit 1
+            fi
+            echo "v4 block present with non-empty credits[] — OK"
+            exit 0
           fi
+
+          # No block at all — FAILED state (orchestrated PR must have a v4 block)
+          if echo "$pr_body" | grep -q '<!-- cost-capture-failed -->'; then
+            echo "::error::cost-capture-failed sentinel present — emit script failed during PR creation"
+          else
+            echo "::error::PR body missing <!-- pipeline-metrics block entirely"
+          fi
+          exit 1

--- a/.github/workflows/cost-pattern-presence-check.yml
+++ b/.github/workflows/cost-pattern-presence-check.yml
@@ -16,11 +16,13 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  # Read-only: this job only calls `gh pr view` to inspect the PR body; it never writes.
   contents: read
   pull-requests: read
 
 jobs:
   check-cost-pattern:
+    name: Check cost pattern presence
     # NOTE: github.head_ref is null on issue_comment events; the startsWith() arm
     # covers pull_request events only. On issue_comment events only the cost-reduction
     # label arm fires. This is a known backstop-completeness gap (B6/P2-F3).
@@ -59,6 +61,6 @@ jobs:
           if echo "$pr_body" | grep -q '<!-- cost-capture-failed -->'; then
             echo "::error::cost-capture-failed sentinel present — emit script failed during PR creation"
           else
-            echo "::error::PR body missing <!-- pipeline-metrics block entirely"
+            echo "::error::PR body missing <!-- pipeline-metrics --> block entirely"
           fi
           exit 1

--- a/.github/workflows/cost-pattern-presence-check.yml
+++ b/.github/workflows/cost-pattern-presence-check.yml
@@ -33,8 +33,11 @@ jobs:
       - name: Check PR body for v4 pipeline-metrics block with non-empty credits
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
+          # GH_REPO is required: this job has no actions/checkout, so gh cannot
+          # infer the repo from a local git remote (otherwise: "not a git repository").
           pr_body=$(gh pr view "$PR_NUMBER" --json body --jq '.body')
 
           # pre-v4 block: marker present but not v4 — taxonomy state: pre-v4 (distinct from FAILED)

--- a/.github/workflows/cost-pattern-presence-check.yml
+++ b/.github/workflows/cost-pattern-presence-check.yml
@@ -17,47 +17,21 @@ concurrency:
 
 jobs:
   check-cost-pattern:
-    if: contains(github.event.pull_request.labels.*.name, 'cost-reduction') || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.issue.labels.*.name, 'cost-reduction'))
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'cost-reduction') ||
+      startsWith(github.head_ref, 'feature/issue-') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.issue.labels.*.name, 'cost-reduction'))
     runs-on: ubuntu-latest
     steps:
-      - name: Check for cost-pattern-data marker
+      - name: Check PR body for v4 pipeline-metrics block
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
-          PR_NUM="${{ github.event.pull_request.number || github.event.issue.number }}"
-          for i in 1 2 3 4 5; do
-            COMMENTS="$(gh pr view "$PR_NUM" -R "$GH_REPO" --json comments --jq '.comments[].body')"
-            if printf '%s\n' "$COMMENTS" | grep -q '<!-- cost-pattern-data'; then
-              echo "Cost Pattern marker found on attempt $i"
-
-              COVERAGE="$(printf '%s\n' "$COMMENTS" | awk '
-                /<!-- cost-pattern-data/ { in_block=1; next }
-                in_block && /^coverage:[[:space:]]*/ { sub(/^coverage:[[:space:]]*/, "", $0); print $0; exit }
-                in_block && /-->/ { in_block=0 }
-              ')"
-
-              case "$COVERAGE" in
-                "claude+copilot")
-                  echo "Cost Pattern coverage is claude+copilot"
-                  ;;
-                "claude-only"|"copilot-only"|"claude-only-with-copilot-fallback-warning")
-                  echo "::warning::Cost Pattern coverage is $COVERAGE; full cross-tool telemetry was not merged for this run"
-                  ;;
-                "")
-                  echo "::error::cost-pattern-data marker is missing a coverage line"
-                  exit 1
-                  ;;
-                *)
-                  echo "::error::cost-pattern-data marker has unexpected coverage '$COVERAGE'"
-                  exit 1
-                  ;;
-              esac
-
-              exit 0
-            fi
-            echo "Marker not found, attempt $i/5; sleeping 30s"
-            sleep 30
-          done
-          echo "::error::cost-reduction PR is missing cost-pattern-data marker after 5 retries (~150s)"
-          exit 1
+          pr_body=$(gh pr view "$PR_NUMBER" --json body --jq '.body')
+          if echo "$pr_body" | grep -q '<!-- pipeline-metrics'; then
+            echo "v4 block present"
+          else
+            echo "::warning::PR body missing <!-- pipeline-metrics block (cost-capture-failed or not emitted)"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to agent-orchestra will be documented in this file.
 
-## [2.35.12] — 2026-06-29
+## [2.35.13] — 2026-06-29
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to agent-orchestra will be documented in this file.
 
+## [2.35.12] — 2026-06-29
+
+### Fixed
+
+- **Cost telemetry v4 emission reliability** (#769): deterministic fail-loud v4 emission path wired end-to-end into Code-Conductor.
+  - **`lib/Get-FCLOriginContext.ps1`**: new CI-safe orchestrated-origin predicate using `$env:GITHUB_HEAD_REF` (primary) and PR body linked-issue signals (fallback). Excludes detached-HEAD `HEAD` literal (M3 bug fix). Returns `IsOrchestratedOrigin`, `LinkedIssueNumber`, `DetectionMethod`.
+  - **`emit-pipeline-metrics-v4.ps1`**: deterministic 3-case fail-loud emitter — builder-throw → `<!-- cost-capture-failed -->` sentinel; empty credits → sentinel; success → v4 block. Called before `gh pr create` in Code-Conductor's fresh-PR path; push-only path explicitly exempted. Non-zero exit on failure.
+  - **`lib/Add-FCLCreditRow.ps1` / `lib/Get-FCLAccumulatedCredits.ps1`**: file-based credit accumulator at `.tmp/issue-{N}/fclcredits.jsonl`; harvest hook in emit script ensures credits are non-empty on orchestrated runs. Conductor body gains `Add-FCLCreditRow` call after each `Build-*CreditRow` step.
+  - **`frame-credit-ledger.ps1`**: origin-gated 3-state taxonomy (`🛑 FAILED` / `not measured (non-orchestrated)` / `pre-v4`) at each short-circuit site; off-switch via `FCL_SUPPRESS_FAILED_POSTS` env var.
+  - **`.github/workflows/cost-pattern-presence-check.yml`**: widened `if:` to include `startsWith(github.head_ref, 'feature/issue-')` head refs; step now checks PR body for `<!-- pipeline-metrics` instead of PR comments for `<!-- cost-pattern-data`.
+
 ## [2.35.11] — 2026-06-28
 
 ### Added

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -216,5 +216,7 @@ The adversarial review pipeline runs after implementation to find defects before
 | **subagent-env-handshake** | A `<!-- subagent-env-handshake v1 -->` block the parent embeds in a dispatch prompt; the subagent live-verifies its git state matches the parent before making tree-grounded claims. | `skills/subagent-env-handshake/SKILL.md` |
 | **persist-changes** | The git-portable commit+push primitive (`skills/persist-changes/SKILL.md`) called as the terminal step after validated changes are staged. | `skills/persist-changes/SKILL.md` |
 | **post-PR review / post-merge cleanup** | The checklist and automation run after a PR merges: archiving tracking files, removing worktrees, deleting orphan branches, and updating docs. | `skills/post-pr-review/SKILL.md` |
+| **`cost-capture-failed` sentinel** | `<!-- cost-capture-failed -->` written to the PR body by `emit-pipeline-metrics-v4.ps1` when the v4 block cannot be built; detected by the CI cost-pattern-presence-check gate. | `.github/scripts/emit-pipeline-metrics-v4.ps1`; `.github/workflows/cost-pattern-presence-check.yml` |
+| **`Get-FCLOriginContext`** | CI-safe origin predicate that classifies a PR as orchestrated (eligible for v4 emission) or non-orchestrated. Primary signal: `$env:GITHUB_HEAD_REF` matching `feature/issue-N`; fallback: PR body linked-issue signals. | `lib/Get-FCLOriginContext.ps1` |
 
 <!-- vocab-seed:end -->

--- a/agents/Code-Conductor.agent.md
+++ b/agents/Code-Conductor.agent.md
@@ -323,6 +323,7 @@ Bundle-specific frame-spine semantics are deferred to #515; #512 v1 spine behavi
    - **Emit v4 pipeline-metrics block (fresh-PR path only)**: Before calling `gh pr create`, compose the full rich PR body string first, then pass it to the emit script so the v4 block is appended and the human-readable content (including `Closes #{issue}`) always survives in the shipped body:
      1. Compose the full rich PR body (summary, changed files, validation evidence, migration scan, `Closes #{issue}`, review score table, etc.) into a string `$richBody` as normal.
      2. Emit the v4 pipeline-metrics block appended to the rich body:
+
      ```powershell
      $bodyFile = Join-Path $env:TEMP "pr-body-{ISSUE}.md"
      $v3Base = @"
@@ -340,6 +341,7 @@ Bundle-specific frame-spine semantics are deferred to #515; #512 v1 spine behavi
          # Non-fatal: gh pr create proceeds with whatever body is in $bodyFile (M9)
      }
      ```
+
      Substitute `{ISSUE}`, `{BRANCH}`, and `{ISSUE_NUMBER}` from the conductor's resolved issue context. The `$bodyFile` path is unique per issue to avoid cross-PR body collisions. The emit script appends the v4 block to `$richBody`; on failure it appends `<!-- cost-capture-failed -->` instead — either way `Closes #{issue}` and the summary are always present in the shipped body. `$richBody` is the full PR body string you would have passed to `gh pr create --body "..."` before this wiring was added; the emit step now owns the file-composition step that appends the v4 block. This call is warn-only: a non-zero exit does NOT abort PR creation. **Push-only path** (pushing additional commits to an already-open PR branch): skip this emit call — the v4 block was emitted at initial PR creation and must not be re-emitted here.
    - Create PR via `github-pull-request/*` tools or `gh pr create --body-file $bodyFile`
    - **Frame credit-ledger (warn-only)**: After PR creation, load `skills/frame-credit-ledger/SKILL.md` and follow its protocol. The hook is warn-only by default; PR creation is never blocked.

--- a/agents/Code-Conductor.agent.md
+++ b/agents/Code-Conductor.agent.md
@@ -459,6 +459,15 @@ Load and follow these references:
 
 Code-Conductor keeps only the emission timing and ownership boundary: at fresh PR creation time, the `.github/scripts/emit-pipeline-metrics-v4.ps1` script (called in the **Create PR** step above) owns `New-PipelineMetricsV4Block` invocation, `Test-PipelineMetricsV4Block` validation, and writing the body file — pass `-V3BaseYaml` (plain YAML string of v3 base fields; do not wrap in the HTML comment, do not include `metrics_version: 4`; the builder adds those), the accumulated `-Credits` / `-DispatchCostSamples` from the session-memory accumulator, and `-IssueNumber`. `Build-*CreditRow` outputs are `[pscustomobject]` rows — pass them directly, the builder normalizes them. The script is warn-only: if it exits non-zero, log the warning and proceed to `gh pr create` regardless (#429). On re-emit the initial-creation guard prevents double-wrapping; use additive-merge writers for updates after the initial PR exists.
 
+After each `Build-*CreditRow` call that produces a credit row for the current issue, persist it to the file-based accumulator so `emit-pipeline-metrics-v4.ps1` can harvest it deterministically at PR creation time (issue #769 s-acc):
+
+```powershell
+. '.github/scripts/lib/Add-FCLCreditRow.ps1'
+Add-FCLCreditRow -IssueNumber {ISSUE_NUMBER} -CreditRow $creditRow
+```
+
+This call is additive alongside the existing prose instruction — do not remove the `Build-*CreditRow` call itself. When `-IssueNumber` is provided to `emit-pipeline-metrics-v4.ps1` and no `-Credits` are passed explicitly, the script auto-harvests from `.tmp/issue-{N}/fclcredits.jsonl`.
+
 For v4 release-hygiene credit row construction (state-file reading, YAML examples) and the CE Gate S2 synthetic-PR test protocol, follow `skills/calibration-pipeline/references/release-hygiene-credit-emission.md`.
 
 <!-- TODO: remove legacy v3 pipeline-metrics fallback at v2.9.0 when pre-v4 back-catalog backfill is confirmed complete (issue #441). -->

--- a/agents/Code-Conductor.agent.md
+++ b/agents/Code-Conductor.agent.md
@@ -320,7 +320,9 @@ Bundle-specific frame-spine semantics are deferred to #515; #512 v1 spine behavi
    - **Formatting gate**: Load `skills/pre-commit-formatting/SKILL.md` and execute the protocol on branch-changed files. If the protocol stages and commits formatting fixes, note the formatting commit in the PR description.
    - **Validation evidence**: run required validation commands from plan/repo instructions and capture pass results for PR body
    - `git push -u origin {branch-name}`
-   - **Emit v4 pipeline-metrics block (fresh-PR path only)**: Before calling `gh pr create`, run the emit script to write the PR body file:
+   - **Emit v4 pipeline-metrics block (fresh-PR path only)**: Before calling `gh pr create`, compose the full rich PR body string first, then pass it to the emit script so the v4 block is appended and the human-readable content (including `Closes #{issue}`) always survives in the shipped body:
+     1. Compose the full rich PR body (summary, changed files, validation evidence, migration scan, `Closes #{issue}`, review score table, etc.) into a string `$richBody` as normal.
+     2. Emit the v4 pipeline-metrics block appended to the rich body:
      ```powershell
      $bodyFile = Join-Path $env:TEMP "pr-body-{ISSUE}.md"
      $v3Base = @"
@@ -331,13 +333,14 @@ Bundle-specific frame-spine semantics are deferred to #515; #512 v1 spine behavi
           -File '.github/scripts/emit-pipeline-metrics-v4.ps1' `
           -BodyFile $bodyFile `
           -V3BaseYaml $v3Base `
+          -RichBody $richBody `
           -IssueNumber {ISSUE_NUMBER}
      if ($LASTEXITCODE -ne 0) {
          Write-Warning "emit-pipeline-metrics-v4.ps1 failed (exit $LASTEXITCODE) — PR body may lack the v4 block."
          # Non-fatal: gh pr create proceeds with whatever body is in $bodyFile (M9)
      }
      ```
-     Substitute `{ISSUE}`, `{BRANCH}`, and `{ISSUE_NUMBER}` from the conductor's resolved issue context. The `$bodyFile` path is unique per issue to avoid cross-PR body collisions. This call is warn-only: a non-zero exit does NOT abort PR creation. **Push-only path** (pushing additional commits to an already-open PR branch): skip this emit call — the v4 block was emitted at initial PR creation and must not be re-emitted here.
+     Substitute `{ISSUE}`, `{BRANCH}`, and `{ISSUE_NUMBER}` from the conductor's resolved issue context. The `$bodyFile` path is unique per issue to avoid cross-PR body collisions. The emit script appends the v4 block to `$richBody`; on failure it appends `<!-- cost-capture-failed -->` instead — either way `Closes #{issue}` and the summary are always present in the shipped body. `$richBody` is the full PR body string you would have passed to `gh pr create --body "..."` before this wiring was added; the emit step now owns the file-composition step that appends the v4 block. This call is warn-only: a non-zero exit does NOT abort PR creation. **Push-only path** (pushing additional commits to an already-open PR branch): skip this emit call — the v4 block was emitted at initial PR creation and must not be re-emitted here.
    - Create PR via `github-pull-request/*` tools or `gh pr create --body-file $bodyFile`
    - **Frame credit-ledger (warn-only)**: After PR creation, load `skills/frame-credit-ledger/SKILL.md` and follow its protocol. The hook is warn-only by default; PR creation is never blocked.
    - PR body MUST include: summary, changed files, validation evidence, migration-scan result (migration-type issues only — when the scan step was auto-inserted by Code-Conductor, the `planner-omitted-scan` dispatch-fallback-events row records this), Review Mode, CE Gate result, adversarial review score table, prosecution depth summary, pipeline metrics, process gaps found (if any), and `Closes #{issue}`

--- a/agents/Code-Conductor.agent.md
+++ b/agents/Code-Conductor.agent.md
@@ -320,7 +320,25 @@ Bundle-specific frame-spine semantics are deferred to #515; #512 v1 spine behavi
    - **Formatting gate**: Load `skills/pre-commit-formatting/SKILL.md` and execute the protocol on branch-changed files. If the protocol stages and commits formatting fixes, note the formatting commit in the PR description.
    - **Validation evidence**: run required validation commands from plan/repo instructions and capture pass results for PR body
    - `git push -u origin {branch-name}`
-   - Create PR via `github-pull-request/*` tools or `gh pr create`
+   - **Emit v4 pipeline-metrics block (fresh-PR path only)**: Before calling `gh pr create`, run the emit script to write the PR body file:
+     ```powershell
+     $bodyFile = Join-Path $env:TEMP "pr-body-{ISSUE}.md"
+     $v3Base = @"
+     pr_number: {ISSUE}
+     branch: {BRANCH}
+     "@
+     pwsh -NoProfile -NonInteractive `
+          -File '.github/scripts/emit-pipeline-metrics-v4.ps1' `
+          -BodyFile $bodyFile `
+          -V3BaseYaml $v3Base `
+          -IssueNumber {ISSUE_NUMBER}
+     if ($LASTEXITCODE -ne 0) {
+         Write-Warning "emit-pipeline-metrics-v4.ps1 failed (exit $LASTEXITCODE) — PR body may lack the v4 block."
+         # Non-fatal: gh pr create proceeds with whatever body is in $bodyFile (M9)
+     }
+     ```
+     Substitute `{ISSUE}`, `{BRANCH}`, and `{ISSUE_NUMBER}` from the conductor's resolved issue context. The `$bodyFile` path is unique per issue to avoid cross-PR body collisions. This call is warn-only: a non-zero exit does NOT abort PR creation. **Push-only path** (pushing additional commits to an already-open PR branch): skip this emit call — the v4 block was emitted at initial PR creation and must not be re-emitted here.
+   - Create PR via `github-pull-request/*` tools or `gh pr create --body-file $bodyFile`
    - **Frame credit-ledger (warn-only)**: After PR creation, load `skills/frame-credit-ledger/SKILL.md` and follow its protocol. The hook is warn-only by default; PR creation is never blocked.
    - PR body MUST include: summary, changed files, validation evidence, migration-scan result (migration-type issues only — when the scan step was auto-inserted by Code-Conductor, the `planner-omitted-scan` dispatch-fallback-events row records this), Review Mode, CE Gate result, adversarial review score table, prosecution depth summary, pipeline metrics, process gaps found (if any), and `Closes #{issue}`
 
@@ -439,7 +457,7 @@ Load and follow these references:
 - `skills/calibration-pipeline/references/verdict-mapping.md`
 - `skills/calibration-pipeline/references/findings-construction.md`
 
-Code-Conductor keeps only the emission timing and ownership boundary: emit the `## Pipeline Metrics` section at PR creation time by calling `New-PipelineMetricsV4Block` (from `.github/scripts/lib/frame-credit-ledger-core.ps1`) with `-V3BaseYaml` (plain YAML string of v3 base fields — do not wrap in the HTML comment, do not include `metrics_version: 4`; the builder adds those) and the accumulated `-Credits` / `-DispatchCostSamples` from the session-memory accumulator. `Build-*CreditRow` outputs are `[pscustomobject]` rows — pass them directly, the builder normalizes them. Then call `Test-PipelineMetricsV4Block` on the resulting PR body; if validation fails, log the warning and proceed to `gh pr create` regardless (warn-only, #429). On re-emit the initial-creation guard prevents double-wrapping; use additive-merge writers for updates after the initial PR exists.
+Code-Conductor keeps only the emission timing and ownership boundary: at fresh PR creation time, the `.github/scripts/emit-pipeline-metrics-v4.ps1` script (called in the **Create PR** step above) owns `New-PipelineMetricsV4Block` invocation, `Test-PipelineMetricsV4Block` validation, and writing the body file — pass `-V3BaseYaml` (plain YAML string of v3 base fields; do not wrap in the HTML comment, do not include `metrics_version: 4`; the builder adds those), the accumulated `-Credits` / `-DispatchCostSamples` from the session-memory accumulator, and `-IssueNumber`. `Build-*CreditRow` outputs are `[pscustomobject]` rows — pass them directly, the builder normalizes them. The script is warn-only: if it exits non-zero, log the warning and proceed to `gh pr create` regardless (#429). On re-emit the initial-creation guard prevents double-wrapping; use additive-merge writers for updates after the initial PR exists.
 
 For v4 release-hygiene credit row construction (state-file reading, YAML examples) and the CE Gate S2 synthetic-PR test protocol, follow `skills/calibration-pipeline/references/release-hygiene-credit-emission.md`.
 

--- a/skills/naming-register-policy/assets/register.json
+++ b/skills/naming-register-policy/assets/register.json
@@ -287,5 +287,17 @@
     "register": "self-describing",
     "kind": "family",
     "decode": "post-PR review = checklist run after PR merges; post-merge cleanup = worktree removal, orphan branch deletion, tracking file archival; see skills/post-pr-review/SKILL.md"
+  },
+  {
+    "term": "`cost-capture-failed` sentinel",
+    "register": "stable-code",
+    "kind": "atomic",
+    "expansion": "`cost-capture-failed` sentinel (the <!-- cost-capture-failed --> HTML comment emit-pipeline-metrics-v4.ps1 writes to a PR body when the v4 pipeline-metrics block cannot be built; the CI cost-pattern-presence-check gate detects it as a distinct FAILED state)"
+  },
+  {
+    "term": "`Get-FCLOriginContext`",
+    "register": "stable-code",
+    "kind": "atomic",
+    "expansion": "`Get-FCLOriginContext` (the CI-safe origin predicate in .github/scripts/lib/Get-FCLOriginContext.ps1 that classifies a PR as orchestrated or non-orchestrated; primary signal $env:GITHUB_HEAD_REF, fallback PR-body linked-issue markers)"
   }
 ]


### PR DESCRIPTION
## Summary

- **Root cause A (M3 fix)** — `Get-FCLOriginContext`: CI-safe orchestrated-origin predicate using `$env:GITHUB_HEAD_REF` (primary) and `<!-- plan-issue-N -->`/`issue_id: N` body signals (fallback). Excludes the literal `HEAD` string that `git rev-parse --abbrev-ref HEAD` yields in CI detached-HEAD checkouts. Keywords like `Fixes #N` intentionally excluded — they are standard prose, not orchestration markers.
- **Root cause B (M5 fix)** — `emit-pipeline-metrics-v4.ps1`: deterministic 3-case fail-loud emitter called before `gh pr create`. Accepts `-RichBody` so the full PR body (summary, `Closes #769`, review table) always ships in both success and failure paths. Writes the cost-capture-failed sentinel (HTML comment) on failure, exits non-zero.
- **Root cause C (M4 gate)** — `Add-FCLCreditRow` + `Get-FCLAccumulatedCredits`: file-based credit accumulator at `.tmp/issue-{N}/fclcredits.jsonl`. Corrupt JSONL lines are skipped (per-line try/catch) rather than propagated. Always returns `@()` array type (OutputType contract enforced).
- **Root cause D (M6 fix)** — `frame-credit-ledger.ps1`: origin-gated 3-state taxonomy at each short-circuit site: `🛑 FAILED` (orchestrated + absent), `not measured (non-orchestrated)`, `pre-v4`. Off-switch via `FCL_SUPPRESS_FAILED_POSTS`.
- **Root cause E (AC4 fix)** — `cost-pattern-presence-check.yml`: widened `if:` to include `startsWith(github.head_ref, 'feature/issue-')`; deepened check to verify `metrics_version: 4` AND non-empty `credits[]`; enforces 3-state taxonomy at the CI check surface (pre-v4 → exit 0 notice, not red).

## Test plan

- [x] 13 Pester tests for `Get-FCLOriginContext` (branch primary, HEAD exclusion, body fallback, priority)
- [x] 12 Pester tests for `emit-pipeline-metrics-v4.ps1` (3 cases, RichBody merge, harvest integration)
- [x] 12 Pester tests for `Add-FCLCreditRow` / `Get-FCLAccumulatedCredits` (round-trip, corrupt-line skip, OutputType array)
- [x] 119 Pester tests for `frame-credit-ledger-core.ps1` (3-state taxonomy, Compose-MissingMetrics default $false)
- [x] 30 Pester tests for `cost-integration.Tests.ps1` (origin-gated taxonomy across 5 contexts)
- [x] Adversarial review: 3-pass prosecution → defense → judge; judge ruling: CONDITIONAL PASS (11/20, C); 5 blockers confirmed and fixed post-review
- [x] CE Gate: 3/3 scenarios PASS (golden path, non-orchestrated edge, failure recovery)

## Adversarial Review Score

| Dimension | Pre-fix | Post-fix |
|---|---|---|
| Correctness | 2/4 | 4/4 |
| Test coverage | 2/4 | 3/4 |
| Integration coherence | 1/4 | 4/4 |
| Security/robustness | 2/4 | 3/4 |
| Documentation | 4/4 | 4/4 |
| **Total** | **11/20 (C)** | **18/20 (A)** |

<!-- judge-rulings
schema_version: 1
issue: 769
verdict: conditional_pass
score: 11
grade: C
blockers:
  - id: B1
    finding: P3-F1
    status: confirmed
    disposition: fix_required
    summary: "Genuine regression — s3's gh pr create --body-file shipped only the bare v4 block; fixed by adding -RichBody param to emit script and updating conductor to compose full body first."
  - id: B2
    finding: P3-F2
    status: confirmed
    disposition: fix_required
    summary: "CI gate grepped marker only; fixed to also check metrics_version: 4 and at least one - port: credit entry."
  - id: B3
    finding: P3-F6
    status: confirmed
    disposition: fix_required
    summary: "CI check failed red on all feature/issue-* PRs; fixed to enforce 3-state taxonomy (pre-v4 → exit 0 notice, empty-credits v4 → exit 1, valid v4 → exit 0)."
  - id: B4a
    finding: P1-F6
    status: confirmed
    disposition: fix_required
    summary: "Fixes #N body fallback misclassified human PRs as orchestrated-origin; fixed by removing keyword-linked leg, keeping only plan-issue/design-issue markers and issue_id: N."
  - id: B4b
    finding: P2-F1
    status: confirmed
    disposition: fix_required
    summary: "Corrupt JSONL line threw through harvest into emit catch, nuking all credits; fixed with per-line try/catch in Get-FCLAccumulatedCredits."
  - id: B5
    finding: P2-F2
    status: confirmed
    disposition: fix_required
    summary: "Get-FCLAccumulatedCredits returned scalar/null; fixed to return ,@($rows) always."
  - id: B6
    finding: P2-F3
    status: confirmed
    disposition: document
    summary: "github.head_ref null on issue_comment events — unlabeled orchestrated PRs checked on push but not on comment; documented as known gap."
recommended_fixes:
  - finding: P1-F2
    summary: ValidateRange(1,...) added to both accumulator IssueNumber params
  - finding: P1-F3
    summary: Add retry/FileShare to Add-Content for defense-in-depth
  - finding: P1-F4
    summary: Per-line try/catch in Get-FCLAccumulatedCredits (paired with B4b fix)
  - finding: P2-F4
    summary: Compose-MissingMetrics default IsOrchestrated changed from true to false
  - finding: P3-F4
    summary: Accumulator cleanup on re-run deferred to follow-up
  - finding: P1-F7
    summary: Write-Warning added when harvest script absent
document_only:
  - finding: P1-F1
    summary: finally guard defensive-only for unreachable pre-write abnormal exit
  - finding: P1-F5
    summary: fork-PR CI trigger benign today; permissions:read block added
  - finding: P3-F3
    summary: contested — builders are conductor-context; CI gate is the determinism backstop
  - finding: P3-F7
    summary: push-only credits by design; additive-merge-writer is future work
-->

Closes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for generating a v4 pipeline-metrics block in PR bodies, including harvesting credits from a local accumulator when needed.
  * PR messaging now distinguishes orchestrated vs non-orchestrated “missing metrics” states.

* **Bug Fixes**
  * Improved robustness of v4 emission with clearer failure fallback behavior.
  * Enhanced origin detection logic and enforced builder guardrails to prevent duplicate/wrong block wrapping.
  * Added an off-switch to suppress FAILED-state postings while keeping non-orchestrated “not measured” reporting.

* **Chores**
  * Bumped plugin version to **2.35.12**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- pipeline-metrics
pr_number: 771
branch: feature/issue-769-v4-emission-reliability
plan_issue: 769
metrics_version: 4
frame_version: 1
credits:
  - port: implement-code
    adapter: skills/implementation-discipline/adapters/implement-code-adapter.md
    status: passed
    run_index: 1
    evidence: s1 Get-FCLOriginContext + 13 origin-predicate tests
    terminal-step-id: 1
  - port: implement-code
    adapter: skills/implementation-discipline/adapters/implement-code-adapter.md
    status: passed
    run_index: 2
    evidence: s2 emit-pipeline-metrics-v4 3-case emitter + tests
    terminal-step-id: 2
  - port: implement-code
    adapter: skills/implementation-discipline/adapters/implement-code-adapter.md
    status: passed
    run_index: 3
    evidence: s3 conductor emit wiring (D10 within ceiling)
    terminal-step-id: 3
  - port: implement-code
    adapter: skills/implementation-discipline/adapters/implement-code-adapter.md
    status: passed
    run_index: 4
    evidence: s4 CI presence gate widened + deepened
    terminal-step-id: 4
  - port: implement-code
    adapter: skills/implementation-discipline/adapters/implement-code-adapter.md
    status: passed
    run_index: 5
    evidence: s5 origin-gated 3-state taxonomy
    terminal-step-id: 5
  - port: implement-code
    adapter: skills/implementation-discipline/adapters/implement-code-adapter.md
    status: passed
    run_index: 6
    evidence: s-acc file-based credit accumulator
    terminal-step-id: 6
  - port: implement-docs
    adapter: skills/documentation-finalization/adapters/implement-docs-adapter.md
    status: passed
    run_index: 1
    evidence: s6 CHANGELOG + HOW-IT-WORKS vocab sync
    terminal-step-id: 7
  - port: review
    adapter: skills/adversarial-review/adapters/standard.md
    status: passed
    run_index: 1
    evidence: s7 prosecution-defense-judge; 18/20 post-fix
    terminal-step-id: 8
  - port: ce-gate
    adapter: skills/customer-experience/adapters/ce-gate-cli.md
    status: passed
    run_index: 1
    evidence: s8 3/3 CE Gate scenarios pass
    terminal-step-id: 9
-->
