### PR TITLE
feat(#777): token telemetry persistence — populated predicate, [long] types, phase_scope

### DIFF
--- a/.github/scripts/Tests/cost-completeness.Tests.ps1
+++ b/.github/scripts/Tests/cost-completeness.Tests.ps1
@@ -206,8 +206,7 @@ Describe 'Resolve-CostDataPreservation' {
             param(
                 [string]$Completeness = 'complete',
                 [string]$StopReason = 'end_turn',
-                [string]$Timestamp = '2026-01-01T00:00:00Z',
-                [int]$TokenSum = 0
+                [string]$Timestamp = '2026-01-01T00:00:00Z'
             )
             return @{
                 completeness                   = $Completeness
@@ -303,8 +302,8 @@ Describe 'Resolve-CostDataPreservation' {
         It 'empty-complete current must NOT clobber complete-populated prior' {
             # Cell 2: current=complete tokens=0, prior=complete tokens>0
             # Current code: complete → use_prior=false (complete always wins). Should be true.
-            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
-            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 1500
+            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn'
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn'
             $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 1500
             $result.use_prior | Should -Be $true
             $result.notice | Should -Not -BeNullOrEmpty
@@ -313,8 +312,8 @@ Describe 'Resolve-CostDataPreservation' {
         It 'partial-nonzero current beats complete-zero prior' {
             # Cell 3: current=partial tokens>0, prior=complete tokens=0
             # Current code: partial + prior=complete → use_prior=true (preserve complete). Should be false.
-            $current = script:New-CompletenessResultWithTokens -Completeness 'partial' -StopReason 'max_tokens' -TokenSum 800
-            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
+            $current = script:New-CompletenessResultWithTokens -Completeness 'partial' -StopReason 'max_tokens'
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn'
             $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 800 -PriorTokenSum 0
             $result.use_prior | Should -Be $false
         }
@@ -323,8 +322,8 @@ Describe 'Resolve-CostDataPreservation' {
             # Cell 5: current=unknown tokens=0, prior=unknown tokens>0
             # This is the dominant non-landing bug: local renders first (unknown, populated),
             # CI renders second (unknown, zeros). Without populated predicate, both-unknown → use_prior=false → CI wins.
-            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown' -StopReason $null -TokenSum 0
-            $prior = script:New-CompletenessResultWithTokens -Completeness 'unknown' -StopReason $null -TokenSum 1200
+            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown' -StopReason $null
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'unknown' -StopReason $null
             $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 1200
             $result.use_prior | Should -Be $true
             $result.notice | Should -Match 'populated'
@@ -333,8 +332,8 @@ Describe 'Resolve-CostDataPreservation' {
         It 'populated-unknown current beats complete-zero prior' {
             # Cell 6: current=unknown tokens>0, prior=complete tokens=0
             # Current code: unknown + prior=complete → use_prior=true (preserve complete). Should be false.
-            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown' -StopReason $null -TokenSum 900
-            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
+            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown' -StopReason $null
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn'
             $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 900 -PriorTokenSum 0
             $result.use_prior | Should -Be $false
         }
@@ -345,7 +344,7 @@ Describe 'Resolve-CostDataPreservation' {
             # Prior has null completeness (legacy render before completeness field existed).
             # Lines 1741-1746 of call site default null completeness to complete.
             # Even if the predicate sees it as complete, empty current must not clobber populated prior.
-            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
+            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn'
             $prior = @{
                 completeness                   = $null
                 stop_reason                    = $null
@@ -360,22 +359,22 @@ Describe 'Resolve-CostDataPreservation' {
         }
 
         It 'both-empty no-op idempotence: both complete tokens=0 -> use current (no churn)' {
-            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
-            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
+            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn'
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn'
             $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 0
             $result.use_prior | Should -Be $false
         }
 
         It 'both-populated falls back to completeness: current=complete, prior=complete -> use current' {
-            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 1000
-            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 1500
+            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn'
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn'
             $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 1000 -PriorTokenSum 1500
             $result.use_prior | Should -Be $false
         }
 
         It 'both-populated falls back to completeness: current=partial, prior=complete-populated -> use prior' {
-            $current = script:New-CompletenessResultWithTokens -Completeness 'partial' -StopReason 'max_tokens' -TokenSum 600
-            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 1200
+            $current = script:New-CompletenessResultWithTokens -Completeness 'partial' -StopReason 'max_tokens'
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn'
             $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 600 -PriorTokenSum 1200
             $result.use_prior | Should -Be $true
             $result.notice | Should -Not -BeNullOrEmpty
@@ -385,7 +384,7 @@ Describe 'Resolve-CostDataPreservation' {
             # Exercises the path where priorCostData is the frame-credit-ledger synthetic fallback
             # (@{ completeness = 'complete' }, no ports key) and both token sums are 0.
             # Both-empty falls through to completeness logic: prior=complete beats current=unknown.
-            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown' -TokenSum 0
+            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown'
             $prior = @{ completeness = 'complete' }  # synthetic fallback shape -- no ports, no rendered_at
             $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 0
             $result.use_prior | Should -Be $true
@@ -394,8 +393,8 @@ Describe 'Resolve-CostDataPreservation' {
         It 'long-boundary: PriorTokenSum > int32.max does not throw and populated prior wins over empty current' {
             # Regression for CR1 (int->long fix): a token sum exceeding Int32.MaxValue must not throw
             # ParameterBindingArgumentTransformationException.
-            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown' -TokenSum 0
-            $prior = script:New-CompletenessResultWithTokens -Completeness 'unknown' -TokenSum 0
+            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown'
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'unknown'
             # Invoke in the current scope so $result is populated after the throw-check.
             { Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 3000000000 } | Should -Not -Throw
             $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 3000000000

--- a/.github/scripts/Tests/cost-completeness.Tests.ps1
+++ b/.github/scripts/Tests/cost-completeness.Tests.ps1
@@ -200,6 +200,23 @@ Describe 'Resolve-CostDataPreservation' {
                 rendered_at                    = $Timestamp
             }
         }
+
+        # Helper: build completeness result WITH token data
+        function script:New-CompletenessResultWithTokens {
+            param(
+                [string]$Completeness = 'complete',
+                [string]$StopReason = 'end_turn',
+                [string]$Timestamp = '2026-01-01T00:00:00Z',
+                [int]$TokenSum = 0
+            )
+            return @{
+                completeness                   = $Completeness
+                stop_reason                    = $StopReason
+                excluded_from_rolling_baseline = ($Completeness -ne 'complete')
+                exclude_reason                 = $null
+                rendered_at                    = $Timestamp
+            }
+        }
     }
 
     It '(complete, any prior) -> use current' {
@@ -273,5 +290,117 @@ Describe 'Resolve-CostDataPreservation' {
         # Resolve-CostDataPreservation just signals use_prior=false so the current data wins.
         $current.excluded_from_rolling_baseline | Should -Be $true
         $current.exclude_reason | Should -Be $excludeReason
+    }
+
+    Context 'populated-predicate (token-magnitude)' {
+        # Non-landing root cause: Code-Conductor posts local render immediately after gh pr create.
+        # Local session is in-flight → completeness='partial', tokens>0. CI runs later on ubuntu-latest
+        # (no transcript) → completeness='unknown', tokens=0. Without the populated predicate, both are
+        # non-complete so Resolve-CostDataPreservation returns use_prior=false → CI zeros overwrite the
+        # populated local render. The populated predicate (sum port tokens > 0) fixes this: a populated
+        # prior always beats an empty current, regardless of completeness or write order.
+
+        It 'empty-complete current must NOT clobber complete-populated prior' {
+            # Cell 2: current=complete tokens=0, prior=complete tokens>0
+            # Current code: complete → use_prior=false (complete always wins). Should be true.
+            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 1500
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 1500
+            $result.use_prior | Should -Be $true
+            $result.notice | Should -Not -BeNullOrEmpty
+        }
+
+        It 'partial-nonzero current beats complete-zero prior' {
+            # Cell 3: current=partial tokens>0, prior=complete tokens=0
+            # Current code: partial + prior=complete → use_prior=true (preserve complete). Should be false.
+            $current = script:New-CompletenessResultWithTokens -Completeness 'partial' -StopReason 'max_tokens' -TokenSum 800
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 800 -PriorTokenSum 0
+            $result.use_prior | Should -Be $false
+        }
+
+        It 'empty-unknown current must NOT clobber unknown-populated prior (CI-overwrites-local scenario)' {
+            # Cell 5: current=unknown tokens=0, prior=unknown tokens>0
+            # This is the dominant non-landing bug: local renders first (unknown, populated),
+            # CI renders second (unknown, zeros). Without populated predicate, both-unknown → use_prior=false → CI wins.
+            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown' -StopReason $null -TokenSum 0
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'unknown' -StopReason $null -TokenSum 1200
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 1200
+            $result.use_prior | Should -Be $true
+            $result.notice | Should -Match 'populated'
+        }
+
+        It 'populated-unknown current beats complete-zero prior' {
+            # Cell 6: current=unknown tokens>0, prior=complete tokens=0
+            # Current code: unknown + prior=complete → use_prior=true (preserve complete). Should be false.
+            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown' -StopReason $null -TokenSum 900
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 900 -PriorTokenSum 0
+            $result.use_prior | Should -Be $false
+        }
+    }
+
+    Context 'populated-predicate — regression guards' {
+        It '#760 regression guard: legacy populated prior (null completeness) still preserved when current is empty' {
+            # Prior has null completeness (legacy render before completeness field existed).
+            # Lines 1741-1746 of call site default null completeness to complete.
+            # Even if the predicate sees it as complete, empty current must not clobber populated prior.
+            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
+            $prior = @{
+                completeness                   = $null
+                stop_reason                    = $null
+                excluded_from_rolling_baseline = $false
+                exclude_reason                 = $null
+                rendered_at                    = '2026-01-01T00:00:00Z'
+                token_sum                      = 2000
+            }
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 2000
+            $result.use_prior | Should -Be $true
+            $result.notice | Should -Not -BeNullOrEmpty
+        }
+
+        It 'both-empty no-op idempotence: both complete tokens=0 -> use current (no churn)' {
+            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 0
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 0
+            $result.use_prior | Should -Be $false
+        }
+
+        It 'both-populated falls back to completeness: current=complete, prior=complete -> use current' {
+            $current = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 1000
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 1500
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 1000 -PriorTokenSum 1500
+            $result.use_prior | Should -Be $false
+        }
+
+        It 'both-populated falls back to completeness: current=partial, prior=complete-populated -> use prior' {
+            $current = script:New-CompletenessResultWithTokens -Completeness 'partial' -StopReason 'max_tokens' -TokenSum 600
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'complete' -StopReason 'end_turn' -TokenSum 1200
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 600 -PriorTokenSum 1200
+            $result.use_prior | Should -Be $true
+            $result.notice | Should -Not -BeNullOrEmpty
+        }
+
+        It 'synthetic-fallback prior (completeness=complete, no ports) + empty current -> use_prior=true via completeness fallback' {
+            # Exercises the path where priorCostData is the frame-credit-ledger synthetic fallback
+            # (@{ completeness = 'complete' }, no ports key) and both token sums are 0.
+            # Both-empty falls through to completeness logic: prior=complete beats current=unknown.
+            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown' -TokenSum 0
+            $prior = @{ completeness = 'complete' }  # synthetic fallback shape -- no ports, no rendered_at
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 0
+            $result.use_prior | Should -Be $true
+        }
+
+        It 'long-boundary: PriorTokenSum > int32.max does not throw and populated prior wins over empty current' {
+            # Regression for CR1 (int->long fix): a token sum exceeding Int32.MaxValue must not throw
+            # ParameterBindingArgumentTransformationException.
+            $current = script:New-CompletenessResultWithTokens -Completeness 'unknown' -TokenSum 0
+            $prior = script:New-CompletenessResultWithTokens -Completeness 'unknown' -TokenSum 0
+            # Invoke in the current scope so $result is populated after the throw-check.
+            { Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 3000000000 } | Should -Not -Throw
+            $result = Resolve-CostDataPreservation -Current $current -Prior $prior -CurrentTokenSum 0 -PriorTokenSum 3000000000
+            $result.use_prior | Should -Be $true  # populated prior (>0) beats empty current
+            $result.notice | Should -Match 'populated'
+        }
     }
 }

--- a/.github/scripts/Tests/cost-pattern-renderer.Tests.ps1
+++ b/.github/scripts/Tests/cost-pattern-renderer.Tests.ps1
@@ -622,6 +622,24 @@ Describe 'Format-CostPatternYaml' {
         $result | Should -Match '(?m)^  cost_estimate_usd: null$'
     }
 
+    It 'emits phase_scope: branch-session-only disclosure field' {
+        $attribution = script:New-YamlAttribution
+        $completeness = script:New-YamlCompleteness
+        $result = Format-CostPatternYaml -Attribution $attribution -Completeness $completeness
+        $result | Should -Match '(?m)^phase_scope: branch-session-only$'
+    }
+
+    It 'emits phase_scope after generated_at and before pr' {
+        $attribution = script:New-YamlAttribution
+        $completeness = script:New-YamlCompleteness
+        $result = Format-CostPatternYaml -Attribution $attribution -Completeness $completeness -Pr 42 -Branch 'test'
+        $generatedAtPos = $result.IndexOf('generated_at:')
+        $phaseScopePos  = $result.IndexOf('phase_scope:')
+        $prPos          = $result.IndexOf("`npr: ")
+        $phaseScopePos | Should -BeGreaterThan $generatedAtPos
+        $phaseScopePos | Should -BeLessThan $prPos
+    }
+
     It 'emits anomaly_flags array' {
         $attribution = script:New-YamlAttribution
         $completeness = script:New-YamlCompleteness
@@ -680,7 +698,7 @@ Describe 'cost-pattern-data schema documentation' {
         $schemaPath | Should -Exist
         $schema = Get-Content -LiteralPath $schemaPath -Raw
 
-        foreach ($field in @('provider_support', 'coverage', 'install_status', 'providers', 'unmapped_session_count')) {
+        foreach ($field in @('provider_support', 'coverage', 'install_status', 'providers', 'unmapped_session_count', 'phase_scope')) {
             $schema | Should -Match "``$field``"
         }
     }

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -1749,7 +1749,56 @@ function Invoke-FrameCreditLedger {
 
             # Fix #760-D1-b: wire the Resolve-CostDataPreservation result instead of discarding it.
             # This drives the skip-when-absent gate below (AC1 + AC2).
-            $preservationResult = Resolve-CostDataPreservation -Current $completeness -Prior $priorCostData
+
+            # Compute current token sum from attribution (populated predicate, issue #777 s2).
+            # Use totals['tokens'] as the authoritative full-session sum (includes overhead +
+            # unattributed tokens that are never placed into any port bucket — CR2).
+            # Fall back to ports-only sum if totals is unavailable (e.g., old data format).
+            [long]$currentTokenSum = 0
+            $currentTotalsTokens = if ($null -ne $costAttribution -and $costAttribution.ContainsKey('totals') -and
+                                        $null -ne $costAttribution['totals'] -and $costAttribution['totals'].ContainsKey('tokens')) {
+                $costAttribution['totals']['tokens']
+            } else { $null }
+            if ($null -ne $currentTotalsTokens) {
+                foreach ($tk in @('input', 'output', 'cache_creation', 'cache_read')) {
+                    if ($currentTotalsTokens.ContainsKey($tk) -and $null -ne $currentTotalsTokens[$tk]) {
+                        $currentTokenSum += [long]$currentTotalsTokens[$tk]
+                    }
+                }
+            } elseif ($null -ne $costAttribution -and $costAttribution.ContainsKey('ports')) {
+                foreach ($portBucket in $costAttribution['ports'].Values) {
+                    if ($null -ne $portBucket -and $portBucket.ContainsKey('tokens')) {
+                        $tok = $portBucket['tokens']
+                        foreach ($tk in @('input', 'output', 'cache_creation', 'cache_read')) {
+                            if ($tok.ContainsKey($tk) -and $null -ne $tok[$tk]) {
+                                $currentTokenSum += [long]$tok[$tk]
+                            }
+                        }
+                    }
+                }
+            }
+
+            # Compute prior token sum from parsed prior YAML (if available).
+            # cost-rolling-history ConvertFrom-CostPatternYaml does not parse totals.tokens, so
+            # use ports-only sum for prior. This is consistent with what was stored.
+            [long]$priorTokenSum = 0
+            if ($null -ne $priorCostData -and $priorCostData.ContainsKey('ports')) {
+                $priorPorts = $priorCostData['ports']
+                # ports is a hashtable keyed by port name (ConvertFrom-CostPatternYaml line 327)
+                $priorPortValues = if ($priorPorts -is [hashtable]) { $priorPorts.Values } elseif ($priorPorts -is [array]) { $priorPorts } else { @() }
+                foreach ($portBucket in $priorPortValues) {
+                    if ($null -ne $portBucket -and $portBucket.ContainsKey('tokens')) {
+                        $tok = $portBucket['tokens']
+                        foreach ($tk in @('input', 'output', 'cache_creation', 'cache_read')) {
+                            if ($tok.ContainsKey($tk) -and $null -ne $tok[$tk]) {
+                                $priorTokenSum += [long]$tok[$tk]
+                            }
+                        }
+                    }
+                }
+            }
+
+            $preservationResult = Resolve-CostDataPreservation -Current $completeness -Prior $priorCostData -CurrentTokenSum $currentTokenSum -PriorTokenSum $priorTokenSum
 
             # Fix #760-D1-a: skip-when-absent gate — if preservation says to use_prior, reuse the
             # prior comment's cost section verbatim.  This fires when the projects root is absent

--- a/.github/scripts/frame-credit-ledger.ps1
+++ b/.github/scripts/frame-credit-ledger.ps1
@@ -1209,6 +1209,22 @@ function script:Get-FCLRemainingCostBudgetSeconds {
     return $remaining
 }
 
+# Sum the four token-count keys (input + output + cache_creation + cache_read)
+# from a single token bucket. Used by both the current-ports-fallback path and
+# the prior-side path (issue #777, R2). The internal $null check subsumes the
+# per-loop bucket null-guard (present key, null value).
+function script:Get-FCLTokenSumFromBucket {
+    param([hashtable]$Bucket)
+    [long]$sum = 0
+    if ($null -eq $Bucket) { return $sum }
+    foreach ($tk in @('input', 'output', 'cache_creation', 'cache_read')) {
+        if ($Bucket.ContainsKey($tk) -and $null -ne $Bucket[$tk]) {
+            $sum += [long]$Bucket[$tk]
+        }
+    }
+    return $sum
+}
+
 # ---------------------------------------------------------------------------
 # Invoke-FrameCreditLedger
 # ---------------------------------------------------------------------------
@@ -1760,20 +1776,11 @@ function Invoke-FrameCreditLedger {
                 $costAttribution['totals']['tokens']
             } else { $null }
             if ($null -ne $currentTotalsTokens) {
-                foreach ($tk in @('input', 'output', 'cache_creation', 'cache_read')) {
-                    if ($currentTotalsTokens.ContainsKey($tk) -and $null -ne $currentTotalsTokens[$tk]) {
-                        $currentTokenSum += [long]$currentTotalsTokens[$tk]
-                    }
-                }
+                $currentTokenSum += script:Get-FCLTokenSumFromBucket -Bucket $currentTotalsTokens
             } elseif ($null -ne $costAttribution -and $costAttribution.ContainsKey('ports')) {
                 foreach ($portBucket in $costAttribution['ports'].Values) {
                     if ($null -ne $portBucket -and $portBucket.ContainsKey('tokens')) {
-                        $tok = $portBucket['tokens']
-                        foreach ($tk in @('input', 'output', 'cache_creation', 'cache_read')) {
-                            if ($tok.ContainsKey($tk) -and $null -ne $tok[$tk]) {
-                                $currentTokenSum += [long]$tok[$tk]
-                            }
-                        }
+                        $currentTokenSum += script:Get-FCLTokenSumFromBucket -Bucket $portBucket['tokens']
                     }
                 }
             }
@@ -1788,12 +1795,7 @@ function Invoke-FrameCreditLedger {
                 $priorPortValues = if ($priorPorts -is [hashtable]) { $priorPorts.Values } elseif ($priorPorts -is [array]) { $priorPorts } else { @() }
                 foreach ($portBucket in $priorPortValues) {
                     if ($null -ne $portBucket -and $portBucket.ContainsKey('tokens')) {
-                        $tok = $portBucket['tokens']
-                        foreach ($tk in @('input', 'output', 'cache_creation', 'cache_read')) {
-                            if ($tok.ContainsKey($tk) -and $null -ne $tok[$tk]) {
-                                $priorTokenSum += [long]$tok[$tk]
-                            }
-                        }
+                        $priorTokenSum += script:Get-FCLTokenSumFromBucket -Bucket $portBucket['tokens']
                     }
                 }
             }

--- a/.github/scripts/lib/cost-completeness.ps1
+++ b/.github/scripts/lib/cost-completeness.ps1
@@ -218,7 +218,15 @@ function Resolve-CostDataPreservation {
         result, determines whether to use prior data (to avoid overwriting a complete render
         with a partial re-run) or use the current data.
 
-        State combinations (9 cases):
+        Populated predicate (token-magnitude, issue #777 s2):
+          A populated block (sum of per-port tokens > 0) is never replaced by an empty/zeros
+          block regardless of completeness or write order. This prevents CI empty runs from
+          clobbering a prior populated local render.
+          If current is populated and prior is empty → use current.
+          If current is empty and prior is populated → use prior (protect real data).
+          Both populated or both empty → fall through to completeness-based logic.
+
+        State combinations (completeness fallback, 9 cases):
           Current = complete                      → use current (fresh data wins)
           Current = partial/unknown, prior = complete → use prior (preserve complete render)
           Both partial/unknown                    → use current (most-recent wins)
@@ -230,6 +238,12 @@ function Resolve-CostDataPreservation {
         Hashtable with at least a 'completeness' key (from Get-SessionCompleteness).
     .PARAMETER Prior
         Optional prior render's completeness hashtable. Pass $null or omit when no prior exists.
+    .PARAMETER CurrentTokenSum
+        Sum of all per-port token counts (input + output + cache_creation + cache_read) for the
+        current session. Used by the populated predicate. Default 0.
+    .PARAMETER PriorTokenSum
+        Sum of all per-port token counts for the prior render. Used by the populated predicate.
+        Default 0.
     .OUTPUTS
         [hashtable] @{ use_prior: $true | $false; notice: <string or $null> }
     #>
@@ -237,9 +251,33 @@ function Resolve-CostDataPreservation {
     [OutputType([hashtable])]
     param(
         [Parameter(Mandatory)][hashtable]$Current,
-        [hashtable]$Prior = $null
+        [hashtable]$Prior = $null,
+        [long]$CurrentTokenSum = 0,
+        [long]$PriorTokenSum = 0
     )
 
+    # Populated predicate: token-magnitude takes precedence over completeness string
+    # populated = sum(per-port tokens) > 0; a populated block is never replaced by an empty one
+    $currentPopulated = $CurrentTokenSum -gt 0
+    $priorPopulated = $PriorTokenSum -gt 0
+
+    if ($currentPopulated -and -not $priorPopulated) {
+        # Current has real data; prior is empty/zeros → current wins regardless of completeness
+        return @{ use_prior = $false; notice = $null }
+    }
+
+    if (-not $currentPopulated -and $priorPopulated) {
+        # Current is empty; prior has real data → protect the populated prior
+        $priorTimestamp = if ($null -ne $Prior) { $Prior['rendered_at'] } else { $null }
+        $noticeText = 'Re-emission preservation (populated): current session has no token data; prior populated render'
+        if ($null -ne $priorTimestamp -and $priorTimestamp -ne '') {
+            $noticeText += " (rendered_at: $priorTimestamp)"
+        }
+        $noticeText += ' was kept to avoid losing real cost data.'
+        return @{ use_prior = $true; notice = $noticeText }
+    }
+
+    # Both populated or both empty: fall through to completeness-based logic
     $currentCompleteness = $Current['completeness']
 
     # Current = complete → always use current (fresh data wins regardless of prior)

--- a/.github/scripts/lib/cost-completeness.ps1
+++ b/.github/scripts/lib/cost-completeness.ps1
@@ -239,8 +239,10 @@ function Resolve-CostDataPreservation {
     .PARAMETER Prior
         Optional prior render's completeness hashtable. Pass $null or omit when no prior exists.
     .PARAMETER CurrentTokenSum
-        Sum of all per-port token counts (input + output + cache_creation + cache_read) for the
-        current session. Used by the populated predicate. Default 0.
+        Total token count for the current session. The caller derives this from totals['tokens']
+        when available (which includes overhead and unattributed tokens outside any per-port
+        bucket), otherwise the sum of per-port token counts (input + output + cache_creation +
+        cache_read). Used by the populated predicate. Default 0.
     .PARAMETER PriorTokenSum
         Sum of all per-port token counts for the prior render. Used by the populated predicate.
         Default 0.

--- a/.github/scripts/lib/cost-pattern-data-schema.md
+++ b/.github/scripts/lib/cost-pattern-data-schema.md
@@ -17,6 +17,7 @@ This document defines the schema for the `<!-- cost-pattern-data ... -->` YAML b
 | `session_completeness` | string | Completeness indicator for the session (e.g., `"complete"`, `"partial"`, `"unknown"`). |
 | `excluded_from_rolling_baseline` | boolean | When `true`, this PR's data is excluded from rolling-baseline calculations (e.g., partial sessions, anomalous runs). |
 | `generated_at` | string (ISO-8601) | UTC timestamp when the payload was generated (e.g., `"2026-04-30T12:00:00Z"`). |
+| `phase_scope` | string | Additive post-#777 disclosure field. Fixed value `branch-session-only` (v1). Indicates the telemetry scope for this block. Human-readable disclosure only; the aggregator does not partition on it. Pre-#777 readers treat unknown fields as null per the additive-only rule. |
 | `pr` | integer | GitHub pull request number this payload is attached to. |
 | `branch` | string | Git branch name associated with the PR. |
 | `provider_support` | array of strings | Additive post-#488 field listing telemetry providers represented by this payload (for example, `["claude", "copilot"]`). Pre-#488 readers default to Claude-only behavior. |

--- a/.github/scripts/lib/cost-pattern-renderer.ps1
+++ b/.github/scripts/lib/cost-pattern-renderer.ps1
@@ -723,6 +723,7 @@ function Format-CostPatternYaml {
     $null = $sb.AppendLine("session_completeness: $completenessValue")
     $null = $sb.AppendLine("excluded_from_rolling_baseline: $excludedStr")
     $null = $sb.AppendLine("generated_at: $generatedAt")
+    $null = $sb.AppendLine('phase_scope: branch-session-only')
     $null = $sb.AppendLine("pr: $Pr")
     $null = $sb.AppendLine("branch: $Branch")
 


### PR DESCRIPTION
## Summary

Fixes the non-landing root cause for issue #777: real token telemetry was being overwritten by CI empty renders because `Resolve-CostDataPreservation` keyed only on the completeness string. A local `partial`/`unknown` render with real tokens had the same completeness class as a CI `unknown` render with zeros ΓÇö both non-complete ΓåÆ `use_prior=false` ΓåÆ CI zeros won.

- **`Resolve-CostDataPreservation`** (cost-completeness.ps1): adds `[long]` `CurrentTokenSum`/`PriorTokenSum` params; populated predicate runs before completeness logic so a populated block is never replaced by an empty one regardless of write order or completeness string
- **`frame-credit-ledger.ps1`**: call site computes `currentTokenSum` from `costAttribution['totals']['tokens']` (authoritative sum including overhead dispatches) and `priorTokenSum` from `priorCostData['ports']`; passes both via `[long]` typed accumulators (prevents `[int]` overflow ΓåÆ OverflowException ΓåÆ silent cost-block erasure)
- **`cost-pattern-renderer.ps1`**: emits `phase_scope: branch-session-only` after `generated_at` (AC5 honest disclosure; aggregator ignores it)
- **`cost-pattern-data-schema.md`**: `phase_scope` row added (additive field, pre-#777 readers treat as null)
- **Tests** (10 new): 8 populated-predicate matrix cells + synthetic-fallback + `[long]` boundary; stale `FAIL-UNTIL-S2:` labels cleaned; dead `token_sum` field removed from test helper

Known limitations (owner-approved, not v1): value-verification, per-port baseline exclusion, merged-PR immutability. Deferred: null-USD-N ΓåÆ #487, shared-SoR contract ΓåÆ #489. Prior-side overhead coverage deferred (rolling-history parser constraint).

Closes #777.

## Test plan

- [x] `cost-completeness.Tests.ps1`: 33/33 (31 pre-existing + 8 populated-predicate matrix + CR5 synthetic-fallback + CR10 `[long]`-boundary)
- [x] `cost-pattern-renderer.Tests.ps1`: 39/39 (37 pre-existing + 2 `phase_scope` golden tests)
- [x] `cost-integration.Tests.ps1`: 30/30
- [x] `cost-rolling-history.Tests.ps1`: 29/29
- [x] Combined cost suites: 131/131 passed, 0 failed
- [x] Adversarial review (5-pass prosecution ΓåÆ defense ΓåÆ judge): FAIL ΓåÆ revision slice applied ΓåÆ all judge-required fixes landed (CR1 `[int]ΓåÆ[long]`, CR2 totals-based sum, CR5/CR10 regression tests, CR7/CR8 hygiene)
- [x] CE Gate: S1ΓÇôS4 scenarios verified; load-bearing decisions articulated

≡ƒñû Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Guard cost telemetry YAML against CI overwriting populated local renders by introducing token-based populated detection and emitting new phase scope metadata.

Bug Fixes:
- Prevent empty or zero-token cost reports from overwriting prior populated telemetry by adding a token-sum-based preservation predicate in Resolve-CostDataPreservation.

Enhancements:
- Compute token sums from attribution data in frame-credit-ledger and pass them as long-typed accumulators into Resolve-CostDataPreservation to avoid overflow and improve preservation decisions.
- Add a phase_scope: branch-session-only disclosure field to cost pattern YAML and document it in the schema as an additive, non-breaking field.

Tests:
- Extend cost completeness and renderer test suites with scenarios covering populated/empty permutations, long boundary behavior, synthetic fallbacks, and phase_scope emission, including schema doc coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `phase_scope: branch-session-only` to generated cost-pattern YAML metadata.
* **Bug Fixes**
  * Improved cost preservation to use token-population precedence, ensuring populated prior output isnΓÇÖt overwritten by empty/zero-current results.
  * Improved safety and correctness for large token totals and key edge scenarios.
* **Documentation**
  * Updated the cost-pattern data schema documentation to include `phase_scope`.
* **Tests**
  * Expanded tests for populated-vs-empty selection, YAML field ordering, and documentation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- pipeline-metrics
pr_number: 783
branch: feature/issue-777-token-telemetry-persistence
metrics_version: 4
frame_version: 1
credits:
  - port: experience
    adapter: work-adapter
    status: complete
    evidence: 'issue #777; experience completion marker posted'
  - port: design
    adapter: work-adapter
    status: complete
    evidence: 'issue #777; design completion marker posted'
  - port: plan
    adapter: work-adapter
    status: complete
    evidence: 'issue #777; plan completion marker posted'
  - port: orchestration
    adapter: scope-classification
    status: complete
    evidence: 'issue #777; scope-classification engagement-record emitted'
  - port: implement-code
    adapter: implement-code-adapter
    status: complete
    evidence: 'issue #777 PR #783; s1-s4 + revision slice; 131/131 cost suites green'
  - port: review
    adapter: standard
    status: complete
    evidence: 'issue #777 PR #783; 5-pass prosecution then defense then judge; verdict FAIL then revised then pass'
  - port: ce-gate
    adapter: ce-gate
    status: complete
    evidence: 'issue #777; S1-S4 scenarios verified; intent match strong'
-->
