### PR TITLE
feat(#704): drain-first umbrella reorder — near-done umbrellas to top

### DIFF
--- a/Documents/Planning/sequence.yaml
+++ b/Documents/Planning/sequence.yaml
@@ -4,4 +4,4 @@
 schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-umbrellas: [476, 761, 571, 674, 662, 343, 693, 732]
+umbrellas: [761, 571, 732, 662, 674, 476, 693, 343]


### PR DESCRIPTION
## Summary

Owner-selected **drain-first** ordering for the Control Tower ranked-umbrella board (decision made in-session via structured question, #704 rank review).

New order: `[761, 571, 732, 662, 674, 476, 693, 343]` (was `[476, 761, 571, 674, 662, 343, 693, 732]`)

**Rationale:**
- #761 (1 open child + newly adopted #768) and #571 (1 open child) are each one PR from closing ΓÇö promote to drain; #761 rides current momentum (#782/#784/#785 shipped last week).
- #732 stays ranked until #751/#752 close (owner decision ΓÇö it was closed as an issue-with-work; its 2 children still need doing). Ranked third as a near-done drain target.
- #662 moves ahead of #674: its four open disposition decisions are what unblock the BLOCKED capstone #671, and #674's review-loop child (#678) builds on the post-migration shape.
- #476 drops to rank 6 pending a child audit (13 open children, mostly April-era follow-ups; #794 adopted as child so the live credit-harvest gap is visible on the board).

**Side effects already applied (GitHub state, not in this diff):** #768 adopted under #761; #794 adopted under #476.

Part of #704 / #692 (derived portfolio tracker).

≡ƒñû Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update ranked umbrella IDs in the planning sequence configuration to reflect the new drain-first ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ordering of the umbrellas priority sequence in the planning document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pipeline-metrics
pr_number: 796
branch: feature/issue-704-drain-first-reorder
metrics_version: 4
frame_version: 1
credits:
  - port: experience
    adapter: work-adapter
    status: passed
    evidence: 'Inline /experience rank-review on Control Tower #704: load-bearing decision d-umbrella-rank-order (drain-first) captured via structured question; L0 gate token emitted (session_key issue-704); analysis doc delivered.'
    terminal-step-id: 1
  - port: implement-docs
    adapter: work-adapter
    status: passed
    evidence: 'Documents/Planning/sequence.yaml umbrellas reordered to owner-selected drain-first [761,571,732,662,674,476,693,343]; 1-line diff; board re-render occurs on merge via render-portfolio.yml. Side effects applied directly: #768 adopted under #761, #794 adopted under #476.'
    terminal-step-id: 1
-->
