### PR TITLE
chore: portfolio sequence — register #801 (last), re-rank #343 to 4th, #693 to 5th, swap #674 ahead of #662

### DIFF
--- a/Documents/Planning/sequence.yaml
+++ b/Documents/Planning/sequence.yaml
@@ -4,4 +4,4 @@
 schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-umbrellas: [761, 571, 732, 343, 662, 674, 476, 693, 801]
+umbrellas: [761, 571, 732, 343, 693, 662, 674, 476, 801]

--- a/Documents/Planning/sequence.yaml
+++ b/Documents/Planning/sequence.yaml
@@ -4,4 +4,4 @@
 schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-umbrellas: [761, 571, 732, 662, 674, 476, 693, 343, 801]
+umbrellas: [761, 571, 732, 343, 662, 674, 476, 693, 801]

--- a/Documents/Planning/sequence.yaml
+++ b/Documents/Planning/sequence.yaml
@@ -4,4 +4,4 @@
 schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-umbrellas: [761, 571, 732, 662, 674, 476, 693, 343]
+umbrellas: [761, 571, 732, 662, 674, 476, 693, 343, 801]

--- a/Documents/Planning/sequence.yaml
+++ b/Documents/Planning/sequence.yaml
@@ -4,4 +4,4 @@
 schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-umbrellas: [761, 571, 732, 343, 693, 662, 674, 476, 801]
+umbrellas: [761, 571, 732, 343, 693, 674, 662, 476, 801]


### PR DESCRIPTION
Two portfolio-sequence changes in `Documents/Planning/sequence.yaml`, authored via the GitHub contents API (no local working-tree contact; an active session is implementing #791 in the primary workspace):

1. **Register umbrella #801** (owner-facing read surfaces) at the **end** of the `umbrellas:` list — deliberately lowest rank: permanently visible on the control tower, behind everything else. Rationale in #801's body; first child #802 already attached.
2. **Re-rank umbrella #343** (Thin Harness, Fat Skills) from last to **4th** — its keystone remaining child #348 (learning loop) now carries `priority: high`, gates #439, and has a 90-day deferral tripwire firing 2026-08-01. Placed after #732 so the readability family (#751, #752) finishes first, per maintainer decision.
3. **Re-rank umbrella #693** (AI-first documentation gap-analysis) from 8th to **5th** — its doc/script drift-bomb class (child #695) produced a live high-priority defect this week (#800, now attached as a #693 child), and #697/#698 carry review-pipeline-integrity and side-effect-guard findings, not just doc polish.
4. **Swap #674 ahead of #662** — dependency order: the spine-runner conductor buildout (#674) must complete before the specialist-shell retirement capstone (#671 under #662) runs, so shells retire in the /spine-run world instead of adding transitional Code-Conductor dispatch work that #677 later deletes. #671's blocked-by now includes #642 to encode this.

Resulting order: `[761, 571, 732, 343, 693, 674, 662, 476, 801]`

Related: #801, #802, #348, #751, #800, #693, #805–#809 (new #674/#662 children), #592/#640/#641/#642/#677 (now parented under #343).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
