### PR TITLE
docs: add Quality-first, shift-left governing principle to CLAUDE.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "3.3.4"
+    "version": "3.3.5"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-      "version": "3.3.4",
+      "version": "3.3.5",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot",
-    "version": "3.3.4"
+    "version": "3.3.5"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot with 16 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "3.3.4"
+      "version": "3.3.5"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to agent-orchestra will be documented in this file.
 
+## [3.3.5] — 2026-07-07
+
+### Added
+
+Add a Quality-first, shift-left governing-principle section to CLAUDE.md: quality ahead of speed/cost, catch defects as early in the pipeline as possible, and relax later review stages only on phase-containment escape-rate data (never a cost argument). Links the phase-containment ledger instrument and umbrella #761.
+
 ## [3.3.4] — 2026-07-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,12 @@ claude plugin install <plugin@marketplace>
 claude plugin uninstall <plugin@marketplace>
 ```
 
+## Quality-first, shift-left
+
+Quality is the first constraint — ahead of speed and token cost; when they conflict, the methodology checkpoint wins (hence engagement gates and adversarial review are non-overridable by pacing directives). We shift defects **left**: the earlier in the pipeline (experience → design → plan → implementation) a defect is caught, the cheaper it is to fix, so every phase and review stage exists to catch a class before it reaches the next. Run the full methodology now — do not pre-emptively skip a stage because it "probably won't find anything."
+
+We remove later checks **only with evidence, never on a cost argument**: a stage earns relaxation only when its *irreducible-catch rate* (defects catchable **only** at that stage) trends to ~0 over a large-enough sample. The instrument is the **phase-containment ledger** — the per-finding record of where a defect was introduced, the earliest phase it was catchable, and where it was caught ([Documents/Design/phase-containment-ledger.md](Documents/Design/phase-containment-ledger.md)); governance lives in umbrella #761. So annotate every sustained finding, and retire later steps once they demonstrably catch nothing new.
+
 ## Engagement-gate non-overridability
 
 <!-- engagement-gate-non-overridability:begin -->

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > ⚠️ **GitHub Copilot / VS Code support is frozen and retiring after 2026-08-31.**
 > Claude Code is the actively supported path. See [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md) for details and the reach-out channel if you depend on Copilot support.
 
-[![Version](https://img.shields.io/badge/version-v3.3.4-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v3.3.5-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development through specialized Claude Code agents. *(GitHub Copilot/VS Code: frozen and retiring after 2026-08-31 — see [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md))*

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "author": {
     "name": "Grimblaz"
   },


### PR DESCRIPTION
## What

Adds a `## Quality-first, shift-left` section to `CLAUDE.md`, placed immediately before `## Engagement-gate non-overridability` so the principle reads first and its enforcement mechanisms follow.

## Why

The concept was already half-built: the **phase-containment ledger** ([Documents/Design/phase-containment-ledger.md](Documents/Design/phase-containment-ledger.md)) measures per-stage escape/irreducible-catch rates, and umbrella #761 owns the relaxation governance — but that lives in a design doc agents never load. There was no always-loaded, agent-facing statement of the *why*. This puts it in the one file every agent reads at session start, alongside the gates that enforce it.

The section states three things:
- Quality is the first constraint, ahead of speed and token cost.
- Shift defects **left** — catch each class as early in the pipeline as possible.
- Remove later checks **only with evidence** (phase-containment escape-rate data trending to ~0), **never on a cost argument**.

It's written outsider-first (first-use-expanded), consistent with the #751 convention it now sits above.

## Changes

- `CLAUDE.md` — new section (markdownlint clean).
- Version `3.3.4` → `3.3.5` across 7 occurrences / 5 files via `bump-version.ps1` (entry-point cache invalidation).
- `CHANGELOG.md` — `## [3.3.5]` / `### Added`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document a new quality-first, shift-left governing principle and bump the project version.

Build:
- Bump project version from 3.3.4 to 3.3.5 across README and plugin manifest files.

Documentation:
- Add a Quality-first, shift-left principle section to CLAUDE.md describing quality as the primary constraint, early defect capture, and evidence-based relaxation of later checks.
- Record the new principle and its rationale in CHANGELOG.md under version 3.3.5.