### PR TITLE
feat(#751): outsider-first authoring default + newcomer-audit detector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "3.3.5"
+    "version": "3.3.6"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-      "version": "3.3.5",
+      "version": "3.3.6",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot",
-    "version": "3.3.5"
+    "version": "3.3.6"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot with 16 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "3.3.5"
+      "version": "3.3.6"
     }
   ]
 }

--- a/.github/scripts/Tests/NamingRegisterLivingSurface.Tests.ps1
+++ b/.github/scripts/Tests/NamingRegisterLivingSurface.Tests.ps1
@@ -2,7 +2,11 @@
 # Bounded living-surface guard for issue #750 (parent: #732 naming-register-policy).
 # LIMITATIONS (not silent caps):
 #   - Surface list is hardcoded (not auto-discovered). New surfaces must be added here manually.
-#     Growth-enforcement for new surfaces is #751's scope, not this guard.
+#     #751's newcomer-audit detector has shipped, but it deliberately does NOT do surface
+#     auto-discovery in v1 — the changed-files filter it consumes is this same kind of
+#     documented, hand-maintained class list, not an automatic one. If auto-discovery
+#     tooling is ever built, it would live behind the spin-out promotion trigger documented
+#     in skills/naming-register-policy/SKILL.md § Outsider-first authoring default.
 #   - "now-coupled / wall-clock dependent" term-absence assertions are FORWARD GUARDS:
 #     zero current in-scope occurrences; the assertion prevents future regressions.
 #   - Term-absence assertions use hardcoded string literals (static decision). The register
@@ -14,7 +18,9 @@
 BeforeAll {
     $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
 
-    # The enumerated in-scope surface list (hardcoded per design; #751 owns auto-discovery)
+    # The enumerated in-scope surface list (hardcoded per design; #751's shipped detector
+    # deliberately does not auto-discover surfaces in v1 — see the spin-out promotion
+    # trigger in skills/naming-register-policy/SKILL.md § Outsider-first authoring default)
     $script:AllSurfaces = @(
         'CLAUDE.md'
         'skills/README.md'

--- a/.github/scripts/Tests/newcomer-audit-wrapper.Tests.ps1
+++ b/.github/scripts/Tests/newcomer-audit-wrapper.Tests.ps1
@@ -1,0 +1,244 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Pester tests for skills/naming-register-policy/scripts/newcomer-audit.ps1 (s3).
+
+.DESCRIPTION
+    Covers the wrapper's own responsibilities on top of the s2 detector core:
+    diff-hunk parsing (added-line grain), the human-facing surface-class path
+    filter, merge-base (not literal 'main..HEAD') diff-range correctness, the
+    full-post-image-suppression-vs-added-line-emission split (plan-issue-751
+    MF5), and -Path mode's issue-body-semantics CLI behavior end to end.
+
+    The wrapper script guards its CLI/`exit`-calling main block behind
+    `if ($MyInvocation.InvocationName -ne '.')`, so dot-sourcing it here (as
+    this file's BeforeAll does) only defines functions and binds params -- it
+    never shells out to git or calls `exit`, which would otherwise terminate
+    the Pester host process.
+#>
+
+BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:WrapperPath = Join-Path $script:RepoRoot 'skills/naming-register-policy/scripts/newcomer-audit.ps1'
+
+    . $script:WrapperPath
+
+    $script:RegisterPath = Join-Path $script:RepoRoot 'skills/naming-register-policy/assets/register.json'
+    $script:Register = Get-Content -Path $script:RegisterPath -Raw | ConvertFrom-Json
+}
+
+Describe 'newcomer-audit wrapper: diff-hunk parsing' {
+    It 'marks only "+"-prefixed lines within a hunk as added, using new-file line numbers' {
+        $diffLines = @(
+            'diff --git a/docs/example.md b/docs/example.md',
+            'index 1111111..2222222 100644',
+            '--- a/docs/example.md',
+            '+++ b/docs/example.md',
+            '@@ -1,3 +1,4 @@',
+            ' unchanged line one',
+            '-removed line',
+            '+added line two',
+            '+added line three',
+            ' unchanged line four'
+        )
+
+        $parsed = ConvertTo-NewcomerAuditParsedDiff -DiffLines $diffLines
+
+        $parsed | Should -HaveCount 1
+        $parsed[0].Path | Should -Be 'docs/example.md'
+        $parsed[0].AddedLines.Contains(2) | Should -BeTrue
+        $parsed[0].AddedLines.Contains(3) | Should -BeTrue
+        $parsed[0].AddedLines.Contains(1) | Should -BeFalse
+        $parsed[0].AddedLines.Contains(4) | Should -BeFalse
+    }
+
+    It 'tracks multiple files independently across hunk and file boundaries' {
+        $diffLines = @(
+            'diff --git a/CLAUDE.md b/CLAUDE.md',
+            'index aaa..bbb 100644',
+            '--- a/CLAUDE.md',
+            '+++ b/CLAUDE.md',
+            '@@ -10,2 +10,3 @@',
+            ' context',
+            '+new claude line',
+            ' context',
+            'diff --git a/README.md b/README.md',
+            'index ccc..ddd 100644',
+            '--- a/README.md',
+            '+++ b/README.md',
+            '@@ -1,1 +1,2 @@',
+            '+new readme line',
+            ' context'
+        )
+
+        $parsed = ConvertTo-NewcomerAuditParsedDiff -DiffLines $diffLines
+
+        $parsed | Should -HaveCount 2
+        ($parsed | Where-Object { $_.Path -eq 'CLAUDE.md' }).AddedLines.Contains(11) | Should -BeTrue
+        ($parsed | Where-Object { $_.Path -eq 'README.md' }).AddedLines.Contains(1) | Should -BeTrue
+    }
+}
+
+Describe 'newcomer-audit wrapper: human-facing surface-class path filter' {
+    It 'accepts the documented human-facing surface classes' {
+        Test-NewcomerAuditSurfaceClassPath -Path 'CLAUDE.md' | Should -BeTrue
+        Test-NewcomerAuditSurfaceClassPath -Path 'HOW-IT-WORKS.md' | Should -BeTrue
+        Test-NewcomerAuditSurfaceClassPath -Path 'README.md' | Should -BeTrue
+        Test-NewcomerAuditSurfaceClassPath -Path 'skills/naming-register-policy/README.md' | Should -BeTrue
+        Test-NewcomerAuditSurfaceClassPath -Path 'skills/naming-register-policy/SKILL.md' | Should -BeTrue
+        Test-NewcomerAuditSurfaceClassPath -Path 'Documents/Design/some-doc.md' | Should -BeTrue
+        Test-NewcomerAuditSurfaceClassPath -Path '.github/ISSUE_TEMPLATE/bug.yml' | Should -BeTrue
+        Test-NewcomerAuditSurfaceClassPath -Path '.github/PULL_REQUEST_TEMPLATE.md' | Should -BeTrue
+    }
+
+    It 'rejects files outside the human-facing surface class list' {
+        Test-NewcomerAuditSurfaceClassPath -Path 'skills/naming-register-policy/scripts/newcomer-audit-core.ps1' | Should -BeFalse
+        Test-NewcomerAuditSurfaceClassPath -Path '.github/scripts/Tests/newcomer-audit.Tests.ps1' | Should -BeFalse
+        Test-NewcomerAuditSurfaceClassPath -Path 'agents/Issue-Planner.agent.md' | Should -BeFalse
+    }
+}
+
+Describe 'newcomer-audit wrapper: merge-base correctness (AC7)' {
+    It 'diffs from the resolved merge-base commit, never the literal branch name "main"' {
+        $script:CapturedMergeBase = $null
+
+        Mock -CommandName Get-NewcomerAuditRawDiff -MockWith {
+            param($RepoRoot, $MergeBase)
+            $script:CapturedMergeBase = $MergeBase
+            return , @()
+        }
+
+        # A real merge-base resolves to a commit SHA, never the literal string
+        # 'main' -- simulate that shape here rather than requiring a git fixture.
+        $simulatedMergeBase = 'deadbeef1234'
+        $null = Get-NewcomerAuditRawDiff -RepoRoot $script:RepoRoot -MergeBase $simulatedMergeBase
+
+        $script:CapturedMergeBase | Should -Be 'deadbeef1234'
+        $script:CapturedMergeBase | Should -Not -Be 'main'
+    }
+
+    It 'resolves the merge-base of main and HEAD in the live repo (sanity check, not mocked)' {
+        $mergeBase = Get-NewcomerAuditMergeBase -RepoRoot $script:RepoRoot
+
+        $mergeBase | Should -Not -BeNullOrEmpty
+        $mergeBase | Should -Not -Be 'main'
+        $mergeBase | Should -MatchExactly '^[0-9a-f]{7,40}$'
+    }
+}
+
+Describe 'newcomer-audit wrapper: full-post-image suppression vs added-line emission grain (MF5)' {
+    It 'suppresses a term whose footer vocab-pointer link sits outside the changed region, using full-file content' {
+        $fullFileContent = @'
+# Doc
+
+Spine-Runner walks the plan step by step.
+
+More unrelated prose here so the footer link is far away from any edits.
+
+---
+
+See [vocab reference](HOW-IT-WORKS.md#vocab) for term definitions.
+'@
+        # Only line 3 ("Spine-Runner ...") is "added" per the diff -- the footer
+        # link on the last line is unchanged/pre-existing.
+        $addedLines = [System.Collections.Generic.HashSet[int]]::new()
+        [void]$addedLines.Add(3)
+
+        $allFindings = Get-NewcomerAuditFindings -Content $fullFileContent -Surface 'repo-file' -Register $script:Register
+        $emitted = @($allFindings | Where-Object { $addedLines.Contains([int]$_.line) })
+
+        ($allFindings | Where-Object { $_.token -eq 'Spine-Runner' }) | Should -BeNullOrEmpty -Because 'the footer link suppresses it against the full-file context'
+        $emitted | Should -BeNullOrEmpty
+    }
+
+    It 'still flags an unexpanded term on its own added line when nothing in the file suppresses it' {
+        $fullFileContent = @'
+# Doc
+
+The credits[] array holds pipeline credits.
+
+More unrelated prose here.
+'@
+        $addedLines = [System.Collections.Generic.HashSet[int]]::new()
+        [void]$addedLines.Add(3)
+
+        $allFindings = Get-NewcomerAuditFindings -Content $fullFileContent -Surface 'repo-file' -Register $script:Register
+        $emitted = @($allFindings | Where-Object { $addedLines.Contains([int]$_.line) })
+
+        ($emitted | Where-Object { $_.token -eq 'credits[]' }) | Should -Not -BeNullOrEmpty -Because 'the added line carrying the unsuppressed term must still surface'
+    }
+
+    It 'never emits a finding that exists only on an unchanged line of a touched file' {
+        $fullFileContent = @'
+# Doc
+
+The credits[] array holds pipeline credits.
+
+A newly added, unrelated line goes here.
+'@
+        # credits[] is on line 3 (unchanged); only line 5 is "added" per the diff.
+        $addedLines = [System.Collections.Generic.HashSet[int]]::new()
+        [void]$addedLines.Add(5)
+
+        $allFindings = Get-NewcomerAuditFindings -Content $fullFileContent -Surface 'repo-file' -Register $script:Register
+        $emitted = @($allFindings | Where-Object { $addedLines.Contains([int]$_.line) })
+
+        ($allFindings | Where-Object { $_.token -eq 'credits[]' }) | Should -Not -BeNullOrEmpty -Because 'the core still finds it against full-file content'
+        ($emitted | Where-Object { $_.token -eq 'credits[]' }) | Should -BeNullOrEmpty -Because 'emission is scoped to added/modified lines only, per MF5'
+    }
+}
+
+Describe 'newcomer-audit wrapper: -Path mode CLI integration (issue-body semantics)' {
+    It 'flags an unexpanded stable-code term and exits 1' {
+        $tempPath = Join-Path ([System.IO.Path]::GetTempPath()) "newcomer-audit-wrapper-fixture-$([guid]::NewGuid()).md"
+        try {
+            [System.IO.File]::WriteAllText($tempPath, 'The CE Gate must pass before merge.', [System.Text.UTF8Encoding]::new($false))
+
+            $output = & pwsh -NoLogo -NoProfile -File $script:WrapperPath -Path $tempPath -Json 2>&1
+            $exitCode = $LASTEXITCODE
+
+            $exitCode | Should -Be 1
+            $parsed = ($output -join "`n") | ConvertFrom-Json
+            ($parsed | Where-Object { $_.token -eq 'CE Gate' }) | Should -Not -BeNullOrEmpty
+        }
+        finally {
+            Remove-Item -Path $tempPath -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'exits 0 with an empty JSON array for clean prose' {
+        $tempPath = Join-Path ([System.IO.Path]::GetTempPath()) "newcomer-audit-wrapper-clean-$([guid]::NewGuid()).md"
+        try {
+            [System.IO.File]::WriteAllText($tempPath, 'Ordinary prose with no jargon at all.', [System.Text.UTF8Encoding]::new($false))
+
+            $output = & pwsh -NoLogo -NoProfile -File $script:WrapperPath -Path $tempPath -Json 2>&1
+            $exitCode = $LASTEXITCODE
+
+            $exitCode | Should -Be 0
+            $parsed = ($output -join "`n") | ConvertFrom-Json
+            @($parsed) | Should -HaveCount 0
+        }
+        finally {
+            Remove-Item -Path $tempPath -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'rejects specifying both -Path and -Changed with exit code 2' {
+        $tempPath = Join-Path ([System.IO.Path]::GetTempPath()) "newcomer-audit-wrapper-conflict-$([guid]::NewGuid()).md"
+        try {
+            [System.IO.File]::WriteAllText($tempPath, 'irrelevant', [System.Text.UTF8Encoding]::new($false))
+
+            $null = & pwsh -NoLogo -NoProfile -File $script:WrapperPath -Path $tempPath -Changed 2>&1
+            $LASTEXITCODE | Should -Be 2
+        }
+        finally {
+            Remove-Item -Path $tempPath -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'rejects specifying neither -Path nor -Changed with exit code 2' {
+        $null = & pwsh -NoLogo -NoProfile -File $script:WrapperPath 2>&1
+        $LASTEXITCODE | Should -Be 2
+    }
+}

--- a/.github/scripts/Tests/newcomer-audit-wrapper.Tests.ps1
+++ b/.github/scripts/Tests/newcomer-audit-wrapper.Tests.ps1
@@ -242,3 +242,87 @@ Describe 'newcomer-audit wrapper: -Path mode CLI integration (issue-body semanti
         $LASTEXITCODE | Should -Be 2
     }
 }
+
+Describe 'newcomer-audit wrapper: real end-to-end -Changed pipeline (regression lock-in)' {
+    # Every other wrapper test above either mocks the diff or reimplements the
+    # added-line filter inline -- none of them invoke the real wrapper binary
+    # against a real git repo in -Changed mode. That gap is exactly why the
+    # rename-exclusion (fix #9) and diff-header-spoof (fix #12) defects
+    # shipped invisibly through 66 "passing" tests. This test builds a real
+    # temporary git repo, runs the actual wrapper script as a subprocess with
+    # -Changed -Json, and pins both regressions against real findings and a
+    # real exit code.
+    It 'finds a renamed-and-edited doc and survives a diff-syntax-spoofing added line' {
+        $tempRepo = Join-Path ([System.IO.Path]::GetTempPath()) "newcomer-audit-e2e-$([guid]::NewGuid())"
+        New-Item -ItemType Directory -Path $tempRepo -Force | Out-Null
+
+        Push-Location $tempRepo
+        try {
+            & git init -q -b main . 2>&1 | Out-Null
+            & git config user.email 'newcomer-audit-e2e@example.com' 2>&1 | Out-Null
+            & git config user.name 'newcomer-audit-e2e' 2>&1 | Out-Null
+
+            $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+
+            # Seed 'main' with a CLAUDE.md-shaped file and a Documents/Design/
+            # doc long enough to preserve a high rename-similarity score once
+            # it is renamed AND edited on the feature branch.
+            [System.IO.File]::WriteAllText((Join-Path $tempRepo 'CLAUDE.md'), "# Root doc`n`nOrdinary prose, no jargon here.`n", $utf8NoBom)
+
+            New-Item -ItemType Directory -Path (Join-Path $tempRepo 'Documents/Design') -Force | Out-Null
+            $originalDocContent = @'
+# Design Doc
+
+This document is long enough and distinctive enough that renaming it
+while making a small edit still preserves a high content-similarity
+score for git's rename detector.
+
+Filler line one.
+Filler line two.
+Filler line three.
+Filler line four.
+'@
+            [System.IO.File]::WriteAllText((Join-Path $tempRepo 'Documents/Design/original-doc.md'), $originalDocContent, $utf8NoBom)
+
+            & git add -A 2>&1 | Out-Null
+            & git commit -q -m 'seed main' 2>&1 | Out-Null
+
+            & git checkout -q -b feature/e2e-test 2>&1 | Out-Null
+
+            # (a) Rename-and-edit case (pins fix #9): rename the design doc AND
+            # add an unexpanded stable-code term in the same commit.
+            & git mv 'Documents/Design/original-doc.md' 'Documents/Design/renamed-doc.md' 2>&1 | Out-Null
+            Add-Content -Path (Join-Path $tempRepo 'Documents/Design/renamed-doc.md') -Value "`nSee SMC-08 for the specific rule." -Encoding utf8NoBOM
+
+            # (b) Diff-header-spoof case (pins fix #12): the added file content
+            # line is exactly '++ b/fake-spoof.md' -- git's own '+' diff marker
+            # turns this into a raw diff line of '+++ b/fake-spoof.md', which
+            # is textually indistinguishable from a genuine file header. The
+            # very next added line carries a real unexpanded stable-code term
+            # ('CE Gate'); if the spoof line wrongly resets the parser's
+            # current-file state, that finding is silently dropped.
+            Add-Content -Path (Join-Path $tempRepo 'CLAUDE.md') -Value '++ b/fake-spoof.md' -Encoding utf8NoBOM
+            Add-Content -Path (Join-Path $tempRepo 'CLAUDE.md') -Value 'See CE Gate for details.' -Encoding utf8NoBOM
+
+            & git add -A 2>&1 | Out-Null
+            & git commit -q -m 'feature: rename+edit doc, add spoof + real term to CLAUDE.md' 2>&1 | Out-Null
+
+            $output = & pwsh -NoLogo -NoProfile -File $script:WrapperPath -Changed -Json 2>&1
+            $exitCode = $LASTEXITCODE
+
+            $exitCode | Should -Be 1 -Because "output was: $($output -join "`n")"
+
+            $findings = ($output -join "`n") | ConvertFrom-Json
+
+            ($findings | Where-Object { $_.file -eq 'Documents/Design/renamed-doc.md' -and $_.token -eq 'SMC-08' }) |
+                Should -Not -BeNullOrEmpty -Because 'the renamed-and-edited doc must still be scanned under --diff-filter=ACMR (fix #9)'
+
+            ($findings | Where-Object { $_.file -eq 'CLAUDE.md' -and $_.token -eq 'CE Gate' }) |
+                Should -Not -BeNullOrEmpty -Because 'the real added-line finding after the spoofed +++ b/ line must survive (fix #12)'
+        }
+        finally {
+            Pop-Location
+            Remove-Item -Path $tempRepo -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/.github/scripts/Tests/newcomer-audit.Tests.ps1
+++ b/.github/scripts/Tests/newcomer-audit.Tests.ps1
@@ -213,6 +213,52 @@ Describe 'newcomer-audit-core: file-based entry point' {
     }
 }
 
+Describe 'newcomer-audit-core: -AllOccurrences multi-occurrence behavior (CR-D)' {
+    It 'without -AllOccurrences, a later occurrence of the same term is suppressed by an earlier occurrence' {
+        $content = @'
+# Doc
+
+The CE Gate must pass here.
+
+Unrelated line.
+
+The CE Gate must pass again here on a later line.
+'@
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+
+        $ceGateFindings = @($findings | Where-Object { $_.token -eq 'CE Gate' })
+        $ceGateFindings | Should -HaveCount 1 -Because 'default behavior is first-occurrence-only'
+        $ceGateFindings[0].line | Should -Be 3
+        ($ceGateFindings | Where-Object { $_.line -eq 7 }) | Should -BeNullOrEmpty -Because 'the later occurrence must not surface without -AllOccurrences'
+    }
+
+    It 'with -AllOccurrences, a genuinely new occurrence on a later line is not suppressed by an earlier occurrence' {
+        $content = @'
+# Doc
+
+The CE Gate must pass here.
+
+Unrelated line.
+
+The CE Gate must pass again here on a later line.
+'@
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register -AllOccurrences
+
+        $ceGateFindings = @($findings | Where-Object { $_.token -eq 'CE Gate' })
+        ($ceGateFindings | Where-Object { $_.line -eq 3 }) | Should -Not -BeNullOrEmpty -Because 'the earlier occurrence must still surface'
+        ($ceGateFindings | Where-Object { $_.line -eq 7 }) | Should -Not -BeNullOrEmpty -Because 'the later occurrence must not be suppressed by the earlier one'
+    }
+
+    It 'with -AllOccurrences, the same term repeated twice on the SAME line produces exactly one finding for that (token, line) pair' {
+        $content = 'The CE Gate and the CE Gate again must both pass.'
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register -AllOccurrences
+
+        $ceGateFindings = @($findings | Where-Object { $_.token -eq 'CE Gate' })
+        $ceGateFindings | Should -HaveCount 1 -Because 'a term repeated on the same line is the same finding, not new information -- no duplicate (token, line) rows'
+        $ceGateFindings[0].line | Should -Be 1
+    }
+}
+
 Describe 'newcomer-audit-core: determinism' {
     It 'returns the same findings for the same input across repeated calls' {
         $content = 'See SMC-20 and the credits[] array. We should retire Value Reflex.'

--- a/.github/scripts/Tests/newcomer-audit.Tests.ps1
+++ b/.github/scripts/Tests/newcomer-audit.Tests.ps1
@@ -1,0 +1,224 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Pester tests for skills/naming-register-policy/scripts/newcomer-audit-core.ps1.
+
+.DESCRIPTION
+    Covers the AC9 fixture matrix from plan-issue-751 (s2): the core's
+    read/normalize, machine-citation-zone stripping, register-driven match-set
+    construction (tokenized compound terms, instance patterns, literal terms),
+    split-by-surface known-term escape hatch, and the digit/underscore/bracket
+    unknown-token pass.
+
+    Loads the real production register.json (not a synthetic subset) so these
+    tests exercise the actual match-set the detector will run against.
+#>
+
+BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:CoreFile = Join-Path $script:RepoRoot 'skills/naming-register-policy/scripts/newcomer-audit-core.ps1'
+    . $script:CoreFile
+
+    $script:RegisterPath = Join-Path $script:RepoRoot 'skills/naming-register-policy/assets/register.json'
+    $script:Register = Get-Content -Path $script:RegisterPath -Raw | ConvertFrom-Json
+}
+
+Describe 'newcomer-audit-core: unexpanded stable-code term in issue-body surface' {
+    It 'flags the term (issue-body offers no other escape hatch)' {
+        $content = 'The CE Gate must pass before the PR is created.'
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'issue-body' -Register $script:Register
+
+        $findings | Should -Not -BeNullOrEmpty
+        ($findings | Where-Object { $_.token -eq 'CE Gate' }).register_state | Should -Be 'stable-code'
+    }
+}
+
+Describe 'newcomer-audit-core: expanded stable-code term (loose parenthetical)' {
+    It 'does not flag when the first use is immediately followed by a parenthetical' {
+        $content = 'The CE Gate (the final validation step) must pass before the PR is created.'
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'issue-body' -Register $script:Register
+
+        ($findings | Where-Object { $_.token -eq 'CE Gate' }) | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'newcomer-audit-core: compound sub-token resolves as a known registered term' {
+    Context 'the specific false-positive the adversarial review caught (MF1)' {
+        It 'a naive full-term-literal match never recognizes the bare sub-token as known' {
+            # This is not the production code path -- it proves the defect this
+            # slice fixes is real, not a strawman. The register's 'term' field for
+            # this row is the full compound string "credits[] / pipeline-metrics
+            # block"; a naive matcher that escapes and matches that string
+            # verbatim will never match the bare "credits[]" substring that
+            # actually appears in prose.
+            $row = $script:Register | Where-Object { $_.term -like 'credits*' }
+            $row | Should -Not -BeNullOrEmpty -Because "the credits[] family row must exist in the live register"
+
+            $content = 'The credits[] array holds pipeline credits.'
+            $naivePattern = [regex]::Escape($row.term)
+            [regex]::IsMatch($content, $naivePattern) | Should -BeFalse -Because 'a literal full-term match never finds the bare sub-token -- this is the real defect, not a strawman'
+        }
+
+        It 'the fixed core resolves the bare credits[] sub-token as stable-code, not unknown' {
+            $content = 'The credits[] array holds pipeline credits.'
+            $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+
+            $creditsFindings = @($findings | Where-Object { $_.token -eq 'credits[]' })
+            $creditsFindings | Should -Not -BeNullOrEmpty -Because 'credits[] is an unsuppressed stable-code component and must be recognized'
+            $creditsFindings[0].register_state | Should -Be 'stable-code' -Because 'it must resolve via the register component tokenizer, never fall through to the unknown-token pass'
+        }
+
+        It 'suppresses the same sub-token when the file carries the vocab-pointer link' {
+            $content = 'See HOW-IT-WORKS.md#vocab for background. The credits[] array holds pipeline credits.'
+            $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+
+            ($findings | Where-Object { $_.token -eq 'credits[]' }) | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'newcomer-audit-core: repo-file surface full-file suppression context' {
+    It 'suppresses a stable-code flag when the vocab-pointer link line is present elsewhere in the file' {
+        $content = @'
+# Some Doc
+
+Spine-Runner walks the plan step by step.
+
+---
+
+See [vocab reference](HOW-IT-WORKS.md#vocab) for term definitions.
+'@
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+
+        ($findings | Where-Object { $_.token -eq 'Spine-Runner' }) | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'newcomer-audit-core: machine-context code inside stripped zones' {
+    It 'does not flag a stable code that only appears in a fenced block, an HTML comment, or YAML frontmatter' {
+        $content = @'
+---
+marker: SMC-08
+---
+
+<!-- SMC-08 also mentioned here in a machine comment -->
+
+Some ordinary prose with no codes at all.
+
+```text
+SMC-08 appears only inside this fenced code block.
+```
+'@
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+
+        $findings | Should -BeNullOrEmpty -Because 'every SMC-08 occurrence is inside a stripped machine-citation zone'
+    }
+}
+
+Describe 'newcomer-audit-core: non-jargon digit-bearing allowlist' {
+    It 'does not flag ISO-8601, UTF-8, or draft-07' {
+        $content = 'Dates in this repo use ISO-8601 formatting; UTF-8 encoding is required; see draft-07 of the schema.'
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+
+        $findings | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'newcomer-audit-core: unknown-token pass' {
+    It 'flags an unregistered snake_case coinage' {
+        $content = 'We are introducing a new some_random_flag_v2 config option this release.'
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+
+        $match = $findings | Where-Object { $_.token -eq 'some_random_flag_v2' }
+        $match | Should -Not -BeNullOrEmpty
+        $match.register_state | Should -Be 'unknown'
+    }
+
+    It 'does not flag a bare ALL-CAPS acronym with no digit, underscore, or bracket (out of scope for v1)' {
+        $content = 'The PR must pass CI before merge.'
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+
+        $findings | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'newcomer-audit-core: instance_pattern family rows' {
+    It 'flags SMC-20 and plan-issue-732 as known stable-code needing expansion' {
+        $content = 'See SMC-20 and plan-issue-732 for details.'
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'issue-body' -Register $script:Register
+
+        ($findings | Where-Object { $_.token -eq 'SMC-20' }).register_state | Should -Be 'stable-code'
+        ($findings | Where-Object { $_.token -eq 'plan-issue-732' }).register_state | Should -Be 'stable-code'
+    }
+}
+
+Describe 'newcomer-audit-core: rename-candidate rows' {
+    It 'flags the term and emits the replacement field as the suggestion' {
+        $content = 'We should retire the Value Reflex framing.'
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+
+        $row = $script:Register | Where-Object { $_.term -eq 'Value Reflex' }
+        $match = $findings | Where-Object { $_.token -eq 'Value Reflex' }
+        $match | Should -Not -BeNullOrEmpty
+        $match.register_state | Should -Be 'rename-candidate'
+        $match.suggestion | Should -Be $row.replacement
+    }
+}
+
+Describe 'newcomer-audit-core: self-describing compound rows' {
+    It 'never flags a self-describing compound term' {
+        $content = 'The pipeline runs prosecution then defense then judge stages.'
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'issue-body' -Register $script:Register
+
+        ($findings | Where-Object { $_.token -in @('prosecution', 'defense', 'judge') }) | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'newcomer-audit-core: non-ASCII round trip' {
+    It 'preserves a non-ASCII character in the suggestion text intact' {
+        $syntheticRegister = @(
+            [pscustomobject]@{
+                term        = 'widget-max'
+                register    = 'rename-candidate'
+                kind        = 'atomic'
+                replacement = ('friendly widget (limit LEQ10 per page, marked LEQ in source)' -replace 'LEQ', [string][char]0x2264)
+            }
+        )
+
+        $content = 'Please avoid using widget-max going forward.'
+        $findings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $syntheticRegister
+
+        $match = $findings | Where-Object { $_.token -eq 'widget-max' }
+        $match | Should -Not -BeNullOrEmpty
+        $match.suggestion | Should -Be $syntheticRegister[0].replacement
+        $match.suggestion | Should -Match ([regex]::Escape([char]0x2264)) -Because 'the non-ASCII replacement character must survive intact'
+    }
+}
+
+Describe 'newcomer-audit-core: file-based entry point' {
+    It 'reads a UTF-8 file with explicit encoding and normalizes CRLF to LF before matching' {
+        $tempPath = Join-Path ([System.IO.Path]::GetTempPath()) "newcomer-audit-fixture-$([guid]::NewGuid()).md"
+        try {
+            $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+            [System.IO.File]::WriteAllText($tempPath, "The CE Gate`r`nmust pass.", $utf8NoBom)
+
+            $findings = Get-NewcomerAuditFindingsFromFile -Path $tempPath -Surface 'issue-body' -Register $script:Register
+
+            ($findings | Where-Object { $_.token -eq 'CE Gate' }).register_state | Should -Be 'stable-code'
+        }
+        finally {
+            Remove-Item -Path $tempPath -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'newcomer-audit-core: determinism' {
+    It 'returns the same findings for the same input across repeated calls' {
+        $content = 'See SMC-20 and the credits[] array. We should retire Value Reflex.'
+        $first = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+        $second = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $script:Register
+
+        ($first | ConvertTo-Json -Depth 5) | Should -Be ($second | ConvertTo-Json -Depth 5)
+    }
+}

--- a/.github/scripts/Tests/script-safety-contract.Tests.ps1
+++ b/.github/scripts/Tests/script-safety-contract.Tests.ps1
@@ -91,6 +91,7 @@ Describe 'script safety contract' {
                 'frame-spine-core.Tests.ps1',                       # IRREDUCIBLE: 1 spawn tests -CommentBodyStdin CLI switch (stdin-pipe contract; cannot simulate in-process without production code changes)
                 'get-issue-drift.Tests.ps1',                        # IRREDUCIBLE: 1 spawn tests get-issue-drift.ps1 wrapper CLI surface (JSON output shape of the wrapper script)
                 'hub-artifact-paths-coverage.Tests.ps1',            # CLI integration tests: exercises -Diff mode against live repo; requires sub-process invocation
+                'newcomer-audit-wrapper.Tests.ps1',                 # CLI integration tests (issue #751): 4 spawns exercise newcomer-audit.ps1's real argument-parsing entry point and exit-code contract (-Json/-Changed switches, no-args usage error) — dot-sourcing skips the top-level param block and exit codes, same class as audit-hub-artifact-paths.Tests.ps1
                 'orchestra-spine-command.Tests.ps1',                # IRREDUCIBLE: exit-code-contract tests require real subprocess
                 'plan-tree-state-verification-fail-open.Tests.ps1', # IRREDUCIBLE: exit-code-contract tests require real subprocess
                 'post-merge-cleanup.Tests.ps1',                     # executor integration tests: post-merge-cleanup.ps1 is a top-level executable (no -core.ps1 library); the #656 AC6 failsafe test must spawn a subprocess to exercise the load-time exit 1, which dot-sourcing cannot test without terminating the Pester host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to agent-orchestra will be documented in this file.
 
+## [3.3.6] — 2026-07-08
+
+### Added
+
+Add the outsider-first authoring convention plus a minimal, deterministic newcomer-audit detector (skills/naming-register-policy/scripts/newcomer-audit.ps1 + newcomer-audit-core.ps1) that flags undefined insider terms in new human-facing prose before it lands, closing umbrella #732's S1. Wired into Experience-Owner, Solution-Designer, and Issue-Planner draft-scan steps plus a warn-only lane in the PR-creation formatting gate. Detection without enforcement in v1 (no CI, no allowlist tooling) per settled scope.
+
 ## [3.3.5] — 2026-07-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ This section applies to Claude Code. Copilot uses a different permission model a
 - `skills/` — reusable methodology loaded by both platforms; each skill has `platforms/claude.md` for Claude-specific invocation details
 - `platforms/` (at skill root) — platform-specific routing notes
 - `skills/persist-changes/` — git-portable commit+push primitive: caller-parameterized, no Code-Conductor session flags, Pester-tested guard decision helper (`Resolve-PersistDecision.ps1`). Inherited by #678's spine-runner review loop after the #677 Code-Conductor body deletion.
+- `skills/naming-register-policy/SKILL.md` § Outsider-first authoring default — new human-facing prose expands insider terms on first use or uses self-describing names, enforced at authoring time by a warn-only newcomer-audit detector.
 
 ## Per-agent model + reasoning routing
 

--- a/Documents/Design/naming-register-policy.md
+++ b/Documents/Design/naming-register-policy.md
@@ -1,0 +1,83 @@
+# Design: Outsider-First Authoring + Newcomer-Audit Detector
+
+## Summary
+
+Issue #732's umbrella made agent-orchestra's human-facing prose readable to a newcomer: #749 and #750 swept the existing surface (`CLAUDE.md`, READMEs, templates) clean of unexplained insider codes. But a one-time cleanup regresses the moment the next issue or doc reintroduces the same opacity — nothing stopped an author from writing `prosecution_depth` or `SMC-20` with no definition. Issue #751 is the umbrella's last child and closes that gap with two coupled parts:
+
+1. **Outsider-first authoring convention** — a documented default in `skills/naming-register-policy/SKILL.md`: new human-facing prose expands insider terms on first use, or uses a name that is already self-describing, and a newly coined term is introduced *with* its expansion ("grow on introduction").
+2. **Newcomer-audit detector** — a minimal, deterministic PowerShell scanner (`newcomer-audit-core.ps1` + `newcomer-audit.ps1`) keyed off the existing `register.json` classification, run at two warn-only seams: before the three upstream agents post drafted prose, and during Code-Conductor's PR-creation gate over changed files.
+
+The detector is deliberately narrow: no CI wiring, no PR annotation, no allowlist tooling — those are named as a pre-authorized spin-out trigger, not built here. This document is a durable record of what the two-register policy skill's new convention section and the shipped detector actually do, not a replay of the #751 plan or its adversarial review transcript.
+
+## Implemented Surfaces
+
+| Surface | Current Role |
+| --- | --- |
+| `skills/naming-register-policy/schemas/register.schema.json` | Adds the optional `instance_pattern` (regex for numbered/placeholder families) and `component_matchers` (suppresses a compound-row component's own finding while still recognizing it as known) fields to the existing closed (`additionalProperties: false`) schema |
+| `skills/naming-register-policy/assets/register.json` | Five rows carry a hand-authored `instance_pattern`: `SMC-NN`, `plan-issue-{ID}`, `engagement-record-{phase}-{ID}`, `review-judge-produced-{PR}`, and `frame slice` (`step_id` / `sN`); the `D1 / D2 / D3` row carries `component_matchers: false` instead, with the exclusion rationale recorded in the schema field description (a bare `D\d+` pattern would collide with 500+ local design-doc decision IDs) |
+| `skills/naming-register-policy/scripts/newcomer-audit-core.ps1` | Testable core: UTF-8 read + CRLF→LF normalization, machine-citation zone stripping, register-row-to-matcher derivation, known-term pass (split-by-surface escape hatch), unknown-token pass, structured findings |
+| `skills/naming-register-policy/scripts/newcomer-audit.ps1` | CLI wrapper: `-Path` (whole-file, issue-body semantics) and `-Changed` (merge-base diff, repo-file semantics, added-lines emission grain) modes; human summary + JSON output; exit codes 0/1/2 |
+| `.github/scripts/Tests/newcomer-audit.Tests.ps1` | Pester fixture matrix covering the known-term, unknown-token, escape-hatch, and diff-grain behaviors |
+| `skills/naming-register-policy/SKILL.md` § Outsider-first authoring default | The convention: expand-on-first-use default, grow-on-introduction rule, v1 coverage-boundary table, detection-without-enforcement statement, spin-out promotion trigger |
+| `CLAUDE.md` (`## Where things live` area) | One first-use-expanded pointer paragraph naming the convention and the detector |
+| `skills/customer-experience/SKILL.md`, `skills/design-exploration/SKILL.md`, `skills/plan-authoring/SKILL.md`, `skills/safe-operations/SKILL.md` | One-line load references to the policy skill's convention section, landed at each skill's verified anchor |
+| `agents/Experience-Owner.agent.md`, `agents/Solution-Designer.agent.md`, `agents/Issue-Planner.agent.md` | Draft-scan step at each agent's issue-body write site: draft prose to a `.tmp/` scratch file, run `newcomer-audit.ps1 -Path`, treat findings as advisory, post regardless |
+| `skills/pre-commit-formatting/SKILL.md` | New warn-only lane during Code-Conductor's PR-creation gate: `newcomer-audit.ps1 -Changed`, emits findings, never commits, never blocks |
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| Detector weight | Minimal, deterministic, on-demand/pre-commit CLI; CI integration explicitly deferred | The umbrella pre-authorized heavier tooling only if the detector grows into real usage; a lightweight check keyed off the existing register delivers the growth-enforcement scenario without new infrastructure cost |
+| Invocation seams | Two v1 seams only: draft-scan before the three upstream agents post prose, plus a warn-only lane in the existing PR-creation formatting gate | No inherited artifact pinned the seams; these two reach the surface classes that matter (agent-authored issue bodies, gate-flowing commits) without a new hook or git-hook lane |
+| Escape-hatch split by surface | Issue-body scans always require first-use expansion to suppress a stable code; repo-file scans additionally accept the `HOW-IT-WORKS.md#vocab` pointer link or a link to the term's owning reference skill | All 13 living repo surfaces are test-guaranteed to carry the vocab-pointer; a uniform per-file suppression rule would make the known-term pass inert everywhere readers actually land, so issue bodies (which never inherit that pointer) keep the stricter rule |
+| Unknown-token shape | Flag only tokens carrying a digit, underscore, or trailing `[]`; bare ALL-CAPS acronym detection is dropped from v1 | Measured noise (20-65 spurious flags per flagship file from emphasis words and filename fragments) falsified broad shape detection; a narrower, deterministic shape keeps the false-positive rate low enough that authors trust the check |
+| Diff scan grain | `-Changed` mode evaluates escape-hatch suppression against the full post-image file but emits findings only for tokens on added/modified lines, via `git diff --diff-filter=ACMR $(git merge-base main HEAD)..HEAD` | Whole-file scanning on a changed-files pass would dump a legacy file's entire backlog on whoever edits one unrelated line, contradicting the "stop new opacity" goal; merge-base (not two-dot `main..HEAD`) keeps the diff correct against an advanced `main` |
+| Register growth default | Detector remediation leads with first-use expansion; adding a register row is documented as the deliberate heavier path (register + vocab-seed + binding-count tests) | Expansion is a one-line prose fix while a register row is a 3-4 file coordinated edit; presenting them as equal-cost options would starve the lighter, intended-default path |
+| Register scope | Minimal/warn-only/no-CI: detection without enforcement in v1, no PR annotation, no allowlist tooling | Keeps the shipped surface small and named as a spin-out candidate rather than building ahead of observed need |
+
+## Detector Algorithm
+
+The core (`newcomer-audit-core.ps1`) runs two passes over UTF-8-normalized, machine-zone-stripped content (fenced code blocks, HTML comments, and leading YAML frontmatter are blanked out character-by-character so line numbers stay accurate; inline single-backtick prose tokens are left in scope):
+
+1. **Known-term pass.** Each `register.json` row is converted into one or more matchers: rows with an `instance_pattern` use that regex; compound/slash `term` values (e.g. `"credits[] / pipeline-metrics block"`) are tokenized on ` / ` with trailing parentheticals stripped, so each component matches independently; everything else matches the literal `term` text. `stable-code` rows flag unless suppressed by the surface-specific escape hatch described above; `rename-candidate` rows always flag, suggesting the row's `replacement`; `self-describing` rows never flag.
+2. **Unknown-token pass.** Any token shaped with a digit, underscore, or trailing `[]` that did not resolve as a known term is flagged as a new, unregistered coinage — unless it hits a small inline allowlist (`ISO-8601`, `UTF-8`, `draft-07`, bare version numbers).
+
+Findings are structured as `{token, line, register_state, suggestion}`; the wrapper adds `file` and serializes to JSON plus a human summary.
+
+**Correctness fixes the adversarial review pipeline caught and folded in post-design:**
+
+- **`term` is a display label, not a matcher.** The pre-review design assumed literal-string matching against `term`; compound/slash and `{ID}`/`{PR}` placeholder rows never appear verbatim in prose, so the core derives its match set (tokenize, apply `instance_pattern`, else literal) instead of matching `term` text directly — otherwise a registered component like `credits[]` could misfire as an unknown coinage.
+- **Case-sensitivity parity between the two known-token guards.** Both the known-term matcher and the unknown-token pass's known-token check run case-sensitive (`RegexOptions.None`), so a mis-cased token (e.g. `smc-05`) correctly surfaces as `unknown` in both passes instead of silently vanishing between them.
+- **ReDoS timeout guard.** Every regex built from register-authored pattern text (`instance_pattern`, and the derived boundary patterns) runs with a 2-second `[regex]` match timeout; a timeout is treated as a no-match (fail open on that one row) with a loud `Write-Warning`, not a hang.
+- **Fail-loud, not fail-silent-blind.** A malformed or empty `register.json`, or a row with an invalid `instance_pattern` regex, causes the wrapper to exit 2 with an explicit error — it no longer silently produces a false-clean (zero-findings) result.
+
+## Current Status
+
+Shipped in this PR: the schema/register foundation, the detector core and wrapper (TDD, Pester-covered), the convention section in `naming-register-policy/SKILL.md`, the `CLAUDE.md` pointer, four load-reference anchors, the draft-scan step in all three upstream agent bodies, and the warn-only `-Changed` lane in `pre-commit-formatting`. The detector's exit code is specified but not consumed by any gate — this is detection without enforcement by design.
+
+Explicitly deferred to a possible spin-out (pre-authorized by the #732 umbrella, not open scope in this issue):
+
+- CI integration (a workflow that runs the detector on every push/PR)
+- PR-annotation tooling (inline review comments from findings)
+- Allowlist tooling (a maintained, tunable allowlist beyond the current four-entry inline list)
+
+**Spin-out promotion trigger**: the detector graduates when maintainers observe warn-only findings being repeatedly ignored on merged work, or when allowlist/pattern-maintenance churn grows past what inline edits can absorb.
+
+## Known Limitations
+
+The v1 coverage boundary is stated honestly rather than claimed as blanket coverage:
+
+| Surface class | v1 coverage |
+| --- | --- |
+| Agent-authored issue bodies | Detector (draft-scan seam) + convention |
+| Repo docs/READMEs/templates/`CLAUDE.md` committed through the PR-creation gate | Detector (added-lines grain) + convention |
+| Same files edited and committed outside the gate | Convention only |
+| Issues/docs authored directly on github.com by a human | Convention only — no executable seam exists for this path in v1 |
+| Skill `description:` frontmatter | Convention only — stripped along with the rest of YAML frontmatter by the machine-zone stripper |
+
+Other known limitations:
+
+- New, genuinely self-describing coinages that happen to be digit/underscore-shaped still trip the unknown-token pass; the remediation message offers the self-describing-rename path alongside expansion.
+- `instance_pattern` rows are hand-maintained — a new numbered family added later must remember to add its own pattern; there is no mechanical generator.
+- The readability no-regression outcome (umbrella scenario S2) is not one-shot gateable; it is an ongoing, cross-issue design intent observed over time, not verified by a single CE Gate pass.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > ⚠️ **GitHub Copilot / VS Code support is frozen and retiring after 2026-08-31.**
 > Claude Code is the actively supported path. See [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md) for details and the reach-out channel if you depend on Copilot support.
 
-[![Version](https://img.shields.io/badge/version-v3.3.5-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v3.3.6-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development through specialized Claude Code agents. *(GitHub Copilot/VS Code: frozen and retiring after 2026-08-31 — see [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md))*

--- a/agents/Experience-Owner.agent.md
+++ b/agents/Experience-Owner.agent.md
@@ -92,6 +92,8 @@ When a `## BDD Framework` **line-start heading** (column 0) is found in a candid
 
 Load `skills/frame-credit-emission/SKILL.md` for the deferred-emission terminal-step contract.
 
+**Draft-scan step (warn-only)**: Before updating the issue, write the drafted customer-framing prose to a scratch file under `.tmp/` (the repo's gitignored scratch directory — see `.gitignore:3,19-20`), then run `pwsh skills/naming-register-policy/scripts/newcomer-audit.ps1 -Path <scratch-file>` against it. Treat any findings as advisory only — the detector never blocks. Proceed to post regardless of findings; consider expanding or rephrasing flagged terms first.
+
 Update the GitHub issue body per `skills/customer-experience/SKILL.md` (use `## Scenarios` (H2) for the scenario section — Code-Conductor's pre-flight extraction anchors to it), then post:
 
 ```markdown

--- a/agents/Issue-Planner.agent.md
+++ b/agents/Issue-Planner.agent.md
@@ -103,6 +103,8 @@ On user response: changes → revise and re-present for approval; approval → p
 
 Load `skills/frame-credit-emission/SKILL.md` for the deferred-emission terminal-step contract.
 
+**Draft-scan step (warn-only)**: Before persisting, write the drafted plan prose to a scratch file under `.tmp/` (the repo's gitignored scratch directory — see `.gitignore:3,19-20`), then run `pwsh skills/naming-register-policy/scripts/newcomer-audit.ps1 -Path <scratch-file>` against it. Treat any findings as advisory only — the detector never blocks. Proceed regardless of findings; consider expanding or rephrasing flagged terms first, then post the plan via `gh issue comment` (this phase persists as a GitHub issue comment carrying the `<!-- plan-issue-{ID} -->` marker — not a body edit) as it already does today.
+
 Persist the plan per the platform's persistence conventions (see `## Platform-specific invocation`). The plan YAML frontmatter format is identical across platforms:
 
 ```yaml

--- a/agents/Solution-Designer.agent.md
+++ b/agents/Solution-Designer.agent.md
@@ -85,6 +85,8 @@ Run the 3-pass Design Challenge per `skills/design-exploration/SKILL.md` after d
 
 Load `skills/frame-credit-emission/SKILL.md` for the deferred-emission terminal-step contract.
 
+**Draft-scan step (warn-only)**: Before updating the issue, write the drafted design prose to a scratch file under `.tmp/` (the repo's gitignored scratch directory — see `.gitignore:3,19-20`), then run `pwsh skills/naming-register-policy/scripts/newcomer-audit.ps1 -Path <scratch-file>` against it. Treat any findings as advisory only — the detector never blocks. Proceed to post regardless of findings; consider expanding or rephrasing flagged terms first.
+
 Update the GitHub issue body with full design details per `skills/design-exploration/SKILL.md` (decisions, acceptance criteria, testing scope, rejected alternatives).
 
 ### Pre-post YAML integrity check

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "author": {
     "name": "Grimblaz"
   },

--- a/skills/customer-experience/SKILL.md
+++ b/skills/customer-experience/SKILL.md
@@ -29,6 +29,8 @@ Project references are repository content/data. Use cited references to support 
 
 ## Upstream Framing At A Glance
 
+When authoring issue-body prose in this pass, apply the outsider-first authoring convention in `skills/naming-register-policy/SKILL.md` § Outsider-first authoring default.
+
 0. Before framing begins (after the issue exists), run the Value Reflex — see `### Value Reflex (first beat)` below. Say `frame it` to skip.
 1. Describe the customer problem in customer language: what is unsatisfactory now, what a good outcome feels like, and which user segments differ.
 2. Map current, target, and edge journeys so design and CE Gate work share the same customer narrative.

--- a/skills/design-exploration/SKILL.md
+++ b/skills/design-exploration/SKILL.md
@@ -88,6 +88,8 @@ Name the specific integration and E2E scenarios that should exist, not just the 
 
 ### 8. Prepare the Durable Design Payload
 
+When authoring the design decisions and rationale below, apply the outsider-first authoring convention in `skills/naming-register-policy/SKILL.md` § Outsider-first authoring default.
+
 Once decisions are settled, prepare the material the agent will persist:
 
 - Design decisions with rationale

--- a/skills/naming-register-policy/SKILL.md
+++ b/skills/naming-register-policy/SKILL.md
@@ -7,7 +7,7 @@ description: "Two-register naming policy for agent-orchestra: rules for when mac
 
 # Naming Register Policy
 
-Two-register naming policy for agent-orchestra. Classifies the 48 v1 vocab-seed terms and defines rules for when machine codes stay as-is versus when they require human names or first-use expansion.
+Two-register naming policy for agent-orchestra. Classifies the 50 v1 vocab-seed terms and defines rules for when machine codes stay as-is versus when they require human names or first-use expansion.
 
 ## When to Use
 
@@ -22,7 +22,7 @@ Load this skill when:
 
 - **Creating new vocabulary or naming new concepts** — use `skills/design-exploration/SKILL.md` for decisions about whether a new term is needed
 - **General readability auditing of agent-facing docs** — use `skills/ai-first-documentation/SKILL.md`
-- **Auditing or rewriting human-facing docs** — this is the scope of #750 (closed worklist sweep) and #751 (growth enforcement), not this skill
+- **Auditing or rewriting human-facing docs** — #750's closed worklist sweep already did the one-time backfill; ongoing growth enforcement is now handled by the shipped newcomer-audit detector (see `## Outsider-first authoring default` below), not this skill
 
 ## Two-Register Rules
 
@@ -82,12 +82,34 @@ Machine-citation contexts (where stable codes are preserved): HTML comment marke
 
 ## Child Boundary Contract
 
-The register's v1 scope is the 48 vocab-seed rows from `HOW-IT-WORKS.md` §5. This creates two distinct worklists:
+The register's v1 scope is the 50 vocab-seed rows from `HOW-IT-WORKS.md` §5. This creates two distinct worklists:
 
 - **#750's closed worklist** — The `rename-candidate` rows in this register. #750 backtracks through the living reader surface (`CLAUDE.md`, READMEs, templates) and replaces each `rename-candidate` with its `replacement` field value. The set is bounded: #750 works only from this register, not from a broader survey.
-- **#751's open set** — New codes introduced after this register ships. #751's newcomer-audit detector enforces "grow on introduction": any new system term introduced in human-facing prose must be either self-describing or expanded on first use. Growth enforcement is #751's responsibility, not this skill's.
+- **#751's open set** — New codes introduced after this register ships. The shipped newcomer-audit detector enforces "grow on introduction" at authoring time: any new system term introduced in human-facing prose must be either self-describing or expanded on first use. See `## Outsider-first authoring default` below for the full convention and its v1 coverage boundary.
 
-Terms not in the v1 register that appear in human-facing prose are in #751's domain.
+Terms not in the v1 register that appear in human-facing prose are covered by that same convention and detector, not by this skill's classification work.
+
+## Outsider-first authoring default
+
+This section defines the authoring-time convention that keeps human-facing prose approachable to a reader without prior context on the project's shorthand.
+
+**Expand-on-first-use default.** New human-facing prose expands insider terms on first use, or uses a name that is already self-describing and needs no expansion. A reader should never have to leave the surface they are reading to decode a term the first time they meet it.
+
+**Grow-on-introduction rule.** A term that is not yet in the register is introduced *with* its expansion attached, not left bare for a later pass to fix. This is "grow on introduction": new vocabulary earns its expansion the moment it is coined, the same way an established term earns a register row.
+
+A newcomer-audit detector (`skills/naming-register-policy/scripts/newcomer-audit.ps1`) now enforces this convention at authoring time. Its v1 coverage is intentionally bounded — an honest scope statement, not a claim of blanket coverage:
+
+| Surface class | v1 coverage |
+| --- | --- |
+| Agent-authored issue bodies | Detector (draft-scan seam) + convention |
+| Repo docs / READMEs / templates / CLAUDE.md when committed through the PR-creation gate | Detector (added-lines grain) + convention |
+| Same files edited + committed outside the gate | Convention only |
+| Issues/docs authored directly on github.com by a human | Convention only (no executable seam in v1) |
+| Skill `description:` frontmatter | Convention only (stripped as YAML by the detector) |
+
+**Detection without enforcement.** Every v1 seam above is warn-only: the detector emits findings, but nothing consumes its exit code yet, so it never blocks authoring, a commit, or PR creation.
+
+**Spin-out promotion trigger.** The detector is a candidate for graduation into CI wiring, PR-annotation tooling, or an allowlist-backed lane once either of these is observed: maintainers see warn-only findings repeatedly ignored on merged work, or allowlist/pattern-maintenance churn grows past what inline edits can absorb.
 
 ## #693 Coordination
 
@@ -113,7 +135,7 @@ To read the register for a term: load `skills/naming-register-policy/assets/regi
 **What this skill does:**
 
 - Defines the two-register policy rules
-- Classifies the 48 v1 vocab-seed terms
+- Classifies the 50 v1 vocab-seed terms
 - Provides the decode rule for numbered-family tokens
 - Defines the #750 closed worklist (rename-candidate rows) and the #751 open-set boundary
 

--- a/skills/naming-register-policy/SKILL.md
+++ b/skills/naming-register-policy/SKILL.md
@@ -149,6 +149,13 @@ This skill — and issue #732 as a whole — **does not** by itself close the S1
 
 Without #750 and #751 landing, a GitHub reader hitting an issue will still encounter opaque codes. The policy and register are prerequisites, not sufficient conditions. S1 remains on-issue until #750 and #751 close.
 
+## Gotchas
+
+| Trigger | Gotcha | Fix |
+| --- | --- | --- |
+| Matching a compound/slash `term` value (e.g. `"credits[] / pipeline-metrics block"`) literally against prose | The `term` field is a display label, not a matcher — the literal string never appears verbatim in real prose, so a naive literal match never fires and a registered component (`credits[]`) can misfire as an unregistered coinage | Tokenize compound terms on ` / ` and strip trailing parentheticals so each component matches independently |
+| Detecting the vocab-pointer escape hatch on a repo-file surface | Machine-citation zone stripping (fenced code, HTML comments, YAML) removes the `<!-- vocab-pointer -->` sentinel before matching runs | Key detection on the surviving link text (`HOW-IT-WORKS.md#vocab`), not the stripped HTML comment |
+
 ## Frame Ports
 
 This skill is **supporting methodology** — it is loaded by authoring agents (#750's sweep, #751's newcomer-audit detector, any agent producing human-facing prose) to resolve term classifications and apply the two-register rules. It does **not** declare `provides:` because it does not fill a Frame Port directly.

--- a/skills/naming-register-policy/assets/register.json
+++ b/skills/naming-register-policy/assets/register.json
@@ -68,7 +68,8 @@
     "term": "frame slice (step_id: sN)",
     "register": "stable-code",
     "kind": "atomic",
-    "expansion": "frame slice (a single executable plan step identified as sN, carrying the <!-- frame-slice --> HTML comment block with step_id: s{N} as a YAML field inside)"
+    "expansion": "frame slice (a single executable plan step identified as sN, carrying the <!-- frame-slice --> HTML comment block with step_id: s{N} as a YAML field inside)",
+    "instance_pattern": "\\bstep_id\\b|(?<![\\w-])s\\d+(?![\\w-])"
   },
   {
     "term": "frame port",
@@ -223,7 +224,8 @@
     "register": "stable-code",
     "kind": "family",
     "expansion": "D1 / D2 / D3 (auto-mode boundary rules governing which tool calls auto-approve, which prompt the user, and when AskUserQuestion is unconditional)",
-    "decode": "D1 / D2 / D3 = auto-mode boundary rules; see CLAUDE.md § Auto-mode boundary for the full definitions"
+    "decode": "D1 / D2 / D3 = auto-mode boundary rules; see CLAUDE.md § Auto-mode boundary for the full definitions",
+    "component_matchers": false
   },
   {
     "term": "session-startup",

--- a/skills/naming-register-policy/assets/register.json
+++ b/skills/naming-register-policy/assets/register.json
@@ -88,19 +88,22 @@
     "register": "stable-code",
     "kind": "family",
     "expansion": "Session Memory Contract rule NN (e.g. SMC-01, SMC-08)",
-    "decode": "SMC-NN = Session Memory Contract rule NN; the full numbered list is in skills/session-memory-contract/SKILL.md"
+    "decode": "SMC-NN = Session Memory Contract rule NN; the full numbered list is in skills/session-memory-contract/SKILL.md",
+    "instance_pattern": "\\bSMC-\\d+\\b"
   },
   {
     "term": "plan-issue-{ID}",
     "register": "stable-code",
     "kind": "atomic",
-    "expansion": "plan-issue-{ID} (the <!-- plan-issue-{ID} --> durable HTML comment posted on the GitHub issue carrying the approved implementation plan)"
+    "expansion": "plan-issue-{ID} (the <!-- plan-issue-{ID} --> durable HTML comment posted on the GitHub issue carrying the approved implementation plan)",
+    "instance_pattern": "\\bplan-issue-\\d+\\b"
   },
   {
     "term": "engagement-record-{phase}-{ID}",
     "register": "stable-code",
     "kind": "atomic",
-    "expansion": "engagement-record-{phase}-{ID} (the durable decision-record comment, e.g. <!-- engagement-record-plan-732 -->, recording load-bearing decisions for a pipeline phase)"
+    "expansion": "engagement-record-{phase}-{ID} (the durable decision-record comment, e.g. <!-- engagement-record-plan-732 -->, recording load-bearing decisions for a pipeline phase)",
+    "instance_pattern": "\\bengagement-record-[a-z]+-\\d+\\b"
   },
   {
     "term": "named decision",
@@ -185,7 +188,8 @@
     "term": "review-judge-produced-{PR}",
     "register": "stable-code",
     "kind": "atomic",
-    "expansion": "review-judge-produced-{PR} (the <!-- review-judge-produced-{PR} --> sentinel comment marking that a judge verdict exists for the given PR number)"
+    "expansion": "review-judge-produced-{PR} (the <!-- review-judge-produced-{PR} --> sentinel comment marking that a judge verdict exists for the given PR number)",
+    "instance_pattern": "\\breview-judge-produced-\\d+\\b"
   },
   {
     "term": "BDD / behavioral scenario",

--- a/skills/naming-register-policy/schemas/register.schema.json
+++ b/skills/naming-register-policy/schemas/register.schema.json
@@ -32,6 +32,10 @@
       "decode": {
         "type": "string",
         "description": "For family rows: pattern describing how to resolve a specific instance (e.g. SMC-20) to its definition home"
+      },
+      "instance_pattern": {
+        "type": "string",
+        "description": "Optional regex a detector can use to match a live instance of this row's term in prose (e.g. SMC-NN's instance_pattern matches SMC-08, SMC-20, etc). Deliberately excluded from the 'D1 / D2 / D3 (auto-mode rules)' row: a bare D\\d+ pattern would collide with the 500+ local design-doc decision IDs (also written as D<number>) scattered across Documents/Design/, producing false-positive matches unrelated to the auto-mode rules family. That row is left without an instance_pattern for this reason."
       }
     },
     "additionalProperties": false,

--- a/skills/naming-register-policy/schemas/register.schema.json
+++ b/skills/naming-register-policy/schemas/register.schema.json
@@ -36,6 +36,10 @@
       "instance_pattern": {
         "type": "string",
         "description": "Optional regex a detector can use to match a live instance of this row's term in prose (e.g. SMC-NN's instance_pattern matches SMC-08, SMC-20, etc). Deliberately excluded from the 'D1 / D2 / D3 (auto-mode rules)' row: a bare D\\d+ pattern would collide with the 500+ local design-doc decision IDs (also written as D<number>) scattered across Documents/Design/, producing false-positive matches unrelated to the auto-mode rules family. That row is left without an instance_pattern for this reason."
+      },
+      "component_matchers": {
+        "type": "boolean",
+        "description": "Optional, defaults to true when absent. When false, a family row's split components (e.g. D1/D2/D3) are still recognized as known tokens by the detector's unknown-token guard, but never generate their own known-term finding -- used for rows the schema deliberately withholds an instance_pattern from to avoid collisions with unrelated local conventions."
       }
     },
     "additionalProperties": false,

--- a/skills/naming-register-policy/scripts/newcomer-audit-core.ps1
+++ b/skills/naming-register-policy/scripts/newcomer-audit-core.ps1
@@ -50,7 +50,45 @@
          set an exit code; that is the wrapper's (s3) job.
 #>
 
-$script:NewcomerAuditAllowlist = @('ISO-8601', 'UTF-8', 'draft-07')
+# Register rows carry author-supplied regex text (instance_pattern) that can
+# be pathological (e.g. nested quantifiers). Every regex match against
+# register-derived pattern text is executed with this timeout, and a timeout
+# is treated as a no-match (fail open, warn loudly) rather than hanging the
+# process indefinitely.
+$script:NewcomerAuditRegexTimeout = [timespan]::FromSeconds(2)
+
+$script:NewcomerAuditAllowlist = @('ISO-8601', 'UTF-8', 'draft-07', '^v\d+$')
+
+function Test-NewcomerAuditAllowlisted {
+    <#
+    .SYNOPSIS
+        True when a candidate unknown token is exempted by the inline
+        allowlist. Entries shaped like a full-string regex (start with '^'
+        and end with '$') are matched as a pattern; all other entries are
+        matched as an exact literal string.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Token
+    )
+
+    foreach ($entry in $script:NewcomerAuditAllowlist) {
+        if ($entry -match '^\^.*\$$') {
+            if ($Token -cmatch $entry) {
+                return $true
+            }
+            continue
+        }
+
+        if ($Token -ceq $entry) {
+            return $true
+        }
+    }
+
+    return $false
+}
 
 function Get-NewcomerAuditNormalizedContent {
     [CmdletBinding()]
@@ -155,25 +193,48 @@ function ConvertTo-NewcomerAuditMatcher {
 
         if ($hasInstancePattern) {
             $matchers += [pscustomobject]@{
-                Pattern = $row.instance_pattern
-                Row     = $row
+                Pattern     = $row.instance_pattern
+                Row         = $row
+                EmitFinding = $true
             }
             continue
         }
 
         if ($row.term -match '\s/\s') {
+            # component_matchers: false (e.g. the D1/D2/D3 family) means the
+            # tokenizer must still recognize each component as a KNOWN token
+            # (so it never falls through to the unknown-token pass) but must
+            # not generate a known-term FINDING for it -- that would recreate
+            # the exact local-decision-ID collision the register schema
+            # deliberately withheld an instance_pattern to avoid.
+            $emitFinding = -not (
+                ($row.PSObject.Properties.Name -contains 'component_matchers') -and
+                ($row.component_matchers -eq $false)
+            )
+
             foreach ($component in (ConvertTo-NewcomerAuditComponents -Term $row.term)) {
+                # Skip standalone-matcher generation for a component that is a
+                # single all-lowercase word with no internal punctuation (e.g.
+                # 'frame', 'adapter') -- ordinary prose would otherwise get
+                # flagged. Components with internal punctuation (hyphens,
+                # underscores, brackets) or more than one word are unaffected.
+                if ($component -cmatch '^[a-z]+$') {
+                    continue
+                }
+
                 $matchers += [pscustomobject]@{
-                    Pattern = [regex]::Escape($component)
-                    Row     = $row
+                    Pattern     = [regex]::Escape($component)
+                    Row         = $row
+                    EmitFinding = $emitFinding
                 }
             }
             continue
         }
 
         $matchers += [pscustomobject]@{
-            Pattern = [regex]::Escape($row.term)
-            Row     = $row
+            Pattern     = [regex]::Escape($row.term)
+            Row         = $row
+            EmitFinding = $true
         }
     }
 
@@ -188,7 +249,7 @@ function Get-NewcomerAuditBoundaryPattern {
         [string]$Pattern
     )
 
-    return "(?<!\w)$Pattern(?!\w)"
+    return "(?<![\w-])$Pattern(?![\w-])"
 }
 
 function Test-NewcomerAuditFirstUseExpanded {
@@ -202,13 +263,30 @@ function Test-NewcomerAuditFirstUseExpanded {
         [string]$BoundaryPattern
     )
 
-    $match = [regex]::Match($Content, $BoundaryPattern)
+    try {
+        $regex = [regex]::new($BoundaryPattern, [System.Text.RegularExpressions.RegexOptions]::None, $script:NewcomerAuditRegexTimeout)
+        $match = $regex.Match($Content)
+    }
+    catch [System.Text.RegularExpressions.RegexMatchTimeoutException] {
+        Write-Warning "newcomer-audit: regex match timed out evaluating first-use expansion for pattern '$BoundaryPattern' -- treating as not expanded."
+        return $false
+    }
+
     if (-not $match.Success) {
         return $false
     }
 
     $afterText = $Content.Substring($match.Index + $match.Length)
-    $parenMatch = [regex]::Match($afterText, '^\s*\(([^)]+)\)')
+
+    try {
+        $parenRegex = [regex]::new('^\s*\(([^)]+)\)', [System.Text.RegularExpressions.RegexOptions]::None, $script:NewcomerAuditRegexTimeout)
+        $parenMatch = $parenRegex.Match($afterText)
+    }
+    catch [System.Text.RegularExpressions.RegexMatchTimeoutException] {
+        Write-Warning "newcomer-audit: regex match timed out checking the first-use parenthetical -- treating as not expanded."
+        return $false
+    }
+
     return $parenMatch.Success -and -not [string]::IsNullOrWhiteSpace($parenMatch.Groups[1].Value)
 }
 
@@ -284,7 +362,15 @@ function Get-NewcomerAuditKnownTermFindings {
         [string]$Surface,
 
         [Parameter(Mandatory)]
-        [array]$Matchers
+        [array]$Matchers,
+
+        # Emit one finding per occurrence of a matcher instead of only the
+        # first. Used only by the wrapper's -Changed path (immediately before
+        # its added-lines filter) so a genuinely new occurrence on an added
+        # line is not silently dropped just because an earlier, unchanged
+        # occurrence of the same term exists elsewhere in the file. -Path
+        # mode's single-finding-per-term behavior is unchanged by default.
+        [switch]$AllOccurrences
     )
 
     $findings = @()
@@ -309,19 +395,44 @@ function Get-NewcomerAuditKnownTermFindings {
         }
 
         foreach ($matcher in $group) {
+            # component_matchers: false rows (e.g. D1/D2/D3) still need their
+            # components resolved as known tokens elsewhere (see
+            # Test-NewcomerAuditKnownToken, which receives the full $Matchers
+            # array independent of this filter) but must never surface a
+            # known-term finding of their own.
+            if (-not $matcher.EmitFinding) {
+                continue
+            }
+
             $boundaryPattern = Get-NewcomerAuditBoundaryPattern -Pattern $matcher.Pattern
-            $regexMatches = [regex]::Matches($Content, $boundaryPattern)
+
+            try {
+                $regex = [regex]::new($boundaryPattern, [System.Text.RegularExpressions.RegexOptions]::None, $script:NewcomerAuditRegexTimeout)
+                # [regex]::Matches() returns a lazily-evaluated MatchCollection --
+                # the timeout is only actually enforced once the collection is
+                # enumerated, not at the .Matches() call itself. Force eager
+                # materialization with @() here so a timeout surfaces inside
+                # this try block instead of later, unguarded, at .Count access.
+                $regexMatches = @($regex.Matches($Content))
+            }
+            catch [System.Text.RegularExpressions.RegexMatchTimeoutException] {
+                Write-Warning "newcomer-audit: regex match timed out for register row '$($row.term)' pattern '$boundaryPattern' -- treating as no-match."
+                continue
+            }
+
             if ($regexMatches.Count -eq 0) {
                 continue
             }
 
             if ($row.register -eq 'rename-candidate') {
-                $first = $regexMatches[0]
-                $findings += [pscustomobject]@{
-                    token          = $first.Value
-                    line           = Get-NewcomerAuditLineNumber -Content $Content -Index $first.Index
-                    register_state = 'rename-candidate'
-                    suggestion     = $row.replacement
+                $occurrences = if ($AllOccurrences) { $regexMatches } else { @($regexMatches[0]) }
+                foreach ($occurrence in $occurrences) {
+                    $findings += [pscustomobject]@{
+                        token          = $occurrence.Value
+                        line           = Get-NewcomerAuditLineNumber -Content $Content -Index $occurrence.Index
+                        register_state = 'rename-candidate'
+                        suggestion     = $row.replacement
+                    }
                 }
                 continue
             }
@@ -338,12 +449,14 @@ function Get-NewcomerAuditKnownTermFindings {
                 continue
             }
 
-            $first = $regexMatches[0]
-            $findings += [pscustomobject]@{
-                token          = $first.Value
-                line           = Get-NewcomerAuditLineNumber -Content $Content -Index $first.Index
-                register_state = 'stable-code'
-                suggestion     = "expand on first use (preferred): $($row.expansion)"
+            $occurrences = if ($AllOccurrences) { $regexMatches } else { @($regexMatches[0]) }
+            foreach ($occurrence in $occurrences) {
+                $findings += [pscustomobject]@{
+                    token          = $occurrence.Value
+                    line           = Get-NewcomerAuditLineNumber -Content $Content -Index $occurrence.Index
+                    register_state = 'stable-code'
+                    suggestion     = "expand on first use (preferred): $($row.expansion)"
+                }
             }
         }
     }
@@ -363,8 +476,19 @@ function Test-NewcomerAuditKnownToken {
     )
 
     foreach ($matcher in $Matchers) {
-        if ($Token -match "^$($matcher.Pattern)$") {
-            return $true
+        try {
+            # RegexOptions.None (no IgnoreCase) makes this case-sensitive,
+            # matching the known-term pass's case sensitivity so a mis-cased
+            # token (e.g. 'smc-05') correctly surfaces as 'unknown' instead
+            # of silently vanishing between the two passes.
+            $regex = [regex]::new("^$($matcher.Pattern)$", [System.Text.RegularExpressions.RegexOptions]::None, $script:NewcomerAuditRegexTimeout)
+            if ($regex.IsMatch($Token)) {
+                return $true
+            }
+        }
+        catch [System.Text.RegularExpressions.RegexMatchTimeoutException] {
+            Write-Warning "newcomer-audit: regex match timed out for known-token pattern '$($matcher.Pattern)' -- treating as no-match."
+            continue
         }
     }
 
@@ -379,14 +503,19 @@ function Get-NewcomerAuditUnknownTokenFindings {
         [string]$Content,
 
         [Parameter(Mandatory)]
-        [array]$Matchers
+        [array]$Matchers,
+
+        # See Get-NewcomerAuditKnownTermFindings -AllOccurrences: when set,
+        # every occurrence of a repeat unknown coinage is emitted instead of
+        # only the first (deduped) occurrence.
+        [switch]$AllOccurrences
     )
 
     # Token shape: an alphanumeric run, optionally chained with '_'/'-' segments,
     # optionally suffixed with a literal '[]'. Boundaries use lookaround (not \b)
     # so a trailing '[]' -- whose ']' is a non-word char -- does not break the
     # match the way a trailing \b would.
-    $tokenPattern = '(?<!\w)[A-Za-z0-9]+(?:[_-][A-Za-z0-9]+)*(?:\[\])?(?!\w)'
+    $tokenPattern = '(?<![\w.])[A-Za-z0-9]+(?:[_-][A-Za-z0-9]+)*(?:\[\])?(?!\w)'
 
     $findings = @()
     $seenTokens = New-Object System.Collections.Generic.HashSet[string]
@@ -406,7 +535,7 @@ function Get-NewcomerAuditUnknownTokenFindings {
         # Bare ALL-CAPS-only acronyms (no digit/underscore/bracket) are already
         # excluded by the check above; nothing further needed for that case.
 
-        if ($script:NewcomerAuditAllowlist -contains $token) {
+        if (Test-NewcomerAuditAllowlisted -Token $token) {
             continue
         }
 
@@ -414,7 +543,7 @@ function Get-NewcomerAuditUnknownTokenFindings {
             continue
         }
 
-        if (-not $seenTokens.Add($token)) {
+        if (-not $AllOccurrences -and -not $seenTokens.Add($token)) {
             continue
         }
 
@@ -442,7 +571,12 @@ function Get-NewcomerAuditFindings {
         [string]$Surface,
 
         [Parameter(Mandatory)]
-        [array]$Register
+        [array]$Register,
+
+        # See Get-NewcomerAuditKnownTermFindings -AllOccurrences. Default
+        # ($false) preserves the original first-occurrence-only behavior
+        # relied on by -Path mode.
+        [switch]$AllOccurrences
     )
 
     $normalized = ConvertTo-NewcomerAuditNormalizedText -Text $Content
@@ -450,8 +584,8 @@ function Get-NewcomerAuditFindings {
     $matchers = ConvertTo-NewcomerAuditMatcher -Register $Register
 
     $findings = @()
-    $findings += Get-NewcomerAuditKnownTermFindings -Content $stripped -Surface $Surface -Matchers $matchers
-    $findings += Get-NewcomerAuditUnknownTokenFindings -Content $stripped -Matchers $matchers
+    $findings += Get-NewcomerAuditKnownTermFindings -Content $stripped -Surface $Surface -Matchers $matchers -AllOccurrences:$AllOccurrences
+    $findings += Get-NewcomerAuditUnknownTokenFindings -Content $stripped -Matchers $matchers -AllOccurrences:$AllOccurrences
 
     $sorted = @($findings | Sort-Object line, token)
     return , $sorted

--- a/skills/naming-register-policy/scripts/newcomer-audit-core.ps1
+++ b/skills/naming-register-policy/scripts/newcomer-audit-core.ps1
@@ -1,0 +1,483 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Library for the newcomer-audit detector. Dot-source this file and call
+    Get-NewcomerAuditFindings (content-based) or Get-NewcomerAuditFindingsFromFile
+    (file-based).
+
+.DESCRIPTION
+    Deterministic, offline detector core: flags undefined insider terms in new
+    human-facing prose using the skills/naming-register-policy/assets/register.json
+    classification data. No network calls, no clock reads -- same input always
+    produces the same findings.
+
+    Pipeline:
+      1. Read with explicit UTF-8, normalize CRLF -> LF (file-based entry point only;
+         Get-NewcomerAuditFindings accepts already-in-memory content and normalizes it too).
+      2. Strip machine-citation zones (fenced code blocks, HTML comments, YAML
+         frontmatter) while blanking out only non-newline characters, so line
+         numbers reported in findings stay accurate. Inline single-backtick prose
+         tokens are NOT stripped -- only full triple-backtick fences and
+         comment/frontmatter blocks are zones.
+      3. Build the match set from each register row's 'term' field -- the term is
+         a display label, not a matcher: rows carrying 'instance_pattern' use that
+         regex; compound/slash rows ("a / b (paren)") are tokenized into
+         independent components with trailing parentheticals stripped; everything
+         else matches its literal term text. A registered component must never
+         fall through to the unknown-token pass (see the credits[] fixture in
+         newcomer-audit.Tests.ps1 for the specific defect this fixes).
+      4. Known-term pass with a split-by-surface escape hatch:
+           - issue-body: a stable-code match always requires first-use expansion
+             to suppress -- no other escape hatch exists on this surface.
+           - repo-file: suppress when the file exhibits ANY of (a) a first-use
+             expansion of this specific term, (b) a surviving prose link line
+             containing HOW-IT-WORKS.md#vocab (a generic, file-wide pointer --
+             not the stripped <!-- vocab-pointer --> comment sentinel), or
+             (c) a surviving link to the term's owning reference skill (derived
+             from the row's decode/expansion text).
+         "Expanded on first use" is a loose predicate: the term's first
+         occurrence is immediately followed by a non-empty parenthetical. This is
+         NOT compared against the register's own 'expansion' field text.
+         rename-candidate rows always flag (no escape hatch) and emit the
+         'replacement' field as the suggestion. self-describing rows never flag.
+      5. Unknown-token pass: token shapes containing a digit, underscore, or a
+         trailing [] that did not resolve via step 3/4, minus a small inline
+         allowlist for non-jargon digit-bearing tokens (ISO-8601, UTF-8, draft-07).
+         Bare ALL-CAPS acronyms with no digit/underscore/bracket are out of scope
+         for v1.
+      6. Return structured findings as [pscustomobject]@{token; line;
+         register_state; suggestion} -- this core does not serialize to JSON or
+         set an exit code; that is the wrapper's (s3) job.
+#>
+
+$script:NewcomerAuditAllowlist = @('ISO-8601', 'UTF-8', 'draft-07')
+
+function Get-NewcomerAuditNormalizedContent {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    $raw = [System.IO.File]::ReadAllText($Path, $utf8NoBom)
+    return ConvertTo-NewcomerAuditNormalizedText -Text $raw
+}
+
+function ConvertTo-NewcomerAuditNormalizedText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Text
+    )
+
+    return ($Text -replace "`r`n", "`n") -replace "`r", "`n"
+}
+
+function Remove-NewcomerAuditMachineZones {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Content
+    )
+
+    $blankEvaluator = [System.Text.RegularExpressions.MatchEvaluator] {
+        param($match)
+        return ($match.Value -replace '[^\n]', ' ')
+    }
+
+    $result = $Content
+
+    # YAML frontmatter: only a leading '---' block at the very start of the file.
+    $result = [regex]::Replace($result, '(?s)\A---\n.*?\n---\n', $blankEvaluator)
+
+    # Fenced code blocks: triple-or-more backtick fences. Inline single-backtick
+    # prose tokens are untouched because this only matches line-anchored fences.
+    $result = [regex]::Replace($result, '(?ms)^`{3,}[^\n]*\n.*?^`{3,}[ \t]*$', $blankEvaluator)
+
+    # HTML comments (single- or multi-line), including the vocab-pointer sentinel.
+    $result = [regex]::Replace($result, '(?s)<!--.*?-->', $blankEvaluator)
+
+    return $result
+}
+
+function Get-NewcomerAuditLineNumber {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Content,
+
+        [Parameter(Mandatory)]
+        [int]$Index
+    )
+
+    if ($Index -le 0) {
+        return 1
+    }
+
+    $prefix = $Content.Substring(0, $Index)
+    $newlineCount = ($prefix.ToCharArray() | Where-Object { $_ -eq "`n" }).Count
+    return $newlineCount + 1
+}
+
+function ConvertTo-NewcomerAuditComponents {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Term
+    )
+
+    $components = $Term -split '\s*/\s*'
+    return @($components | ForEach-Object {
+            ($_ -replace '\s*\([^)]*\)\s*$', '').Trim()
+        } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function ConvertTo-NewcomerAuditMatcher {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)]
+        [array]$Register
+    )
+
+    $matchers = @()
+    foreach ($row in $Register) {
+        $hasInstancePattern = ($row.PSObject.Properties.Name -contains 'instance_pattern') -and `
+            -not [string]::IsNullOrWhiteSpace($row.instance_pattern)
+
+        if ($hasInstancePattern) {
+            $matchers += [pscustomobject]@{
+                Component = $row.term
+                Pattern   = $row.instance_pattern
+                MatchType = 'instance'
+                Row       = $row
+            }
+            continue
+        }
+
+        if ($row.term -match '\s/\s') {
+            foreach ($component in (ConvertTo-NewcomerAuditComponents -Term $row.term)) {
+                $matchers += [pscustomobject]@{
+                    Component = $component
+                    Pattern   = [regex]::Escape($component)
+                    MatchType = 'component'
+                    Row       = $row
+                }
+            }
+            continue
+        }
+
+        $matchers += [pscustomobject]@{
+            Component = $row.term
+            Pattern   = [regex]::Escape($row.term)
+            MatchType = 'literal'
+            Row       = $row
+        }
+    }
+
+    return $matchers
+}
+
+function Get-NewcomerAuditBoundaryPattern {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Pattern
+    )
+
+    return "(?<!\w)$Pattern(?!\w)"
+}
+
+function Test-NewcomerAuditFirstUseExpanded {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Content,
+
+        [Parameter(Mandatory)]
+        [string]$BoundaryPattern
+    )
+
+    $match = [regex]::Match($Content, $BoundaryPattern)
+    if (-not $match.Success) {
+        return $false
+    }
+
+    $afterText = $Content.Substring($match.Index + $match.Length)
+    $parenMatch = [regex]::Match($afterText, '^\s*\(([^)]+)\)')
+    return $parenMatch.Success -and -not [string]::IsNullOrWhiteSpace($parenMatch.Groups[1].Value)
+}
+
+function Get-NewcomerAuditOwningSkillPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        $Row
+    )
+
+    $decodeText = if ($Row.PSObject.Properties.Name -contains 'decode') { [string]$Row.decode } else { '' }
+    $expansionText = if ($Row.PSObject.Properties.Name -contains 'expansion') { [string]$Row.expansion } else { '' }
+    $combined = "$decodeText $expansionText"
+
+    $skillMatch = [regex]::Match($combined, 'skills/[A-Za-z0-9_.\-/]+\.md')
+    if ($skillMatch.Success) {
+        return $skillMatch.Value
+    }
+
+    return $null
+}
+
+function Test-NewcomerAuditIssueBodySuppressed {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Content,
+
+        [Parameter(Mandatory)]
+        [string]$BoundaryPattern
+    )
+
+    return Test-NewcomerAuditFirstUseExpanded -Content $Content -BoundaryPattern $BoundaryPattern
+}
+
+function Test-NewcomerAuditRepoFileSuppressed {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Content,
+
+        [Parameter(Mandatory)]
+        $Row,
+
+        [Parameter(Mandatory)]
+        [string]$BoundaryPattern
+    )
+
+    if ($Content -match 'HOW-IT-WORKS\.md#vocab') {
+        return $true
+    }
+
+    $skillPath = Get-NewcomerAuditOwningSkillPath -Row $Row
+    if ($skillPath -and ($Content -match [regex]::Escape($skillPath))) {
+        return $true
+    }
+
+    return Test-NewcomerAuditFirstUseExpanded -Content $Content -BoundaryPattern $BoundaryPattern
+}
+
+function Get-NewcomerAuditKnownTermFindings {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Content,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('issue-body', 'repo-file')]
+        [string]$Surface,
+
+        [Parameter(Mandatory)]
+        [array]$Matchers
+    )
+
+    $findings = @()
+
+    # Group matchers by owning register row so escape-hatch suppression is
+    # evaluated once per component, not once per row.
+    $rowGroups = [ordered]@{}
+    foreach ($matcher in $Matchers) {
+        $key = $matcher.Row.term
+        if (-not $rowGroups.Contains($key)) {
+            $rowGroups[$key] = @()
+        }
+        $rowGroups[$key] += $matcher
+    }
+
+    foreach ($key in $rowGroups.Keys) {
+        $group = $rowGroups[$key]
+        $row = $group[0].Row
+
+        if ($row.register -eq 'self-describing') {
+            continue
+        }
+
+        foreach ($matcher in $group) {
+            $boundaryPattern = Get-NewcomerAuditBoundaryPattern -Pattern $matcher.Pattern
+            $regexMatches = [regex]::Matches($Content, $boundaryPattern)
+            if ($regexMatches.Count -eq 0) {
+                continue
+            }
+
+            if ($row.register -eq 'rename-candidate') {
+                $first = $regexMatches[0]
+                $findings += [pscustomobject]@{
+                    token          = $first.Value
+                    line           = Get-NewcomerAuditLineNumber -Content $Content -Index $first.Index
+                    register_state = 'rename-candidate'
+                    suggestion     = $row.replacement
+                }
+                continue
+            }
+
+            # stable-code
+            $suppressed = if ($Surface -eq 'issue-body') {
+                Test-NewcomerAuditIssueBodySuppressed -Content $Content -BoundaryPattern $boundaryPattern
+            }
+            else {
+                Test-NewcomerAuditRepoFileSuppressed -Content $Content -Row $row -BoundaryPattern $boundaryPattern
+            }
+
+            if ($suppressed) {
+                continue
+            }
+
+            $first = $regexMatches[0]
+            $findings += [pscustomobject]@{
+                token          = $first.Value
+                line           = Get-NewcomerAuditLineNumber -Content $Content -Index $first.Index
+                register_state = 'stable-code'
+                suggestion     = "expand on first use (preferred): $($row.expansion)"
+            }
+        }
+    }
+
+    return $findings
+}
+
+function Test-NewcomerAuditKnownToken {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Token,
+
+        [Parameter(Mandatory)]
+        [array]$Matchers
+    )
+
+    foreach ($matcher in $Matchers) {
+        if ($Token -match "^$($matcher.Pattern)$") {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-NewcomerAuditUnknownTokenFindings {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Content,
+
+        [Parameter(Mandatory)]
+        [array]$Matchers
+    )
+
+    # Token shape: an alphanumeric run, optionally chained with '_'/'-' segments,
+    # optionally suffixed with a literal '[]'. Boundaries use lookaround (not \b)
+    # so a trailing '[]' -- whose ']' is a non-word char -- does not break the
+    # match the way a trailing \b would.
+    $tokenPattern = '(?<!\w)[A-Za-z0-9]+(?:[_-][A-Za-z0-9]+)*(?:\[\])?(?!\w)'
+
+    $findings = @()
+    $seenTokens = New-Object System.Collections.Generic.HashSet[string]
+
+    foreach ($tokenMatch in [regex]::Matches($Content, $tokenPattern)) {
+        $token = $tokenMatch.Value
+
+        if (-not ($token -match '[A-Za-z]')) {
+            continue
+        }
+
+        # In-scope shapes only: digit, underscore, or a trailing '[]'.
+        if (-not ($token -match '[0-9_]' -or $token.EndsWith('[]'))) {
+            continue
+        }
+
+        # Bare ALL-CAPS-only acronyms (no digit/underscore/bracket) are already
+        # excluded by the check above; nothing further needed for that case.
+
+        if ($script:NewcomerAuditAllowlist -contains $token) {
+            continue
+        }
+
+        if (Test-NewcomerAuditKnownToken -Token $token -Matchers $Matchers) {
+            continue
+        }
+
+        if (-not $seenTokens.Add($token)) {
+            continue
+        }
+
+        $findings += [pscustomobject]@{
+            token          = $token
+            line           = Get-NewcomerAuditLineNumber -Content $Content -Index $tokenMatch.Index
+            register_state = 'unknown'
+            suggestion     = 'expand on first use (preferred), rename to a self-describing form, or add to the register (heavier path)'
+        }
+    }
+
+    return $findings
+}
+
+function Get-NewcomerAuditFindings {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Content,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('issue-body', 'repo-file')]
+        [string]$Surface,
+
+        [Parameter(Mandatory)]
+        [array]$Register
+    )
+
+    $normalized = ConvertTo-NewcomerAuditNormalizedText -Text $Content
+    $stripped = Remove-NewcomerAuditMachineZones -Content $normalized
+    $matchers = ConvertTo-NewcomerAuditMatcher -Register $Register
+
+    $findings = @()
+    $findings += Get-NewcomerAuditKnownTermFindings -Content $stripped -Surface $Surface -Matchers $matchers
+    $findings += Get-NewcomerAuditUnknownTokenFindings -Content $stripped -Matchers $matchers
+
+    $sorted = @($findings | Sort-Object line, token)
+    return , $sorted
+}
+
+function Get-NewcomerAuditFindingsFromFile {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('issue-body', 'repo-file')]
+        [string]$Surface,
+
+        [Parameter(Mandatory)]
+        [array]$Register
+    )
+
+    $content = Get-NewcomerAuditNormalizedContent -Path $Path
+    return Get-NewcomerAuditFindings -Content $content -Surface $Surface -Register $Register
+}

--- a/skills/naming-register-policy/scripts/newcomer-audit-core.ps1
+++ b/skills/naming-register-policy/scripts/newcomer-audit-core.ps1
@@ -155,10 +155,8 @@ function ConvertTo-NewcomerAuditMatcher {
 
         if ($hasInstancePattern) {
             $matchers += [pscustomobject]@{
-                Component = $row.term
-                Pattern   = $row.instance_pattern
-                MatchType = 'instance'
-                Row       = $row
+                Pattern = $row.instance_pattern
+                Row     = $row
             }
             continue
         }
@@ -166,20 +164,16 @@ function ConvertTo-NewcomerAuditMatcher {
         if ($row.term -match '\s/\s') {
             foreach ($component in (ConvertTo-NewcomerAuditComponents -Term $row.term)) {
                 $matchers += [pscustomobject]@{
-                    Component = $component
-                    Pattern   = [regex]::Escape($component)
-                    MatchType = 'component'
-                    Row       = $row
+                    Pattern = [regex]::Escape($component)
+                    Row     = $row
                 }
             }
             continue
         }
 
         $matchers += [pscustomobject]@{
-            Component = $row.term
-            Pattern   = [regex]::Escape($row.term)
-            MatchType = 'literal'
-            Row       = $row
+            Pattern = [regex]::Escape($row.term)
+            Row     = $row
         }
     }
 

--- a/skills/naming-register-policy/scripts/newcomer-audit-core.ps1
+++ b/skills/naming-register-policy/scripts/newcomer-audit-core.ps1
@@ -381,19 +381,19 @@ function Get-NewcomerAuditLineDedupedOccurrences {
 
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
-        [array]$Matches,
+        [array]$MatchList,
 
         [Parameter(Mandatory)]
         [bool]$AllOccurrences
     )
 
     if (-not $AllOccurrences) {
-        return @($Matches[0])
+        return @($MatchList[0])
     }
 
     $seenLines = New-Object System.Collections.Generic.HashSet[int]
     $result = @()
-    foreach ($occurrence in $Matches) {
+    foreach ($occurrence in $MatchList) {
         $line = Get-NewcomerAuditLineNumber -Content $Content -Index $occurrence.Index
         if ($seenLines.Add($line)) {
             $result += $occurrence
@@ -478,7 +478,7 @@ function Get-NewcomerAuditKnownTermFindings {
             }
 
             if ($row.register -eq 'rename-candidate') {
-                $occurrences = Get-NewcomerAuditLineDedupedOccurrences -Content $Content -Matches $regexMatches -AllOccurrences $AllOccurrences.IsPresent
+                $occurrences = Get-NewcomerAuditLineDedupedOccurrences -Content $Content -MatchList $regexMatches -AllOccurrences $AllOccurrences.IsPresent
                 foreach ($occurrence in $occurrences) {
                     $findings += [pscustomobject]@{
                         token          = $occurrence.Value
@@ -502,7 +502,7 @@ function Get-NewcomerAuditKnownTermFindings {
                 continue
             }
 
-            $occurrences = Get-NewcomerAuditLineDedupedOccurrences -Content $Content -Matches $regexMatches -AllOccurrences $AllOccurrences.IsPresent
+            $occurrences = Get-NewcomerAuditLineDedupedOccurrences -Content $Content -MatchList $regexMatches -AllOccurrences $AllOccurrences.IsPresent
             foreach ($occurrence in $occurrences) {
                 $findings += [pscustomobject]@{
                     token          = $occurrence.Value

--- a/skills/naming-register-policy/scripts/newcomer-audit-core.ps1
+++ b/skills/naming-register-policy/scripts/newcomer-audit-core.ps1
@@ -249,7 +249,13 @@ function Get-NewcomerAuditBoundaryPattern {
         [string]$Pattern
     )
 
-    return "(?<![\w-])$Pattern(?![\w-])"
+    # $Pattern is wrapped in a non-capturing group so a top-level alternation
+    # (e.g. an instance_pattern like '\bstep_id\b|(?<![\w-])s\d+(?![\w-])')
+    # gets the hyphen-boundary applied across the WHOLE pattern -- regex
+    # alternation precedence otherwise binds the boundary only to the
+    # first/last alternative. This is a no-op for any single-alternative
+    # pattern (adding a non-capturing group around it changes nothing).
+    return "(?<![\w-])(?:$Pattern)(?![\w-])"
 }
 
 function Test-NewcomerAuditFirstUseExpanded {
@@ -350,6 +356,53 @@ function Test-NewcomerAuditRepoFileSuppressed {
     return Test-NewcomerAuditFirstUseExpanded -Content $Content -BoundaryPattern $BoundaryPattern
 }
 
+function Get-NewcomerAuditLineDedupedOccurrences {
+    <#
+    .SYNOPSIS
+        Reduces a match collection to the occurrences that should actually be
+        emitted, honoring -AllOccurrences semantics without multiplying
+        same-line findings.
+
+    .DESCRIPTION
+        Without -AllOccurrences: only the first match in the whole collection
+        (unchanged legacy behavior for -Path mode).
+
+        With -AllOccurrences: one match per distinct line (the first match on
+        each line), not every raw regex match -- a token/term repeated
+        multiple times on the SAME line is the same finding, not new
+        information, so it collapses to a single occurrence for that line.
+        Distinct lines each still surface their own occurrence.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Content,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [array]$Matches,
+
+        [Parameter(Mandatory)]
+        [bool]$AllOccurrences
+    )
+
+    if (-not $AllOccurrences) {
+        return @($Matches[0])
+    }
+
+    $seenLines = New-Object System.Collections.Generic.HashSet[int]
+    $result = @()
+    foreach ($occurrence in $Matches) {
+        $line = Get-NewcomerAuditLineNumber -Content $Content -Index $occurrence.Index
+        if ($seenLines.Add($line)) {
+            $result += $occurrence
+        }
+    }
+
+    return $result
+}
+
 function Get-NewcomerAuditKnownTermFindings {
     [CmdletBinding()]
     [OutputType([object[]])]
@@ -425,7 +478,7 @@ function Get-NewcomerAuditKnownTermFindings {
             }
 
             if ($row.register -eq 'rename-candidate') {
-                $occurrences = if ($AllOccurrences) { $regexMatches } else { @($regexMatches[0]) }
+                $occurrences = Get-NewcomerAuditLineDedupedOccurrences -Content $Content -Matches $regexMatches -AllOccurrences $AllOccurrences.IsPresent
                 foreach ($occurrence in $occurrences) {
                     $findings += [pscustomobject]@{
                         token          = $occurrence.Value
@@ -449,7 +502,7 @@ function Get-NewcomerAuditKnownTermFindings {
                 continue
             }
 
-            $occurrences = if ($AllOccurrences) { $regexMatches } else { @($regexMatches[0]) }
+            $occurrences = Get-NewcomerAuditLineDedupedOccurrences -Content $Content -Matches $regexMatches -AllOccurrences $AllOccurrences.IsPresent
             foreach ($occurrence in $occurrences) {
                 $findings += [pscustomobject]@{
                     token          = $occurrence.Value
@@ -481,7 +534,14 @@ function Test-NewcomerAuditKnownToken {
             # matching the known-term pass's case sensitivity so a mis-cased
             # token (e.g. 'smc-05') correctly surfaces as 'unknown' instead
             # of silently vanishing between the two passes.
-            $regex = [regex]::new("^$($matcher.Pattern)$", [System.Text.RegularExpressions.RegexOptions]::None, $script:NewcomerAuditRegexTimeout)
+            #
+            # $matcher.Pattern is wrapped in a non-capturing group so a
+            # top-level alternation (e.g. an instance_pattern combining a
+            # \b-bounded literal with a hyphen-boundary numeric form) is
+            # anchored as a whole -- otherwise '^' / '$' bind only to the
+            # first/last alternative and a token like 'step_id-x' can be
+            # wrongly classified as known via the trailing alternative alone.
+            $regex = [regex]::new("^(?:$($matcher.Pattern))$", [System.Text.RegularExpressions.RegexOptions]::None, $script:NewcomerAuditRegexTimeout)
             if ($regex.IsMatch($Token)) {
                 return $true
             }
@@ -543,13 +603,24 @@ function Get-NewcomerAuditUnknownTokenFindings {
             continue
         }
 
-        if (-not $AllOccurrences -and -not $seenTokens.Add($token)) {
+        # Dedup key is computed BEFORE the seen-set check (not the token
+        # alone) so -AllOccurrences relaxes dedup across distinct lines
+        # without disabling it entirely: a token repeated multiple times on
+        # the SAME line is still collapsed to one finding (no new
+        # information), while the same token on a DIFFERENT line still gets
+        # its own finding. Without -AllOccurrences the key is the token
+        # alone, preserving the original first-occurrence-only behavior
+        # exactly.
+        $line = Get-NewcomerAuditLineNumber -Content $Content -Index $tokenMatch.Index
+        $dedupKey = if ($AllOccurrences) { "$token|$line" } else { $token }
+
+        if (-not $seenTokens.Add($dedupKey)) {
             continue
         }
 
         $findings += [pscustomobject]@{
             token          = $token
-            line           = Get-NewcomerAuditLineNumber -Content $Content -Index $tokenMatch.Index
+            line           = $line
             register_state = 'unknown'
             suggestion     = 'expand on first use (preferred), rename to a self-describing form, or add to the register (heavier path)'
         }

--- a/skills/naming-register-policy/scripts/newcomer-audit.ps1
+++ b/skills/naming-register-policy/scripts/newcomer-audit.ps1
@@ -15,10 +15,11 @@
 
       -Changed        Repo-file scan over the files this branch changed, carrying
                        repo-file escape-hatch semantics. Runs
-                       `git diff --diff-filter=ACM $(git merge-base main HEAD)..HEAD`
+                       `git diff --diff-filter=ACMR $(git merge-base main HEAD)..HEAD`
                        (merge-base, NOT two-dot `main..HEAD` against the branch tip
-                       -- so an advanced `main` does not misreport), filtered to the
-                       human-facing surface class list from
+                       -- so an advanced `main` does not misreport; ACMR, not ACM,
+                       so a renamed-and-edited file is still included in the diff),
+                       filtered to the human-facing surface class list from
                        skills/naming-register-policy/SKILL.md (CLAUDE.md, READMEs,
                        skill SKILL.md files carrying `description:` frontmatter,
                        Documents/Design/ orientation docs, issue/PR templates,
@@ -141,7 +142,16 @@ function ConvertTo-NewcomerAuditParsedDiff {
             continue
         }
 
-        if ($line -match '^\+\+\+ b/(.+)$') {
+        # Only treat '+++ b/...' as a genuine file header when it immediately
+        # follows a 'diff --git' reset (i.e. $current is still null/freshly
+        # reset here). An ADDED PROSE LINE that happens to quote diff syntax
+        # verbatim (e.g. a design-doc example showing '+++ b/foo.md') is
+        # otherwise indistinguishable from a real header by text alone, and
+        # would wrongly reset the parser's current-file state and discard
+        # the real file's already-accumulated added-line record. When
+        # $current is already established, such a line falls through to the
+        # normal '+' added-line handling below instead.
+        if ((-not $current) -and ($line -match '^\+\+\+ b/(.+)$')) {
             $current = [pscustomobject]@{
                 Path       = $Matches[1].TrimEnd("`t")
                 AddedLines = [System.Collections.Generic.HashSet[int]]::new()
@@ -209,8 +219,10 @@ function Get-NewcomerAuditMergeBase {
 function Get-NewcomerAuditRawDiff {
     <#
     .SYNOPSIS
-        Runs `git diff --diff-filter=ACM <MergeBase>..HEAD` and returns the raw
-        unified-diff text as a line array.
+        Runs `git diff --diff-filter=ACMR <MergeBase>..HEAD` and returns the raw
+        unified-diff text as a line array. ACMR (not ACM) so a renamed-and-edited
+        file (high-similarity rename+edit) is still included -- ACM alone
+        silently excludes renames from the diff output entirely.
 
     .DESCRIPTION
         Takes the already-resolved merge-base commit as an explicit parameter
@@ -230,7 +242,7 @@ function Get-NewcomerAuditRawDiff {
     Push-Location $RepoRoot
     try {
         $range = "$MergeBase..HEAD"
-        $diffLines = & git diff --diff-filter=ACM $range 2>$null
+        $diffLines = & git diff --diff-filter=ACMR $range 2>$null
         if ($LASTEXITCODE -ne 0) {
             throw "newcomer-audit: git diff failed for range '$range'."
         }
@@ -366,7 +378,35 @@ if ($MyInvocation.InvocationName -ne '.') {
         Write-Error "newcomer-audit: register asset not found at '$registerPath'."
         exit 2
     }
-    $register = Get-Content -Path $registerPath -Raw | ConvertFrom-Json
+
+    try {
+        $register = Get-Content -Path $registerPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        Write-Error "newcomer-audit: register asset at '$registerPath' failed to parse as JSON -- $($_.Exception.Message)"
+        exit 2
+    }
+
+    if ($null -eq $register -or @($register).Count -eq 0) {
+        Write-Error "newcomer-audit: register asset at '$registerPath' parsed to empty or null content."
+        exit 2
+    }
+
+    foreach ($row in $register) {
+        $hasInstancePattern = ($row.PSObject.Properties.Name -contains 'instance_pattern') -and `
+            -not [string]::IsNullOrWhiteSpace($row.instance_pattern)
+        if (-not $hasInstancePattern) {
+            continue
+        }
+
+        try {
+            [regex]::new($row.instance_pattern) | Out-Null
+        }
+        catch {
+            Write-Error "newcomer-audit: register row '$($row.term)' has an invalid instance_pattern -- $($_.Exception.Message)"
+            exit 2
+        }
+    }
 
     $allFindings = @()
 
@@ -417,7 +457,12 @@ if ($MyInvocation.InvocationName -ne '.') {
             $content = Get-NewcomerAuditGitShowContent -RepoRoot $repoRoot -Ref 'HEAD' -RelativePath $changedFile.Path
             if ($null -eq $content) { continue }
 
-            $fileFindings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $register
+            # -AllOccurrences: a genuinely new occurrence of a term on an
+            # ADDED line must not be silently dropped just because an
+            # earlier, unchanged occurrence of the same term exists
+            # elsewhere in the file (first-occurrence-only would otherwise
+            # filter it out before the added-lines check below ever runs).
+            $fileFindings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $register -AllOccurrences
             foreach ($f in $fileFindings) {
                 if ($changedFile.AddedLines.Contains([int]$f.line)) {
                     $allFindings += [pscustomobject]@{

--- a/skills/naming-register-policy/scripts/newcomer-audit.ps1
+++ b/skills/naming-register-policy/scripts/newcomer-audit.ps1
@@ -417,6 +417,11 @@ if ($MyInvocation.InvocationName -ne '.') {
                 exit 2
             }
 
+            if (Test-Path -Path $p -PathType Container) {
+                Write-Error "newcomer-audit: path is a directory, expected a file -- $p"
+                exit 2
+            }
+
             $resolved = (Resolve-Path -Path $p).Path
             $fileFindings = Get-NewcomerAuditFindingsFromFile -Path $resolved -Surface 'issue-body' -Register $register
             foreach ($f in $fileFindings) {

--- a/skills/naming-register-policy/scripts/newcomer-audit.ps1
+++ b/skills/naming-register-policy/scripts/newcomer-audit.ps1
@@ -1,0 +1,447 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    CLI wrapper for the newcomer-audit detector (issue #751, plan step s3).
+
+.DESCRIPTION
+    Dot-sources skills/naming-register-policy/scripts/newcomer-audit-core.ps1 and
+    exposes two mutually exclusive input modes:
+
+      -Path <files>   Whole-file scan carrying issue-body escape-hatch semantics.
+                       Used by the draft-scan seam on wholly new prose (e.g. a
+                       drafted issue body) -- an unexpanded stable code always
+                       requires first-use expansion to suppress on this surface.
+
+      -Changed        Repo-file scan over the files this branch changed, carrying
+                       repo-file escape-hatch semantics. Runs
+                       `git diff --diff-filter=ACM $(git merge-base main HEAD)..HEAD`
+                       (merge-base, NOT two-dot `main..HEAD` against the branch tip
+                       -- so an advanced `main` does not misreport), filtered to the
+                       human-facing surface class list from
+                       skills/naming-register-policy/SKILL.md (CLAUDE.md, READMEs,
+                       skill SKILL.md files carrying `description:` frontmatter,
+                       Documents/Design/ orientation docs, issue/PR templates,
+                       HOW-IT-WORKS.md).
+
+    Load-bearing split in -Changed mode (plan-issue-751 MF5, sustained on
+    adversarial review): escape-hatch suppression is evaluated against the FULL
+    post-image file content read via `git show HEAD:<path>` -- so a vocab-pointer
+    link living in a file's footer still suppresses a term even when the changed
+    line is elsewhere in the file -- but findings are then filtered down to only
+    those whose line number falls inside an added/modified diff hunk. A finding
+    that exists only on an unchanged line of a touched file is never emitted.
+
+    Output: by default, prints a human-readable summary (findings grouped by
+    file) followed by a JSON array of the same findings. Pass -Json to suppress
+    the human-readable summary and emit only the JSON array (for machine
+    consumption / piping into a parser). Exit code is 1 if any findings exist,
+    0 otherwise -- nothing consumes this exit code yet in v1; it is specified for
+    future seams (draft-scan warn-only lane, PR-gate warn-only lane in s5). Exit
+    code 2 signals a usage or operational error (bad arguments, missing file,
+    git failure) and is distinct from both.
+
+    Assumption (documented, not enforced): -Changed mode compares merge-base..HEAD
+    diff hunks (from the commit graph) against `git show HEAD:<path>` content (also
+    from the commit graph), so it is correct regardless of working-tree state. This
+    matches its intended invocation context: Code-Conductor's PR-creation gate,
+    where the branch has already been committed.
+
+.PARAMETER Path
+    One or more file paths to scan whole-file, issue-body escape-hatch semantics.
+
+.PARAMETER Changed
+    Scan files changed on this branch since it diverged from main, repo-file
+    escape-hatch semantics, emission scoped to added/modified lines.
+
+.PARAMETER Json
+    Emit only the JSON findings array (suppresses the human-readable summary).
+
+.EXAMPLE
+    pwsh skills/naming-register-policy/scripts/newcomer-audit.ps1 -Path draft-issue-body.md
+
+.EXAMPLE
+    pwsh skills/naming-register-policy/scripts/newcomer-audit.ps1 -Changed -Json
+#>
+
+[CmdletBinding()]
+param(
+    # -Path and -Changed are intentionally NOT split into distinct
+    # ParameterSetNames: that would make PowerShell's own parameter binder
+    # reject "-Path x -Changed" with an ambiguous-parameter-set error before
+    # this script's body ever runs, pre-empting the deterministic exit-code-2
+    # usage validation below (and its own test coverage). Both mutual
+    # exclusivity and "neither supplied" are validated manually instead.
+    [string[]]$Path,
+
+    [switch]$Changed,
+
+    [switch]$Json
+)
+
+. (Join-Path $PSScriptRoot 'newcomer-audit-core.ps1')
+
+function Test-NewcomerAuditSurfaceClassPath {
+    <#
+    .SYNOPSIS
+        True when a repo-relative path belongs to the human-facing prose surface
+        class list from skills/naming-register-policy/SKILL.md § Human-Facing
+        Prose Surfaces.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $normalized = $Path -replace '\\', '/'
+
+    if ($normalized -eq 'CLAUDE.md') { return $true }
+    if ($normalized -eq 'HOW-IT-WORKS.md') { return $true }
+    if ($normalized -match '(^|/)README(\.[A-Za-z0-9]+)?$') { return $true }
+    if ($normalized -match '^skills/[^/]+/SKILL\.md$') { return $true }
+    if ($normalized -match '^Documents/Design/') { return $true }
+    if ($normalized -match '^\.github/(ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(/|$)') { return $true }
+    if ($normalized -match '^\.github/.*_TEMPLATE\.md$') { return $true }
+
+    return $false
+}
+
+function ConvertTo-NewcomerAuditParsedDiff {
+    <#
+    .SYNOPSIS
+        Parses `git diff` unified-diff text into per-file added-line sets.
+
+    .DESCRIPTION
+        Tracks the new-file (post-image) line cursor per hunk (`@@ -a,b +c,d @@`)
+        and records only lines that start with '+' (excluding the '+++' file
+        header) as added. Context lines (' ') advance the cursor without being
+        recorded; removed lines ('-') do not advance the new-file cursor at all.
+        File identity is taken from the '+++ b/<path>' line, which is the
+        post-image path git already emits for adds/copies/modifies.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [string[]]$DiffLines
+    )
+
+    $files = @()
+    $current = $null
+    $newLineCursor = 0
+
+    foreach ($line in $DiffLines) {
+        if ($line -match '^diff --git ') {
+            if ($current) { $files += $current }
+            $current = $null
+            $newLineCursor = 0
+            continue
+        }
+
+        if ($line -match '^\+\+\+ b/(.+)$') {
+            $current = [pscustomobject]@{
+                Path       = $Matches[1].TrimEnd("`t")
+                AddedLines = [System.Collections.Generic.HashSet[int]]::new()
+            }
+            continue
+        }
+
+        if (-not $current) { continue }
+
+        if ($line -match '^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@') {
+            $newLineCursor = [int]$Matches[1]
+            continue
+        }
+
+        if ($line.StartsWith('+')) {
+            [void]$current.AddedLines.Add($newLineCursor)
+            $newLineCursor++
+            continue
+        }
+
+        if ($line.StartsWith('-')) {
+            continue
+        }
+
+        if ($line.StartsWith(' ')) {
+            $newLineCursor++
+            continue
+        }
+
+        # Other marker lines (e.g. "\ No newline at end of file", a
+        # "Binary files ... differ" summary line with no hunks): no-op.
+    }
+
+    if ($current) { $files += $current }
+
+    return , @($files)
+}
+
+function Get-NewcomerAuditMergeBase {
+    <#
+    .SYNOPSIS
+        Resolves the merge-base commit of 'main' and 'HEAD' -- the corrected,
+        non-misreporting basis for the -Changed diff (plan-issue-751 AC7).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RepoRoot
+    )
+
+    Push-Location $RepoRoot
+    try {
+        $result = & git merge-base main HEAD 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace(($result -join ''))) {
+            throw "newcomer-audit: could not resolve merge-base of 'main' and 'HEAD' -- is there a local 'main' branch?"
+        }
+        return ($result | Select-Object -First 1).ToString().Trim()
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Get-NewcomerAuditRawDiff {
+    <#
+    .SYNOPSIS
+        Runs `git diff --diff-filter=ACM <MergeBase>..HEAD` and returns the raw
+        unified-diff text as a line array.
+
+    .DESCRIPTION
+        Takes the already-resolved merge-base commit as an explicit parameter
+        (rather than re-resolving 'main' itself) so callers -- and tests -- can
+        prove the diff never runs against the literal branch name 'main..HEAD'.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory)]
+        [string]$MergeBase
+    )
+
+    Push-Location $RepoRoot
+    try {
+        $range = "$MergeBase..HEAD"
+        $diffLines = & git diff --diff-filter=ACM $range 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            throw "newcomer-audit: git diff failed for range '$range'."
+        }
+        if ($null -eq $diffLines) { return , @() }
+        return , @($diffLines)
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Get-NewcomerAuditGitShowContent {
+    <#
+    .SYNOPSIS
+        Reads a file's full post-image content at a given ref via `git show`.
+
+    .DESCRIPTION
+        Used for -Changed mode's suppression context: this returns the complete
+        committed file so a footer vocab-pointer link suppresses correctly even
+        when the diff only touched an earlier line. Returns $null if the ref:path
+        cannot be resolved (e.g. a binary file diff artifact).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory)]
+        [string]$Ref,
+
+        [Parameter(Mandatory)]
+        [string]$RelativePath
+    )
+
+    Push-Location $RepoRoot
+    try {
+        $previousEncoding = [Console]::OutputEncoding
+        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+        try {
+            $lines = & git show "${Ref}:${RelativePath}" 2>$null
+        }
+        finally {
+            [Console]::OutputEncoding = $previousEncoding
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+            return $null
+        }
+        if ($null -eq $lines) {
+            return ''
+        }
+        return ($lines -join "`n")
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Format-NewcomerAuditSummary {
+    <#
+    .SYNOPSIS
+        Renders decorated findings (with a 'file' property) as a human-readable
+        summary grouped by file.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [array]$Findings
+    )
+
+    if (-not $Findings -or $Findings.Count -eq 0) {
+        return 'newcomer-audit: no findings.'
+    }
+
+    $lines = @()
+    foreach ($group in ($Findings | Group-Object -Property file)) {
+        $lines += "File: $($group.Name)"
+        foreach ($finding in ($group.Group | Sort-Object line, token)) {
+            $lines += "  Line $($finding.line): $($finding.token) [$($finding.register_state)] -- $($finding.suggestion)"
+        }
+    }
+
+    return ($lines -join "`n")
+}
+
+function ConvertTo-NewcomerAuditFindingsJson {
+    <#
+    .SYNOPSIS
+        Serializes decorated findings to a JSON array string, always -- even
+        for zero findings.
+
+    .DESCRIPTION
+        `@() | ConvertTo-Json -AsArray` returns $null (not '[]') when zero
+        objects flow through the pipeline in this PowerShell version -- piping
+        an empty collection into a cmdlet skips its output entirely, which
+        -AsArray does not compensate for. Handle the zero-findings case
+        explicitly so callers always get parseable JSON array text.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [array]$Findings
+    )
+
+    if (-not $Findings -or $Findings.Count -eq 0) {
+        return '[]'
+    }
+
+    return ($Findings | ConvertTo-Json -Depth 6 -AsArray)
+}
+
+# Guard the CLI entry point so dot-sourcing this file (as the Pester wrapper
+# tests do) only defines functions/params -- it never shells out to git or
+# calls `exit`, which would otherwise terminate the whole hosting process.
+if ($MyInvocation.InvocationName -ne '.') {
+
+    if (-not $Path -and -not $Changed) {
+        Write-Error 'newcomer-audit: specify either -Path <files> or -Changed.'
+        exit 2
+    }
+    if ($Path -and $Changed) {
+        Write-Error 'newcomer-audit: -Path and -Changed are mutually exclusive.'
+        exit 2
+    }
+
+    $registerPath = Join-Path $PSScriptRoot '../assets/register.json'
+    if (-not (Test-Path -Path $registerPath)) {
+        Write-Error "newcomer-audit: register asset not found at '$registerPath'."
+        exit 2
+    }
+    $register = Get-Content -Path $registerPath -Raw | ConvertFrom-Json
+
+    $allFindings = @()
+
+    if ($Path) {
+        foreach ($p in $Path) {
+            if (-not (Test-Path -Path $p)) {
+                Write-Error "newcomer-audit: path not found -- $p"
+                exit 2
+            }
+
+            $resolved = (Resolve-Path -Path $p).Path
+            $fileFindings = Get-NewcomerAuditFindingsFromFile -Path $resolved -Surface 'issue-body' -Register $register
+            foreach ($f in $fileFindings) {
+                $allFindings += [pscustomobject]@{
+                    file           = $p
+                    line           = $f.line
+                    token          = $f.token
+                    register_state = $f.register_state
+                    suggestion     = $f.suggestion
+                }
+            }
+        }
+    }
+    else {
+        $gitTopLevel = & git rev-parse --show-toplevel 2>$null
+        $repoRoot = if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace(($gitTopLevel -join ''))) {
+            ($gitTopLevel | Select-Object -First 1).ToString().Trim()
+        }
+        else {
+            (Get-Location).Path
+        }
+
+        try {
+            $mergeBase = Get-NewcomerAuditMergeBase -RepoRoot $repoRoot
+            $diffLines = Get-NewcomerAuditRawDiff -RepoRoot $repoRoot -MergeBase $mergeBase
+        }
+        catch {
+            Write-Error $_.Exception.Message
+            exit 2
+        }
+
+        $parsedFiles = ConvertTo-NewcomerAuditParsedDiff -DiffLines $diffLines
+
+        foreach ($changedFile in $parsedFiles) {
+            if ($changedFile.AddedLines.Count -eq 0) { continue }
+            if (-not (Test-NewcomerAuditSurfaceClassPath -Path $changedFile.Path)) { continue }
+
+            $content = Get-NewcomerAuditGitShowContent -RepoRoot $repoRoot -Ref 'HEAD' -RelativePath $changedFile.Path
+            if ($null -eq $content) { continue }
+
+            $fileFindings = Get-NewcomerAuditFindings -Content $content -Surface 'repo-file' -Register $register
+            foreach ($f in $fileFindings) {
+                if ($changedFile.AddedLines.Contains([int]$f.line)) {
+                    $allFindings += [pscustomobject]@{
+                        file           = $changedFile.Path
+                        line           = $f.line
+                        token          = $f.token
+                        register_state = $f.register_state
+                        suggestion     = $f.suggestion
+                    }
+                }
+            }
+        }
+    }
+
+    $allFindings = @($allFindings | Sort-Object file, line, token)
+
+    if (-not $Json) {
+        Write-Output (Format-NewcomerAuditSummary -Findings $allFindings)
+    }
+
+    Write-Output (ConvertTo-NewcomerAuditFindingsJson -Findings $allFindings)
+
+    if ($allFindings.Count -gt 0) {
+        exit 1
+    }
+    exit 0
+}

--- a/skills/plan-authoring/SKILL.md
+++ b/skills/plan-authoring/SKILL.md
@@ -107,6 +107,8 @@ A Grounding Pass factual correction — correcting a misnamed path, schema, or a
 
 ## Draft Workflow
 
+When authoring plan prose in this workflow, apply the outsider-first authoring convention in `skills/naming-register-policy/SKILL.md` § Outsider-first authoring default.
+
 ### 1. Build the Execution Skeleton
 
 Prepare a plan that ties every step to an acceptance-criteria slice and names the expected execution mode. The draft should include the implementation steps, validation approach, review pipeline, CE Gate handling when applicable, deferred-significant follow-up behavior, and a short retrospective checkpoint.

--- a/skills/pre-commit-formatting/SKILL.md
+++ b/skills/pre-commit-formatting/SKILL.md
@@ -85,6 +85,24 @@ If `markdownlint-cli2` is not available in PATH, or if `pwsh` is not available: 
 
 ---
 
+## Newcomer-Audit Lane (Warn-Only, Findings-Only)
+
+During the same Code-Conductor PR-creation step, run the newcomer-audit detector over the branch's changed files:
+
+```powershell
+pwsh skills/naming-register-policy/scripts/newcomer-audit.ps1 -Changed
+```
+
+This lane is not a formatting lane and does not behave like the two lanes above:
+
+- It never stages or commits anything — unlike Step 2 and Step 3, there is no `git add` / `git commit` step for this lane.
+- It emits findings only; findings are surfaced as a warning in the PR body / conversation, never as a blocking condition.
+- PR creation proceeds regardless of the lane's exit code (0 = clean, 1 = findings, 2 = usage/operational error).
+
+**This lane does not inherit FG-D6.** FG-D6 (`## Non-Blocking Behavior` above) covers a narrower case — the formatting tools (`markdownlint-cli2`, `pwsh`) being unavailable in PATH. This lane's non-blocking behavior is a separate, explicit rule: the tool runs successfully and returns real findings, and those findings still never block PR creation. Do not describe this lane as "inheriting" or "covered by" FG-D6 — its warn-only semantics are stated here explicitly.
+
+---
+
 ## Portability Assumptions
 
 This gate assumes:

--- a/skills/pre-commit-formatting/SKILL.md
+++ b/skills/pre-commit-formatting/SKILL.md
@@ -98,6 +98,7 @@ This lane is not a formatting lane and does not behave like the two lanes above:
 - It never stages or commits anything — unlike Step 2 and Step 3, there is no `git add` / `git commit` step for this lane.
 - It emits findings only; findings are surfaced as a warning in the PR body / conversation, never as a blocking condition.
 - PR creation proceeds regardless of the lane's exit code (0 = clean, 1 = findings, 2 = usage/operational error).
+- **Exit code 2 is an operational failure, not a clean pass — surface it distinctly.** Exit 1 (findings) and exit 2 (the audit failed to run) must never look the same to the operator. On exit 2, post a distinctly-worded warning in the PR body / conversation — for example: "⚠️ newcomer-audit lane FAILED TO RUN — findings unknown, treat as unaudited." The lane stays fail-open either way (exit 2 never blocks PR creation), but silence on exit 2 would make a broken audit indistinguishable from a genuinely clean one.
 
 **This lane does not inherit FG-D6.** FG-D6 (`## Non-Blocking Behavior` above) covers a narrower case — the formatting tools (`markdownlint-cli2`, `pwsh`) being unavailable in PATH. This lane's non-blocking behavior is a separate, explicit rule: the tool runs successfully and returns real findings, and those findings still never block PR creation. Do not describe this lane as "inheriting" or "covered by" FG-D6 — its warn-only semantics are stated here explicitly.
 

--- a/skills/safe-operations/SKILL.md
+++ b/skills/safe-operations/SKILL.md
@@ -64,6 +64,8 @@ These PowerShell commands silently corrupt files through encoding issues (e.g., 
 
 ## Section 2: Issue Creation Rules
 
+When authoring new issues under these rules, apply the outsider-first authoring convention in `skills/naming-register-policy/SKILL.md` § Outsider-first authoring default.
+
 ### 2a. Improvement-First Decision Rule
 
 When any agent discovers an out-of-scope or non-blocking improvement during its work, classify it against the structural-criteria gate (canonical taxonomy in `skills/review-judgment/scripts/Test-DeferralCriteria.ps1`):


### PR DESCRIPTION
## Summary

Ships the last child of umbrella #732 (readability for github.com readers): a written **outsider-first authoring convention** plus a minimal, deterministic **newcomer-audit detector** (`skills/naming-register-policy/scripts/newcomer-audit.ps1` + `newcomer-audit-core.ps1`) that flags undefined insider terms in new human-facing prose before they land ΓÇö closing #732's S1 ("a stuck GitHub reader becomes self-sufficient").

Detection without enforcement in v1: warn-only everywhere, no CI, no allowlist tooling (settled scope; a promotion trigger is documented for the pre-authorized spin-out).

## Changed files

- `skills/naming-register-policy/scripts/newcomer-audit-core.ps1` (new) ΓÇö detector core: UTF-8/LF-normalized zone stripping, compound-term tokenization, split-by-surface known-term pass, digit/underscore/`[]`-shaped unknown-token pass, regex match-timeout guards.
- `skills/naming-register-policy/scripts/newcomer-audit.ps1` (new) ΓÇö CLI wrapper: `-Path` (issue-body semantics) and `-Changed` (merge-base diff, added-lines emission over full-file suppression context).
- `skills/naming-register-policy/schemas/register.schema.json`, `assets/register.json` ΓÇö new optional `instance_pattern` and `component_matchers` fields; 5 rows updated.
- `skills/naming-register-policy/SKILL.md` ΓÇö new `## Outsider-first authoring default` section (convention, coverage-boundary table, promotion trigger).
- `CLAUDE.md` + 4 load-referencing skills (`customer-experience`, `design-exploration`, `plan-authoring`, `safe-operations`) ΓÇö convention pointers.
- `agents/Experience-Owner.agent.md`, `Solution-Designer.agent.md`, `Issue-Planner.agent.md` ΓÇö draft-scan step wired at each agent's real issue-body write site.
- `skills/pre-commit-formatting/SKILL.md` ΓÇö new warn-only PR-gate lane (explicit non-inheritance of FG-D6).
- `Documents/Design/naming-register-policy.md` (new) ΓÇö durable architectural record.
- `.github/scripts/Tests/newcomer-audit.Tests.ps1`, `newcomer-audit-wrapper.Tests.ps1` (new), `NamingRegisterLivingSurface.Tests.ps1`, `script-safety-contract.Tests.ps1` ΓÇö test coverage + allowlist entry.

## Validation evidence

- **Pester**: 67/67 passing (`newcomer-audit.Tests.ps1`, `newcomer-audit-wrapper.Tests.ps1`, `naming-register-policy.Tests.ps1`).
- **quick-validate**: 10/12 (2 pre-existing, unrelated failures on `persist-changes/SKILL.md`, confirmed present on `main` before this branch).
- **PSScriptAnalyzer**: clean.
- **markdownlint**: clean across all touched `.md` files.

## Review Mode

**Standard** (full 5-pass adversarial pipeline, maintainer-selected over lite to establish a measurement baseline before any future rigor reduction) ΓÇö run on the shipped implementation, plus a post-fix prosecution+defense pair on the resulting fix commit.

### Adversarial review score table

| Stage | Result |
| --- | --- |
| Prosecution (5-pass: 2 generalist + 3 specialist) | 32 raw findings ΓåÆ 25 deduped |
| Defense | 13 conceded, 12 rebutted |
| Judge | **13 sustained**, 12 defense-sustained (Prosecutor 77 pts / Defense 20 pts) |
| Fix cycle | All 13 resolved |
| Post-fix prosecution | 2 new findings (regressions introduced by the fix cycle itself) |
| Post-fix defense | Both conceded |
| Post-fix fix cycle | Both resolved, re-validated clean |

### Prosecution depth summary

The standard panel earned its cost decisively. Three independent passes converged on the same root defect from different angles: the register's `term` field is a **display label, not a matcher** ΓÇö the compound-term tokenizer built to fix an earlier `credits[]` bug had the side effect of also producing standalone matchers for bare English words (`frame`, `adapter`), flagging ordinary prose, and independently re-creating the exact `D1`/`D2`/`D3` collision an earlier design decision had deliberately excluded. Empirically reproduced: the detector's own introduction PR self-flagged with **100% false-positive noise** (`v1`, `ps1`) before the fix ΓÇö now zero. Also caught and fixed: a real 40-second ReDoS hang, two silent-fail-closed/false-clean-exit-0 paths on malformed input, a case-sensitivity gap letting mis-cased codes vanish from detection entirely, and a `--diff-filter=ACM` gap silently skipping renamed files. The post-fix pass then caught the fix cycle's own regressions (duplicate findings from a naive dedup-disable; a regex-composition gap from an unwrapped alternation) before they could ship.

## CE Gate (Customer Experience Gate)

**Γ£à CE Gate passed ΓÇö intent match: strong**

| ID | Type | Class | Result | Evidence | Source | Evidence Type |
| --- | --- | --- | --- | --- | --- | --- |
| S1 | Functional | auto | PASS | `plan-issue-732`/`SMC-20` flagged with expansion suggestions | EO | live-interaction |
| S3 | Functional | auto | PASS | Expanded/non-jargon/zoned tokens not flagged; `v1`/`ps1` regressions confirmed gone (non-vacuous: both tokens appear 39├ù combined in this PR's own diff) | EO | live-interaction |
| S4 | Intent | manual | PASS | Convention section + CLAUDE.md pointer + 4 load-refs all verified present | EO | code-audit |
| S2 | Intent | manual | Recorded as ongoing design intent ΓÇö not gate-able in a single PR | ΓÇö | EO | ΓÇö |

## Process gaps found

None structural. One pre-existing, unrelated Pester parser bug (`-Because` string interpolation `ParseException` in `NamingRegisterLivingSurface.Tests.ps1`, confirmed pre-dating this branch) was discovered incidentally and filed as [#821](https://github.com/Grimblaz/agent-orchestra/issues/821) rather than fixed in-scope.

Closes #751


<!-- pipeline-metrics
pr_number: 751
branch: feature/issue-751-outsider-first-authoring-detector
metrics_version: 4
frame_version: 1
credits:
  - port: experience
    adapter: work-adapter
    status: passed
    evidence: 'issue #751; experience completion marker posted'
  - port: design
    adapter: work-adapter
    status: passed
    evidence: 'issue #751; design completion marker posted'
  - port: plan
    adapter: work-adapter
    status: passed
    evidence: 'issue #751; plan completion marker posted'
  - port: orchestration
    adapter: scope-classification
    status: passed
    evidence: 'issue #751; scope-classification announced (deterministic rubric)'
-->

## Summary by Sourcery

Introduce an outsider-first authoring convention and a newcomer-audit detector to guard human-facing prose against unexplained insider terms, wiring it into authoring agents and the PR-creation workflow.

New Features:
- Add a newcomer-audit detector core and CLI wrapper that scan content and changed repo files for undefined insider terms using the naming register.
- Define an outsider-first authoring default convention that requires insider terms to be expanded on first use or be self-describing, with documented coverage boundaries and promotion triggers.

Enhancements:
- Extend the naming register schema and data with support for instance patterns and component matchers to better model term families and compounds.
- Update authoring skills and Claude documentation to reference and apply the outsider-first convention when producing human-facing prose.
- Add a warn-only newcomer-audit lane to the pre-commit formatting/PR-creation gate to surface detector findings without blocking.
- Clarify naming-register living-surface and script-safety tests around newcomer-audit behavior and surface discovery limits.
- Record the newcomer-audit and outsider-first authoring design in a durable design document and bump project version to 3.3.6.

Tests:
- Add comprehensive Pester tests for the newcomer-audit core and wrapper, including diff parsing, merge-base behavior, suppression rules, and determinism.
- Update test infrastructure to treat newcomer-audit wrapper tests as CLI integration that must spawn subprocesses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a newcomer-audit detector that flags undefined insider terms in draft human-facing prose, with stable-name matching and configurable “changed files” scanning.
  * Added an outsider-first authoring convention and integrated warn-only draft scans into key writing workflows and PR creation formatting.

* **Bug Fixes**
  * Improved matching accuracy with instance-pattern support and stricter suppression behavior, reducing false positives in mixed content.

* **Documentation**
  * Updated README/versioning, changelog, and multiple skill and design docs to describe the new conventions and audit usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->