### PR TITLE
fix(#818): migrate Pester test suite to 6.x with a standing fall-through guard

### DIFF
--- a/.github/scripts/Tests/Get-AcTermsFromIssue.Tests.ps1
+++ b/.github/scripts/Tests/Get-AcTermsFromIssue.Tests.ps1
@@ -70,11 +70,13 @@ Describe 'Basic extraction' {
 
 - Not in AC.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
     }
 
     It 'returns entries for each non-stop-list backtick term' {
         $result = Get-AcTermsFromIssue -IssueNumber '123'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $result | Should -Not -BeNullOrEmpty
         $terms = $result | Select-Object -ExpandProperty term
         $terms | Should -Contain 'MyFeature'
@@ -83,6 +85,7 @@ Describe 'Basic extraction' {
 
     It 'each entry has term, source_ac_line, and is_behavioral fields' {
         $result = Get-AcTermsFromIssue -IssueNumber '123'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         foreach ($entry in $result) {
             $entry.PSObject.Properties.Name | Should -Contain 'term'
             $entry.PSObject.Properties.Name | Should -Contain 'source_ac_line'
@@ -92,12 +95,14 @@ Describe 'Basic extraction' {
 
     It 'source_ac_line is the trimmed full AC line for each term' {
         $result = Get-AcTermsFromIssue -IssueNumber '123'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $myFeatureEntry = $result | Where-Object { $_.term -eq 'MyFeature' }
         $myFeatureEntry.source_ac_line | Should -Be '- The `MyFeature` identifier must be supported.'
     }
 
     It 'does not include terms from sections after the next H2' {
         $result = Get-AcTermsFromIssue -IssueNumber '123'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $terms = $result | Select-Object -ExpandProperty term
         $terms | Should -Not -Contain 'Not'
     }
@@ -111,9 +116,11 @@ Describe 'Behavioral keyword detection' {
 
 - The renderer must fetch `TargetIdentifier` before proceeding.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '1'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $entry = $result | Where-Object { $_.term -eq 'TargetIdentifier' }
         $entry | Should -Not -BeNullOrEmpty
         $entry.is_behavioral | Should -Be $true
@@ -125,9 +132,11 @@ Describe 'Behavioral keyword detection' {
 
 - The `NeutralThing` is returned as a plain object.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '2'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $entry = $result | Where-Object { $_.term -eq 'NeutralThing' }
         $entry | Should -Not -BeNullOrEmpty
         $entry.is_behavioral | Should -Be $false
@@ -139,9 +148,11 @@ Describe 'Behavioral keyword detection' {
 
 - The `CasedTerm` MUST be enforced.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '3'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $entry = $result | Where-Object { $_.term -eq 'CasedTerm' }
         $entry.is_behavioral | Should -Be $true
     }
@@ -153,9 +164,11 @@ Describe 'Behavioral keyword detection' {
 
 - The `MustyIdentifier` is a musty old value.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '4'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $entry = $result | Where-Object { $_.term -eq 'MustyIdentifier' }
         $entry | Should -Not -BeNullOrEmpty
         $entry.is_behavioral | Should -Be $false
@@ -171,9 +184,11 @@ Describe 'Stop-list rejection' {
 - The flag is `true` or `false` and never `null`.
 - The `RealIdentifier` is always present.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '10'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $terms = $result | Select-Object -ExpandProperty term
         $terms | Should -Not -Contain 'true'
         $terms | Should -Not -Contain 'false'
@@ -188,9 +203,11 @@ Describe 'Stop-list rejection' {
 - The result is `TRUE` when configured, `False` otherwise.
 - The `ActualTerm` is defined.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '11'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $terms = $result | Select-Object -ExpandProperty term
         $terms | Should -Not -Contain 'TRUE'
         $terms | Should -Not -Contain 'False'
@@ -204,9 +221,11 @@ Describe 'Stop-list rejection' {
 - The `ac_cross_check` field must be set; behavior is `dismiss` or `defer`.
 - The `SemanticTarget` is the load-bearing output.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '12'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $terms = $result | Select-Object -ExpandProperty term
         $terms | Should -Not -Contain 'ac_cross_check'
         $terms | Should -Not -Contain 'dismiss'
@@ -231,9 +250,11 @@ Describe 'H3-resilient AC section' {
 
 - `NotIncluded` is outside AC.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '20'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $terms = $result | Select-Object -ExpandProperty term
         $terms | Should -Contain 'TopLevelTerm'
         $terms | Should -Contain 'SubSectionTerm'
@@ -248,9 +269,11 @@ Describe 'H3-resilient AC section' {
 
 - `RealTerm` is required.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '21'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $terms = $result | Select-Object -ExpandProperty term
         # HeaderToken appears in an ### line — it is still parseable as a term
         # (H3 lines are AC content); the key invariant is RealTerm is also present.
@@ -274,9 +297,11 @@ Describe 'H2 boundary' {
 
 - `ImplNoteTerm` is only in Implementation Notes.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '30'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $terms = $result | Select-Object -ExpandProperty term
         $terms | Should -Contain 'AcTerm'
         $terms | Should -Not -Contain 'TestingScopeTerm'
@@ -294,10 +319,12 @@ This issue has no AC section.
 
 - `SomeToken` is here but not in AC.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $warnings = @()
         $result = Get-AcTermsFromIssue -IssueNumber '40' -WarningVariable warnings
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         @($result).Count | Should -Be 0
         $warnMessages = @($warnings) | ForEach-Object {
             if ($_ -is [System.Management.Automation.WarningRecord]) { $_.Message } else { "$_" }
@@ -312,10 +339,12 @@ This issue has no AC section.
 - The system works correctly.
 - No backtick identifiers are present here.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         { Get-AcTermsFromIssue -IssueNumber '41' -WarningAction Stop } | Should -Not -Throw
         $result = Get-AcTermsFromIssue -IssueNumber '41'
+        Should -Invoke gh -Times 2 -ParameterFilter { $args[0] -eq 'issue' }
         $result | Should -BeNullOrEmpty
     }
 }
@@ -331,9 +360,11 @@ Describe 'CR8/CR9-style behavioral AC (originating incident pattern)' {
 - the renderer is specified to fetch `triage`-labeled issues repo-wide; must query repo-wide not just sequenced issues
 - the `portfolio-tracker` label is applied unconditionally to all new portfolio issues
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '709'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $terms = $result | Select-Object -ExpandProperty term
 
         # triage must be extracted
@@ -357,9 +388,11 @@ Describe 'CR8/CR9-style behavioral AC (originating incident pattern)' {
 
 - the renderer must not `get` or `set` values; use `FetchEngine` instead
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '709b'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $terms = $result | Select-Object -ExpandProperty term
 
         $terms | Should -Not -Contain 'get'
@@ -378,9 +411,11 @@ Describe 'Deduplication' {
 - The `SharedTerm` should also be validated on output.
 - The `OtherTerm` is independent.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '50'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $terms = $result | Select-Object -ExpandProperty term
         ($terms | Where-Object { $_ -eq 'SharedTerm' }).Count | Should -Be 1
         $terms | Should -Contain 'OtherTerm'
@@ -393,9 +428,11 @@ Describe 'Deduplication' {
 - First line: `DupTerm` must be checked.
 - Second line: `DupTerm` should also be checked.
 '@
+        Mock gh { return '' }
         Mock gh { return $issueBody } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = Get-AcTermsFromIssue -IssueNumber '51'
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $dupEntry = $result | Where-Object { $_.term -eq 'DupTerm' }
         $dupEntry.source_ac_line | Should -Be '- First line: `DupTerm` must be checked.'
     }
@@ -404,23 +441,29 @@ Describe 'Deduplication' {
 Describe 'Failure path' {
 
     It 'returns zero entries when gh returns empty output' {
+        Mock gh { return '' }
         Mock gh { return '' } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = @(Get-AcTermsFromIssue -IssueNumber '99')
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         # @() is the canonical empty-array return; Count 0 is the observable guarantee.
         $result.Count | Should -Be 0
     }
 
     It 'does not throw when gh returns empty output' {
+        Mock gh { return '' }
         Mock gh { return '' } -ParameterFilter { $args[0] -eq 'issue' }
 
         { Get-AcTermsFromIssue -IssueNumber '99' } | Should -Not -Throw
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
     }
 
     It 'returns zero entries when gh returns null' {
+        Mock gh { return '' }
         Mock gh { return $null } -ParameterFilter { $args[0] -eq 'issue' }
 
         $result = @(Get-AcTermsFromIssue -IssueNumber '100')
+        Should -Invoke gh -Times 1 -ParameterFilter { $args[0] -eq 'issue' }
         $result.Count | Should -Be 0
     }
 }

--- a/.github/scripts/Tests/NamingRegisterLivingSurface.Tests.ps1
+++ b/.github/scripts/Tests/NamingRegisterLivingSurface.Tests.ps1
@@ -118,7 +118,7 @@ Describe "File existence" {
 }
 
 Describe "Vocab anchor" {
-    It 'vocab anchor (<a id="vocab">) appears exactly once in HOW-IT-WORKS.md' {
+    It 'vocab anchor (anchor tag with id="vocab") appears exactly once in HOW-IT-WORKS.md' {
         $content = Get-Content $script:HowItWorksPath -Raw
         $anchorMatches = [regex]::Matches($content, '<a\s+id="vocab">')
         $anchorMatches.Count | Should -Be 1 -Because "exactly one vocab anchor is required for unambiguous fragment routing"

--- a/.github/scripts/Tests/Test-DeferralCriteria.Tests.ps1
+++ b/.github/scripts/Tests/Test-DeferralCriteria.Tests.ps1
@@ -13,6 +13,9 @@ Describe 'Test-DeferralCriteria' {
             $data
         }
     }
+    if (@($Fixtures).Count -eq 0) {
+        throw "no fixtures found in $FixturesDir — coverage would silently vanish"
+    }
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
@@ -118,7 +121,7 @@ Describe 'Test-DeferralCriteria' {
     Context 'M8 / M9 module-mapping invariants (root and infra)' {
         # M8: root-level files become a virtual <root> module.
         # M9: dotfile-prefixed top-level dirs collapse into a virtual <infra> module.
-        It 'M8 + M9: 4 distinct modules across <root>, <infra>, agents, and skills trips S-cross-cutting' {
+        It 'M8 + M9: 4 distinct modules across root, infra, agents, and skills trips S-cross-cutting' {
             $Finding = @{
                 id    = "F_m8_m9"
                 text  = "Touches root file, dotfile-dir, agents, and skills."

--- a/.github/scripts/Tests/code-review-deferral-integration.Tests.ps1
+++ b/.github/scripts/Tests/code-review-deferral-integration.Tests.ps1
@@ -169,6 +169,9 @@ Describe 'Code-Review-Deferral-Integration' {
                 $data
             }
         }
+        if (@($Fixtures).Count -eq 0) {
+            throw "no fixtures found in $FixturesDir — coverage would silently vanish"
+        }
 
         It 'correctly executes all synthetic corpus cases and matches expected verdicts' -ForEach $Fixtures {
             $Fixture = $_
@@ -536,18 +539,60 @@ Describe 'Code-Review-Deferral-Integration' {
         }
 
         It 'integrated routed:defer path: Get-StructuralVerdict no-match + Add-FollowUpIssue with ac_cross_check guard (F7/AC7)' {
-            # Mock gh to return issue body WITH AC section but no terms that match the finding
+            # Default gh mock: replicates the Describe-level global:gh catch-all (create/edit/
+            # view-bare/graphql) so Add-FollowUpIssue's internal node-lookup and mutation calls
+            # below still resolve once the narrow filter below claims the `issue view --json body`
+            # shape. Pester 6 throws on unmatched Mock calls instead of falling through, so this
+            # default is required as soon as any filtered Mock is registered for `gh` in this scope.
+            Mock gh {
+                $joined = $RemainingArgs -join ' '
+                if ($joined -match 'issue\s+create') {
+                    $idx = [array]::IndexOf($RemainingArgs, '--body')
+                    if ($idx -ge 0 -and $idx + 1 -lt $RemainingArgs.Count) {
+                        $script:CapturedCreateBody = $RemainingArgs[$idx + 1]
+                    }
+                    $global:LASTEXITCODE = 0
+                    return 'https://github.com/Grimblaz/agent-orchestra/issues/999'
+                }
+                if ($joined -match 'issue\s+edit') {
+                    $idx = [array]::IndexOf($RemainingArgs, '--body')
+                    if ($idx -ge 0 -and $idx + 1 -lt $RemainingArgs.Count) {
+                        $script:CapturedEditBody = $RemainingArgs[$idx + 1]
+                    }
+                    $global:LASTEXITCODE = 0
+                    return ''
+                }
+                if ($joined -match 'issue\s+view') {
+                    $global:LASTEXITCODE = 0
+                    return 'I_node_id'
+                }
+                if ($joined -match 'api\s+graphql') {
+                    $global:LASTEXITCODE = 0
+                    return '{"data":{"addSubIssue":{"issue":{"title":"Child"}}}}'
+                }
+                return ''
+            }
+
+            # Mock gh to return issue body WITH AC section but no terms that match the finding.
+            # Narrowed to `issue view` + `--json body` specifically (not bare `issue view`, which
+            # also matches Add-FollowUpIssue's `--json id` node-lookup calls below) and rebound to
+            # $RemainingArgs (the mocked global:gh function binds via
+            # [Parameter(ValueFromRemainingArguments=$true)]$RemainingArgs, not the automatic $args).
             Mock gh {
                 return @'
 ## Acceptance Criteria
 
 - the `portfolio-tracker` label is applied unconditionally to all new portfolio issues
 '@
-            } -ParameterFilter { $args[0] -eq 'issue' }
+            } -ParameterFilter { ($RemainingArgs -join ' ') -match 'issue\s+view' -and ($RemainingArgs -join ' ') -match '--json\s+body' }
 
             # Step 1: extract AC terms — 'portfolio-tracker' is present
             $acTerms = Get-AcTermsFromIssue -IssueNumber '709'
             $acTerms | Should -Not -BeNullOrEmpty
+            # Sound invoke-pairing (d-dead-filter-tripwire-v2): assertion filter is textually
+            # identical to the narrow Mock's -ParameterFilter above, so a future dead filter on
+            # either side fails loudly instead of silently falling through to the default mock.
+            Should -Invoke gh -Times 1 -ParameterFilter { ($RemainingArgs -join ' ') -match 'issue\s+view' -and ($RemainingArgs -join ' ') -match '--json\s+body' }
 
             # Step 2: Get-StructuralVerdict for a finding that does NOT mention portfolio-tracker
             $Finding = @{

--- a/.github/scripts/Tests/cost-walker-copilot.Tests.ps1
+++ b/.github/scripts/Tests/cost-walker-copilot.Tests.ps1
@@ -155,6 +155,7 @@ Describe 'Invoke-CostCopilotWalk' {
             $capturedReflogLines = $ReflogLines
 
             try {
+                Mock Get-CostCopilotReflog { }
                 Mock Get-CostCopilotReflog { return $capturedReflogLines } -ParameterFilter { $RepoRoot -eq $script:RepoRoot }
 
                 $result = @(Invoke-CostCopilotWalk `
@@ -163,6 +164,10 @@ Describe 'Invoke-CostCopilotWalk' {
                     -OtelJsonlPath $otelPath `
                     -WorkspaceFolderBasename $WorkspaceBasename `
                     -WarningVariable localWarnings)
+
+                # Sound invoke-pairing (d-dead-filter-tripwire-v2): assertion filter is textually
+                # identical to the narrow Mock's -ParameterFilter above.
+                Should -Invoke Get-CostCopilotReflog -Times 1 -ParameterFilter { $RepoRoot -eq $script:RepoRoot }
 
                 if ($null -ne $Warnings) {
                     $Warnings.Value = @($localWarnings)
@@ -179,6 +184,7 @@ Describe 'Invoke-CostCopilotWalk' {
     Context 'sanitized fixture contract' {
         It 'joins the S1 OTel fixture to the synthetic reflog and emits a normalized Copilot cost event' -Skip { # TODO(#651-option1-remove): Copilot sunset 2026-08-31 — frozen, no forward Copilot work
             $reflogLines = Get-Content -Path $script:SyntheticReflog -Encoding utf8
+            Mock Get-CostCopilotReflog { }
             Mock Get-CostCopilotReflog { return $reflogLines } -ParameterFilter { $RepoRoot -eq $script:RepoRoot }
 
             $walkOutput = @(Invoke-CostCopilotWalk `

--- a/.github/scripts/Tests/cost-walker.Tests.ps1
+++ b/.github/scripts/Tests/cost-walker.Tests.ps1
@@ -115,12 +115,32 @@ Describe 'Invoke-CostTranscriptWalk' {
             )
 
             $exactLowercasePath = Join-Path $tmp $slug
+
+            # Default gh-cmdlet call-through: this It creates a REAL uppercase-named directory
+            # on disk and asserts the code discovers it via real filesystem fallback
+            # (Resolve-CostWalkerPrimarySlugDir's case-insensitive Get-ChildItem match at
+            # cost-walker.ps1:214-216). Only the exact lowercase path this It is simulating as
+            # absent should be intercepted; every other Test-Path call (directory-discovery,
+            # subagent-file probes, etc.) must hit the real filesystem so that fallback works.
+            # A captured CommandInfo reference is required to call through without recursing
+            # back into this same Mock (a module-qualified call still resolves to the mock).
+            $realTestPath = Get-Command Test-Path -CommandType Cmdlet
+            Mock Test-Path {
+                if ($LiteralPath) {
+                    & $realTestPath -LiteralPath $LiteralPath
+                } else {
+                    & $realTestPath -Path $Path
+                }
+            }
             Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $exactLowercasePath }
 
             $result = @(Invoke-CostTranscriptWalk -Slug $slug -Branch $script:TestBranch -ParentCwd $script:TestCwd -ProjectsRoot $tmp)
             $result.Count | Should -Be 1
             $result[0].uuid | Should -Be $eventId
             $result[0].type | Should -Be 'assistant'
+            # Sound invoke-pairing (d-dead-filter-tripwire-v2): assertion filter is textually
+            # identical to the narrow Mock's -ParameterFilter above.
+            Should -Invoke Test-Path -Times 1 -ParameterFilter { $LiteralPath -eq $exactLowercasePath }
             Remove-Item -Recurse -Force $tmp
         }
 
@@ -402,8 +422,7 @@ Describe 'Invoke-CostTranscriptWalk' {
         ) {
             param([string]$Cwd)
 
-            Mock Get-NormalizedPath { throw 'Get-NormalizedPath must not run for Copilot OTel sentinel cwd values' } `
-                -ParameterFilter { $Path -like 'copilot-otel://*' }
+            Mock Get-NormalizedPath { throw 'Get-NormalizedPath must not run for Copilot OTel sentinel cwd values' } -ParameterFilter { $Path -like 'copilot-otel://*' }
 
             $matchesParent = script:Test-CostWalkerEventCwdMatchesParent `
                 -TranscriptEvent @{ cwd = $Cwd } `

--- a/.github/scripts/Tests/create-improvement-issue.Tests.ps1
+++ b/.github/scripts/Tests/create-improvement-issue.Tests.ps1
@@ -1,5 +1,5 @@
 #Requires -Version 7.0
-#Requires -Modules @{ ModuleName = 'Pester'; RequiredVersion = '5.7.1' }
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
     Pester 5 tests for Invoke-CreateImprovementIssue (create-improvement-issue-core.ps1).

--- a/.github/scripts/Tests/frame-audit-report.Tests.ps1
+++ b/.github/scripts/Tests/frame-audit-report.Tests.ps1
@@ -1,7 +1,32 @@
 #Requires -Version 7.0
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
+function script:Get-FrameAuditReportVersionFixtures {
+    # Single source of truth for the metrics-version fixture window, called
+    # from BOTH the discovery-time declaration below and BeforeAll (Run
+    # phase). Pester 6 isolates the Describe body's own top-level statements
+    # and BeforeDiscovery blocks to the DISCOVERY pass only — neither
+    # persists into Run phase (confirmed empirically: a script-scope
+    # variable set outside BeforeAll reads back as $null once Run-phase It
+    # bodies execute, and `@($null).Count` deceptively equals 1 rather than
+    # 0 or throwing, which is what originally masked this). -ForEach (below)
+    # needs the data at discovery time; the "replays the judged historical
+    # fixture window" test needs the same data again at Run time via
+    # $script:VersionFixtures, so it must be (re-)assigned in BeforeAll too.
+    return @(
+        @{ MetricsVersion = '1'; PrNumber = 286; FixtureFile = 'frame-pr-286-v1.json' }
+        @{ MetricsVersion = '2'; PrNumber = 338; FixtureFile = 'frame-pr-338-v2.json' }
+        @{ MetricsVersion = '3'; PrNumber = 415; FixtureFile = 'frame-pr-415-v3.json' }
+        @{ MetricsVersion = '4'; PrNumber = 411; FixtureFile = 'frame-pr-411-v4.json' }
+    )
+}
+
 Describe 'Invoke-FrameAuditReport' {
+
+    # Discovery-time population so -ForEach (below) never sees a null/empty
+    # collection under Pester 6. See Get-FrameAuditReportVersionFixtures for
+    # why this must be re-populated again inside BeforeAll.
+    $script:VersionFixtures = Get-FrameAuditReportVersionFixtures
 
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
@@ -14,12 +39,8 @@ Describe 'Invoke-FrameAuditReport' {
             . $script:LibFile
         }
 
-        $script:VersionFixtures = @(
-            @{ MetricsVersion = '1'; PrNumber = 286; FixtureFile = 'frame-pr-286-v1.json' }
-            @{ MetricsVersion = '2'; PrNumber = 338; FixtureFile = 'frame-pr-338-v2.json' }
-            @{ MetricsVersion = '3'; PrNumber = 415; FixtureFile = 'frame-pr-415-v3.json' }
-            @{ MetricsVersion = '4'; PrNumber = 411; FixtureFile = 'frame-pr-411-v4.json' }
-        )
+        # Run-phase re-population — see Get-FrameAuditReportVersionFixtures.
+        $script:VersionFixtures = Get-FrameAuditReportVersionFixtures
 
         $script:TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "pester-frame-audit-report-$([System.Guid]::NewGuid().ToString('N'))"
         New-Item -ItemType Directory -Path $script:TempRoot -Force | Out-Null

--- a/.github/scripts/Tests/frame-credit-ledger-core.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-core.Tests.ps1
@@ -1934,7 +1934,7 @@ credits:
     # Markdown table newline escape (Gemini Finding 4)
     # -------------------------------------------------------------------------
 
-    It 'Compose-Comment escapes literal newlines in evidence to <br> so table rows survive' {
+    It 'Compose-Comment escapes literal newlines in evidence to a br tag so table rows survive' {
         $reports = @(
             [pscustomobject]@{
                 PortName          = 'review'

--- a/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-orchestrator.Tests.ps1
@@ -849,7 +849,7 @@ Describe 'frame-credit-ledger.ps1 orchestrator' {
 
     Context 'Parameter parsing + outer fail-open wrapper' {
 
-        It 'accepts -Pr <int> -Mode warn and exits 0 on the all-covered v4 fixture' {
+        It 'accepts a -Pr int-argument flag with -Mode warn and exits 0 on the all-covered v4 fixture' {
             $bodyJson = (@{ body = $script:V4AllCoveredBody } | ConvertTo-Json -Compress)
 
             $ip = & $script:InvokeOrchestratorInProcess `
@@ -859,7 +859,7 @@ Describe 'frame-credit-ledger.ps1 orchestrator' {
             $ip.Result.ExitCode | Should -Be 0
         }
 
-        It 'accepts -Pr <int> -Mode enforce and exits 0 on the all-covered v4 fixture' {
+        It 'accepts a -Pr int-argument flag with -Mode enforce and exits 0 on the all-covered v4 fixture' {
             $bodyJson = (@{ body = $script:V4AllCoveredBody } | ConvertTo-Json -Compress)
 
             $ip = & $script:InvokeOrchestratorInProcess `

--- a/.github/scripts/Tests/frame-predicate-never-identifier.Tests.ps1
+++ b/.github/scripts/Tests/frame-predicate-never-identifier.Tests.ps1
@@ -30,7 +30,7 @@ BeforeAll {
 }
 
 Describe 'never identifier' {
-    It 'resolves bare <never> to Result=false' {
+    It 'resolves bare never identifier to Result=false' {
         $result = script:Parse-And-Eval -Predicate 'never'
         $result.Result | Should -Be 'false'
     }

--- a/.github/scripts/Tests/frame-validate.Tests.ps1
+++ b/.github/scripts/Tests/frame-validate.Tests.ps1
@@ -1021,6 +1021,7 @@ applies-when: port ==
     Context 'Invoke-QuickValidate integration' {
 
         It 'surfaces frame validator failure through quick-validate aggregation' {
+            Mock Get-Module { }
             Mock Get-Module { return @{ Name = 'PSScriptAnalyzer'; Version = '1.22.0' } } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
 
             $root = & $script:NewFrameValidateFixture -Ports @('experience')
@@ -1032,6 +1033,10 @@ applies-when: port ==
                 -GuidanceComplexityScriptPath $support.GuidanceComplexityScriptPath `
                 -PSScriptAnalyzerSettingsPath $support.PSScriptAnalyzerSettingsPath `
                 -ScriptsPath $support.ScriptsPath
+
+            # Sound invoke-pairing (d-dead-filter-tripwire-v2): assertion filter is textually
+            # identical to the narrow Mock's -ParameterFilter above.
+            Should -Invoke Get-Module -Times 1 -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
 
             $frameValidator = @($result.Results | Where-Object { $_.Name -eq 'FrameValidator' })
             $frameValidator | Should -HaveCount 1
@@ -1052,6 +1057,7 @@ applies-when: port ==
         }
 
         It 'prints detail for a passing frame validator check when adapter symmetry is skipped' {
+            Mock Get-Module { }
             Mock Get-Module { return @{ Name = 'PSScriptAnalyzer'; Version = '1.22.0' } } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
 
             $root = & $script:NewFrameValidateFixture -WithoutPortCatalog
@@ -1063,6 +1069,10 @@ applies-when: port ==
                 -PSScriptAnalyzerSettingsPath $support.PSScriptAnalyzerSettingsPath `
                 -ScriptsPath $support.ScriptsPath `
                 -InformationVariable infoOutput
+
+            # Sound invoke-pairing (d-dead-filter-tripwire-v2): assertion filter is textually
+            # identical to the narrow Mock's -ParameterFilter above.
+            Should -Invoke Get-Module -Times 1 -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
 
             $frameValidator = @($result.Results | Where-Object { $_.Name -eq 'FrameValidator' })
             $frameValidator | Should -HaveCount 1

--- a/.github/scripts/Tests/migration-scan-enforcement.Tests.ps1
+++ b/.github/scripts/Tests/migration-scan-enforcement.Tests.ps1
@@ -400,7 +400,7 @@ Describe 'Migration-scan enforcement' -Tag 'unit' {
             $script:ConductorBody | Should -Match 'planner-omitted-scan'
         }
 
-        It 'contains no <plan_style_guide> reference' {
+        It 'contains no plan_style_guide token reference' {
             $script:ConductorBody | Should -Not -Match 'plan_style_guide'
         }
 

--- a/.github/scripts/Tests/pester-mock-fallthrough-guard.Tests.ps1
+++ b/.github/scripts/Tests/pester-mock-fallthrough-guard.Tests.ps1
@@ -1,0 +1,699 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Pester mock fall-through guard (issue #818, step s6).
+
+.DESCRIPTION
+    Locks the d-dead-filter-tripwire-v2 contract from the #818 Pester 5->6 migration
+    plan (issue-818 plan comment, frame slice s6):
+
+      Clause 1 (fall-through shape): every filtered `Mock <cmd> -ParameterFilter`
+      registration must have a same-file default (unfiltered) `Mock <cmd>`
+      registration, unless the (File, Command) site is explicitly allowlisted.
+      Pester 6 throws on an unmatched Mock call instead of silently falling through
+      to the real command; a filtered-only Mock with no default is a latent 6.x
+      break if any call misses the filter.
+
+      Clause 2 (sound invoke-pairing): every filtered `Mock <cmd> -ParameterFilter
+      {F}` must pair, in the SAME FILE, with a `Should -Invoke <cmd> -Times N
+      (N>=1) -ParameterFilter {F'}` where F' is textually equivalent (whitespace-
+      normalized) to F, or with a justified allowlist entry. `Should -Invoke`
+      evaluates its OWN filter, so a bare pairing (any Should -Invoke on the same
+      command, any filter) is unsound: a dead Mock filter can coexist with a
+      passing, differently-filtered assertion. Identical-filter + Times>=1 is what
+      makes a dead filter fail loudly (see plan Challenge M3 / d-dead-filter-
+      tripwire-v2).
+
+      Clause 3 (version-window, fail-loud): pester.yml's Install-Module line is
+      the single source of truth for the validated Pester major (its
+      -MinimumVersion floor). Both the Install-Module and Import-Module lines
+      must carry a -MaximumVersion whose major equals that floor's major, and the
+      floor major must be >= 6. If the pin cannot be located or parsed, the guard
+      fails loudly (a named test failure), never silently passes.
+
+    Modeled on script-safety-contract.Tests.ps1's precedent: AST-based scan (not
+    text grep/regex over source), a centralized $allowlist array with per-entry
+    inline justification, explicit self-exclusion, and documented residual-gap
+    comments.
+
+    Design note on the allowlist's scope: the task's per-mock-site allowlist is
+    described as clause 2's escape hatch, but in practice a single reviewed site
+    (cost-walker.Tests.ps1 / Get-NormalizedPath, see BeforeAll below) is a
+    deliberate negative-assertion trap that also has no default Mock. Rather than
+    invent a second, undocumented exemption mechanism for clause 1, this guard
+    treats a justified allowlist entry as exempting its (File, Command) site from
+    BOTH clause 1's missing-default check and clause 2's identical-filter pairing
+    check -- one reviewed, justified escape hatch, not two.
+
+    Design note on global:<cmd> functions (class e2/e3 in the #818 s1 inventory):
+    this guard's clause-1/clause-2 scanners only ever look at `Mock` cmdlet
+    CommandAst nodes. A file that implements a command exclusively via
+    `function global:<cmd> { ... }` (bare, or nested inside a helper such as
+    Install-GhMock) never produces a `Mock <cmd>` registration at all, so it can
+    never enter the "has a filtered Mock in this group" precondition that clause 1
+    checks. No special-casing of `global:` function definitions is implemented --
+    intentionally so, per the s6 RC's explicit warning that "is there a global
+    function with this name" is orthogonal to "does a Mock <cmd> -ParameterFilter
+    site have a default Mock <cmd>". The falsifiability fixture in the "novel
+    helper-wrapped global: variant" context proves this generalizes beyond the
+    one known Install-GhMock example.
+#>
+
+# ---------------------------------------------------------------------------
+# Module-scope helpers (AST-based; no text/regex scanning of Mock call bodies)
+# ---------------------------------------------------------------------------
+
+function script:Get-NormalizedScriptblockText {
+    param([string]$Text)
+    if ([string]::IsNullOrEmpty($Text)) { return $Text }
+    return (($Text -replace '\s+', ' ').Trim())
+}
+
+function script:Resolve-KnownParamName {
+    param(
+        [string]$RawName,
+        [string[]]$KnownNames
+    )
+    foreach ($known in $KnownNames) {
+        if ($known -ieq $RawName) { return $known }
+    }
+    # PowerShell allows unambiguous parameter-name prefixes (e.g. -Param for
+    # -ParameterFilter); resolve those to the canonical name too.
+    foreach ($known in $KnownNames) {
+        if ($known -like "$RawName*") { return $known }
+    }
+    return $RawName
+}
+
+function script:Get-AstLiteralStringValue {
+    param($Node)
+    if ($null -eq $Node) { return $null }
+    if ($Node -is [System.Management.Automation.Language.StringConstantExpressionAst]) { return $Node.Value }
+    if ($Node -is [System.Management.Automation.Language.ExpandableStringExpressionAst]) { return $Node.Value }
+    return $Node.Extent.Text.Trim("'`"")
+}
+
+# Extracts structured info from a single `Mock ...` CommandAst: the mocked
+# command name (positional or -CommandName), whether -ParameterFilter is
+# present, and its normalized filter text. Handles both `Mock <cmd> { } ` and
+# `Mock -CommandName <cmd> -MockWith { }` forms, and (because this walks the
+# already-parsed AST) multi-line/backtick-continued calls transparently.
+function script:Get-MockRegistrationInfo {
+    param([System.Management.Automation.Language.CommandAst]$Cmd)
+
+    $knownParams = @('CommandName', 'MockWith', 'ParameterFilter', 'Verifiable', 'ModuleName', 'RemoveParameterType', 'RemoveParameterValidation')
+    $switchParams = @('Verifiable')
+
+    $elems = $Cmd.CommandElements
+    $positional = [System.Collections.Generic.List[object]]::new()
+    $named = @{}
+
+    $i = 1
+    while ($i -lt $elems.Count) {
+        $el = $elems[$i]
+        if ($el -is [System.Management.Automation.Language.CommandParameterAst]) {
+            $resolved = Resolve-KnownParamName -RawName $el.ParameterName -KnownNames $knownParams
+            if ($el.Argument) {
+                $named[$resolved] = $el.Argument
+                $i++
+                continue
+            }
+            if ($switchParams -contains $resolved) {
+                $i++
+                continue
+            }
+            if (($i + 1) -lt $elems.Count) {
+                $named[$resolved] = $elems[$i + 1]
+                $i += 2
+                continue
+            }
+            $i++
+            continue
+        }
+        else {
+            $positional.Add($el)
+            $i++
+        }
+    }
+
+    $cmdName = $null
+    if ($named.ContainsKey('CommandName')) {
+        $cmdName = Get-AstLiteralStringValue -Node $named['CommandName']
+    }
+    elseif ($positional.Count -ge 1) {
+        $cmdName = Get-AstLiteralStringValue -Node $positional[0]
+    }
+
+    $hasFilter = $named.ContainsKey('ParameterFilter')
+    $filterText = $null
+    if ($hasFilter) {
+        $filterText = Get-NormalizedScriptblockText -Text $named['ParameterFilter'].Extent.Text
+    }
+
+    [PSCustomObject]@{
+        CommandName = $cmdName
+        HasFilter   = $hasFilter
+        FilterText  = $filterText
+        Line        = $Cmd.Extent.StartLineNumber
+    }
+}
+
+# Extracts structured info from a `Should -Invoke ...` CommandAst. Returns
+# $null for any other `Should` assertion (e.g. `Should -Be`, `Should
+# -InvokeVerifiable`) so callers only see genuine -Invoke assertions.
+function script:Get-ShouldInvokeInfo {
+    param([System.Management.Automation.Language.CommandAst]$Cmd)
+
+    $knownParams = @('Invoke', 'Times', 'Exactly', 'ParameterFilter', 'Scope', 'ModuleName', 'CommandName')
+    $switchParams = @('Invoke', 'Exactly')
+
+    $elems = $Cmd.CommandElements
+    $positional = [System.Collections.Generic.List[object]]::new()
+    $named = @{}
+    $isInvoke = $false
+
+    $i = 1
+    while ($i -lt $elems.Count) {
+        $el = $elems[$i]
+        if ($el -is [System.Management.Automation.Language.CommandParameterAst]) {
+            $resolved = Resolve-KnownParamName -RawName $el.ParameterName -KnownNames $knownParams
+            if ($resolved -eq 'Invoke') { $isInvoke = $true }
+            if ($el.Argument) {
+                $named[$resolved] = $el.Argument
+                $i++
+                continue
+            }
+            if ($switchParams -contains $resolved) {
+                $i++
+                continue
+            }
+            if (($i + 1) -lt $elems.Count) {
+                $named[$resolved] = $elems[$i + 1]
+                $i += 2
+                continue
+            }
+            $i++
+            continue
+        }
+        else {
+            $positional.Add($el)
+            $i++
+        }
+    }
+
+    if (-not $isInvoke) { return $null }
+
+    $invokedCmd = $null
+    if ($named.ContainsKey('CommandName')) {
+        $invokedCmd = Get-AstLiteralStringValue -Node $named['CommandName']
+    }
+    elseif ($positional.Count -ge 1) {
+        $invokedCmd = Get-AstLiteralStringValue -Node $positional[0]
+    }
+
+    $hasFilter = $named.ContainsKey('ParameterFilter')
+    $filterText = $null
+    if ($hasFilter) {
+        $filterText = Get-NormalizedScriptblockText -Text $named['ParameterFilter'].Extent.Text
+    }
+
+    $timesValue = $null
+    if ($named.ContainsKey('Times')) {
+        $timesText = $named['Times'].Extent.Text.Trim()
+        $parsed = 0
+        if ([int]::TryParse($timesText, [ref]$parsed)) { $timesValue = $parsed }
+    }
+
+    [PSCustomObject]@{
+        InvokedCommand = $invokedCmd
+        HasFilter      = $hasFilter
+        FilterText     = $filterText
+        Times          = $timesValue
+        Line           = $Cmd.Extent.StartLineNumber
+    }
+}
+
+# Parses one file and returns @{ MockSites = ...; InvokeSites = ... }. Only
+# `Mock` CommandAst nodes feed MockSites, and only `Should -Invoke` CommandAst
+# nodes feed InvokeSites -- this is the AST-level distinction between a Mock
+# registration and a Should -Invoke assertion the guard is required to make.
+function script:Get-MockFallthroughFileScan {
+    param([string]$Path)
+
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+
+    if ($errors -and $errors.Count -gt 0) {
+        return [PSCustomObject]@{
+            ParseError  = ($errors | ForEach-Object { $_.Message }) -join '; '
+            MockSites   = @()
+            InvokeSites = @()
+        }
+    }
+
+    $allCmds = $ast.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.CommandAst]
+        }, $true)
+
+    $mockSites = [System.Collections.Generic.List[object]]::new()
+    $invokeSites = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($cmd in $allCmds) {
+        $cmdName = $cmd.GetCommandName()
+        if ($cmdName -ieq 'Mock') {
+            $mockSites.Add((Get-MockRegistrationInfo -Cmd $cmd))
+        }
+        elseif ($cmdName -ieq 'Should') {
+            $info = Get-ShouldInvokeInfo -Cmd $cmd
+            if ($null -ne $info) { $invokeSites.Add($info) }
+        }
+    }
+
+    [PSCustomObject]@{
+        ParseError  = $null
+        MockSites   = $mockSites
+        InvokeSites = $invokeSites
+    }
+}
+
+# Clause 1: for each mocked command with >=1 filtered registration, a same-file
+# unfiltered (default) registration must also exist, unless allowlisted.
+function script:Get-Clause1Violations {
+    param(
+        [string]$FileName,
+        [PSCustomObject]$Scan,
+        [object[]]$Allowlist
+    )
+
+    $violations = [System.Collections.Generic.List[object]]::new()
+    if ($Scan.ParseError) {
+        $violations.Add("PARSE ERROR in ${FileName}: $($Scan.ParseError)")
+        return $violations
+    }
+
+    $byCommand = $Scan.MockSites | Where-Object { $null -ne $_.CommandName } | Group-Object -Property CommandName
+    foreach ($group in $byCommand) {
+        $hasFiltered = $group.Group | Where-Object { $_.HasFilter }
+        if (-not $hasFiltered) { continue }
+
+        $hasDefault = $group.Group | Where-Object { -not $_.HasFilter }
+        if ($hasDefault) { continue }
+
+        $allowed = $Allowlist | Where-Object { $_.File -eq $FileName -and $_.Command -eq $group.Name }
+        if ($allowed) { continue }
+
+        $lines = ($hasFiltered | ForEach-Object { $_.Line }) -join ', '
+        $violations.Add("${FileName}: '$($group.Name)' has a filtered Mock -ParameterFilter (line(s) $lines) with no same-file default Mock and no allowlist entry")
+    }
+
+    return $violations
+}
+
+# Clause 2: for each distinct (command, normalized filter text) filtered
+# registration, a same-file identical-filter Should -Invoke -Times>=1 must
+# exist, unless allowlisted at (File, Command) granularity.
+function script:Get-Clause2Violations {
+    param(
+        [string]$FileName,
+        [PSCustomObject]$Scan,
+        [object[]]$Allowlist
+    )
+
+    $violations = [System.Collections.Generic.List[object]]::new()
+    if ($Scan.ParseError) {
+        $violations.Add("PARSE ERROR in ${FileName}: $($Scan.ParseError)")
+        return $violations
+    }
+
+    $filteredMocks = $Scan.MockSites | Where-Object { $_.HasFilter -and $null -ne $_.CommandName }
+    $filteredGroups = $filteredMocks | Group-Object -Property CommandName, FilterText
+
+    foreach ($group in $filteredGroups) {
+        $sample = $group.Group[0]
+        $cmdName = $sample.CommandName
+        $filterText = $sample.FilterText
+
+        $soundPairingExists = $Scan.InvokeSites | Where-Object {
+            $_.HasFilter -and
+            $_.InvokedCommand -ieq $cmdName -and
+            $_.FilterText -eq $filterText -and
+            $null -ne $_.Times -and $_.Times -ge 1
+        }
+        if ($soundPairingExists) { continue }
+
+        $allowed = $Allowlist | Where-Object { $_.File -eq $FileName -and $_.Command -eq $cmdName }
+        if ($allowed) { continue }
+
+        $lines = ($group.Group | ForEach-Object { $_.Line }) -join ', '
+        $violations.Add("${FileName}: '$cmdName' filtered Mock (line(s) $lines, filter: $filterText) has no same-file identical-filter Should -Invoke -Times>=1 pairing and no allowlist entry")
+    }
+
+    return $violations
+}
+
+# Clause 3: derive the validated major from pester.yml's Install-Module
+# -MinimumVersion floor, then assert both the Install-Module and Import-Module
+# lines carry a matching-major -MaximumVersion cap, floor >= 6. Fails loudly
+# (throws with a specific message) if the pin cannot be located/parsed instead
+# of silently returning a pass-shaped result.
+function script:Get-PesterVersionWindow {
+    param([string]$PesterYmlPath)
+
+    if (-not (Test-Path $PesterYmlPath)) {
+        throw "clause 3: pester.yml not found at '$PesterYmlPath'"
+    }
+    $lines = Get-Content -Path $PesterYmlPath
+
+    $installLine = $lines | Where-Object { $_ -match '(?i)Install-Module\s+.*-Name\s+Pester\b' } | Select-Object -First 1
+    if (-not $installLine) {
+        throw "clause 3: could not locate an 'Install-Module ... -Name Pester' line in pester.yml"
+    }
+    $importLine = $lines | Where-Object { $_ -match '(?i)Import-Module\s+Pester\b' } | Select-Object -First 1
+    if (-not $importLine) {
+        throw "clause 3: could not locate an 'Import-Module Pester' line in pester.yml"
+    }
+
+    $installFloorMatch = [regex]::Match($installLine, '(?i)-MinimumVersion\s+(?<v>\d+\.\d+\.\d+)')
+    $installCapMatch = [regex]::Match($installLine, '(?i)-MaximumVersion\s+(?<v>\d+\.\d+\.\d+)')
+    $importFloorMatch = [regex]::Match($importLine, '(?i)-MinimumVersion\s+(?<v>\d+\.\d+\.\d+)')
+    $importCapMatch = [regex]::Match($importLine, '(?i)-MaximumVersion\s+(?<v>\d+\.\d+\.\d+)')
+
+    if (-not $installFloorMatch.Success) {
+        throw "clause 3: Install-Module line has no parseable -MinimumVersion floor: '$installLine'"
+    }
+    if (-not $installCapMatch.Success) {
+        throw "clause 3: Install-Module line has no parseable -MaximumVersion cap: '$installLine'"
+    }
+    if (-not $importFloorMatch.Success) {
+        throw "clause 3: Import-Module line has no parseable -MinimumVersion floor: '$importLine'"
+    }
+    if (-not $importCapMatch.Success) {
+        throw "clause 3: Import-Module line has no parseable -MaximumVersion cap: '$importLine'"
+    }
+
+    [PSCustomObject]@{
+        InstallFloor = [version]$installFloorMatch.Groups['v'].Value
+        InstallCap   = [version]$installCapMatch.Groups['v'].Value
+        ImportFloor  = [version]$importFloorMatch.Groups['v'].Value
+        ImportCap    = [version]$importCapMatch.Groups['v'].Value
+    }
+}
+
+Describe 'Pester mock fall-through guard (issue #818 s6)' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:TestsRoot = Join-Path $script:RepoRoot '.github/scripts/Tests'
+        $script:PesterYmlPath = Join-Path $script:RepoRoot '.github/workflows/pester.yml'
+
+        # self-excluded: this file's own falsifiability fixtures below write
+        # temp-file corpora containing example Mock/-ParameterFilter/global:
+        # text; scanning this file itself would trip clause 1/clause 2 against
+        # its own docstrings and helper-function source (same rationale as
+        # script-safety-contract.Tests.ps1's self-exclusion).
+        $script:SelfFileName = 'pester-mock-fallthrough-guard.Tests.ps1'
+
+        # Centralized allowlist -- per-mock-site (File + Command) granularity,
+        # matching script-safety-contract's shape. Exempts the (File, Command)
+        # pair from BOTH clause 1 (missing default) and clause 2 (identical-
+        # filter -Times>=1 pairing); see the file header design note above for
+        # why one allowlist covers both clauses instead of two mechanisms.
+        $script:Allowlist = @(
+            [PSCustomObject]@{
+                File          = 'cost-walker.Tests.ps1'
+                Command       = 'Get-NormalizedPath'
+                Justification = 'Deliberate negative-assertion trap, not a functional stub: cost-walker.ps1:83 (Test-CostWalkerEventCwdMatchesParent) short-circuits on the Copilot OTel sentinel-cwd prefix before ever calling Get-NormalizedPath, so this filtered Mock (cost-walker.Tests.ps1:425) intentionally has no default and its paired assertion (line 432) is "Should -Invoke -Exactly -Times 0" -- proving the call NEVER happens, the opposite of the automatic Times>=1 sound-pairing mechanism. See .tmp/issue-818/migration-scan-inventory.md class (a), cost-walker.Tests.ps1 Get-NormalizedPath row.'
+            }
+        )
+
+        foreach ($entry in $script:Allowlist) {
+            if ([string]::IsNullOrWhiteSpace($entry.Justification)) {
+                throw "Allowlist entry for '$($entry.File)' / '$($entry.Command)' has no justification -- every allowlist entry must carry a non-empty reason."
+            }
+        }
+
+        $script:AllTestFiles = Get-ChildItem -Path $script:TestsRoot -Filter '*.Tests.ps1' -File |
+            Where-Object { $_.Name -ne $script:SelfFileName }
+    }
+
+    Context 'Clause 1: fall-through shape (missing default Mock)' {
+        It 'no filtered Mock command lacks a same-file default Mock for that same command, across the full Tests suite' {
+            $allViolations = [System.Collections.Generic.List[object]]::new()
+            foreach ($file in $script:AllTestFiles) {
+                $scan = Get-MockFallthroughFileScan -Path $file.FullName
+                $fileViolations = Get-Clause1Violations -FileName $file.Name -Scan $scan -Allowlist $script:Allowlist
+                foreach ($v in $fileViolations) { $allViolations.Add($v) }
+            }
+
+            $allViolations | Should -BeNullOrEmpty -Because (
+                "every filtered Mock <cmd> -ParameterFilter must have a same-file default (unfiltered) Mock <cmd>, or a justified allowlist entry, because Pester 6 throws on an unmatched Mock call instead of falling through:`n" +
+                ($allViolations -join "`n")
+            )
+        }
+    }
+
+    Context 'Clause 2: sound invoke-pairing' {
+        It 'every filtered Mock command -ParameterFilter pairs with an identical-filter Should -Invoke -Times>=1, or a justified allowlist entry, across the full Tests suite' {
+            $allViolations = [System.Collections.Generic.List[object]]::new()
+            foreach ($file in $script:AllTestFiles) {
+                $scan = Get-MockFallthroughFileScan -Path $file.FullName
+                $fileViolations = Get-Clause2Violations -FileName $file.Name -Scan $scan -Allowlist $script:Allowlist
+                foreach ($v in $fileViolations) { $allViolations.Add($v) }
+            }
+
+            $allViolations | Should -BeNullOrEmpty -Because (
+                "every filtered Mock <cmd> -ParameterFilter {F} must pair, in the same file, with an identical-filter Should -Invoke <cmd> -Times N (N>=1) -ParameterFilter {F'}, or a justified allowlist entry, per d-dead-filter-tripwire-v2 (a bare/mismatched pairing lets a dead filter pass silently):`n" +
+                ($allViolations -join "`n")
+            )
+        }
+
+        It 'every allowlist entry carries a non-empty justification (self-check)' {
+            foreach ($entry in $script:Allowlist) {
+                $entry.Justification | Should -Not -BeNullOrEmpty -Because "allowlist entry '$($entry.File)' / '$($entry.Command)' must document why it is exempt"
+            }
+        }
+    }
+
+    Context 'Clause 3: version-window, fail-loud' {
+        It 'derives a parseable floor/cap version window from pester.yml' {
+            { Get-PesterVersionWindow -PesterYmlPath $script:PesterYmlPath } | Should -Not -Throw -Because 'the guard must fail loudly, not silently, if the pin cannot be located/parsed -- but the real pester.yml must always parse cleanly'
+        }
+
+        It 'both Install-Module and Import-Module lines carry a -MaximumVersion whose major equals the -MinimumVersion floor major, and the floor major is >= 6' {
+            $window = Get-PesterVersionWindow -PesterYmlPath $script:PesterYmlPath
+
+            $window.InstallFloor.Major | Should -Be $window.InstallCap.Major -Because 'the Install-Module line''s floor and cap must share a major version window'
+            $window.ImportFloor.Major | Should -Be $window.ImportCap.Major -Because 'the Import-Module line''s floor and cap must share a major version window'
+            $window.InstallFloor.Major | Should -Be $window.ImportFloor.Major -Because 'Install-Module and Import-Module must validate the same major'
+            $window.InstallFloor.Major | Should -BeGreaterOrEqual 6 -Because 'issue #818 established Pester 6.0.0 as the validated floor'
+        }
+    }
+
+    Context 'Falsifiability: clause 1 fires on a genuine fall-through violation and stays silent on compliant input' {
+        BeforeAll {
+            $script:FixtureDir = Join-Path ([System.IO.Path]::GetTempPath()) "pmfg-clause1-$([System.Guid]::NewGuid().ToString('N'))"
+            $null = New-Item -ItemType Directory -Path $script:FixtureDir -Force
+        }
+        AfterAll {
+            if (Test-Path $script:FixtureDir) { Remove-Item -Recurse -Force $script:FixtureDir }
+        }
+
+        It 'flags a filtered Mock with no same-file default' {
+            $path = Join-Path $script:FixtureDir 'violation.Tests.ps1'
+            Set-Content -Path $path -Value @'
+Describe 'x' {
+    It 'y' {
+        Mock Get-Something { 1 } -ParameterFilter { $Id -eq 1 }
+        Should -Invoke Get-Something -Times 1 -ParameterFilter { $Id -eq 1 }
+    }
+}
+'@
+            $scan = Get-MockFallthroughFileScan -Path $path
+            $violations = Get-Clause1Violations -FileName 'violation.Tests.ps1' -Scan $scan -Allowlist @()
+            $violations | Should -Not -BeNullOrEmpty -Because 'a filtered Mock with no default and no allowlist entry must be flagged'
+        }
+
+        It 'stays silent on a compliant file (default + filtered pair)' {
+            $path = Join-Path $script:FixtureDir 'compliant.Tests.ps1'
+            Set-Content -Path $path -Value @'
+Describe 'x' {
+    It 'y' {
+        Mock Get-Something { 0 }
+        Mock Get-Something { 1 } -ParameterFilter { $Id -eq 1 }
+        Should -Invoke Get-Something -Times 1 -ParameterFilter { $Id -eq 1 }
+    }
+}
+'@
+            $scan = Get-MockFallthroughFileScan -Path $path
+            $violations = Get-Clause1Violations -FileName 'compliant.Tests.ps1' -Scan $scan -Allowlist @()
+            $violations | Should -BeNullOrEmpty -Because 'a filtered Mock with a same-file default must not be flagged'
+        }
+    }
+
+    Context 'Falsifiability: clause 2 fires on unsound pairing and stays silent when properly paired' {
+        BeforeAll {
+            $script:FixtureDir = Join-Path ([System.IO.Path]::GetTempPath()) "pmfg-clause2-$([System.Guid]::NewGuid().ToString('N'))"
+            $null = New-Item -ItemType Directory -Path $script:FixtureDir -Force
+        }
+        AfterAll {
+            if (Test-Path $script:FixtureDir) { Remove-Item -Recurse -Force $script:FixtureDir }
+        }
+
+        It 'flags a filtered Mock with no paired identical-filter Should -Invoke and no allowlist entry' {
+            $path = Join-Path $script:FixtureDir 'unsound.Tests.ps1'
+            Set-Content -Path $path -Value @'
+Describe 'x' {
+    It 'y' {
+        Mock Get-Something { 0 }
+        Mock Get-Something { 1 } -ParameterFilter { $Id -eq 1 }
+        # unsound: the pairing assertion below uses a DIFFERENT filter than the
+        # Mock's -ParameterFilter, so a dead $Id -eq 1 filter would pass silently.
+        Should -Invoke Get-Something -Times 1 -ParameterFilter { $Id -eq 2 }
+    }
+}
+'@
+            $scan = Get-MockFallthroughFileScan -Path $path
+            $violations = Get-Clause2Violations -FileName 'unsound.Tests.ps1' -Scan $scan -Allowlist @()
+            $violations | Should -Not -BeNullOrEmpty -Because 'a filtered Mock without an identical-filter Times>=1 pairing must be flagged even when an unrelated-filter assertion exists'
+        }
+
+        It 'stays silent when properly paired (identical filter, Times>=1)' {
+            $path = Join-Path $script:FixtureDir 'sound.Tests.ps1'
+            Set-Content -Path $path -Value @'
+Describe 'x' {
+    It 'y' {
+        Mock Get-Something { 0 }
+        Mock Get-Something { 1 } -ParameterFilter { $Id -eq 1 }
+        Should -Invoke Get-Something -Times 1 -ParameterFilter { $Id -eq 1 }
+    }
+}
+'@
+            $scan = Get-MockFallthroughFileScan -Path $path
+            $violations = Get-Clause2Violations -FileName 'sound.Tests.ps1' -Scan $scan -Allowlist @()
+            $violations | Should -BeNullOrEmpty -Because 'an identical-filter, Times>=1 pairing is sound and must not be flagged'
+        }
+    }
+
+    Context 'Falsifiability: clause 2 allowlist escape hatch' {
+        BeforeAll {
+            $script:FixtureDir = Join-Path ([System.IO.Path]::GetTempPath()) "pmfg-clause2-allowlist-$([System.Guid]::NewGuid().ToString('N'))"
+            $null = New-Item -ItemType Directory -Path $script:FixtureDir -Force
+        }
+        AfterAll {
+            if (Test-Path $script:FixtureDir) { Remove-Item -Recurse -Force $script:FixtureDir }
+        }
+
+        It 'a justified allowlist entry exempts an otherwise-unsound pairing' {
+            $path = Join-Path $script:FixtureDir 'allowlisted.Tests.ps1'
+            Set-Content -Path $path -Value @'
+Describe 'x' {
+    It 'y' {
+        Mock Get-Something { 1 } -ParameterFilter { $Id -eq 1 }
+    }
+}
+'@
+            $scan = Get-MockFallthroughFileScan -Path $path
+            $noAllowlist = Get-Clause2Violations -FileName 'allowlisted.Tests.ps1' -Scan $scan -Allowlist @()
+            $noAllowlist | Should -Not -BeNullOrEmpty -Because 'without an allowlist entry, an unpaired filtered Mock must be flagged'
+
+            $withAllowlist = @([PSCustomObject]@{ File = 'allowlisted.Tests.ps1'; Command = 'Get-Something'; Justification = 'fixture proof' })
+            $violations = Get-Clause2Violations -FileName 'allowlisted.Tests.ps1' -Scan $scan -Allowlist $withAllowlist
+            $violations | Should -BeNullOrEmpty -Because 'a justified allowlist entry at (File, Command) granularity must exempt the site'
+        }
+    }
+
+    Context 'Falsifiability: clause 3 fires on version-window violations and fails loudly on an unparseable pin' {
+        BeforeAll {
+            $script:FixtureDir = Join-Path ([System.IO.Path]::GetTempPath()) "pmfg-clause3-$([System.Guid]::NewGuid().ToString('N'))"
+            $null = New-Item -ItemType Directory -Path $script:FixtureDir -Force
+        }
+        AfterAll {
+            if (Test-Path $script:FixtureDir) { Remove-Item -Recurse -Force $script:FixtureDir }
+        }
+
+        It 'flags a floor/cap major mismatch (runaway ceiling)' {
+            $path = Join-Path $script:FixtureDir 'mismatch-pester.yml'
+            Set-Content -Path $path -Value @'
+name: fixture
+jobs:
+  pester:
+    steps:
+      - run: |
+          Install-Module -Name Pester -Force -SkipPublisherCheck -MinimumVersion 6.0.0 -MaximumVersion 7.999.999
+          Import-Module Pester -MinimumVersion 6.0.0 -MaximumVersion 7.999.999
+'@
+            $window = Get-PesterVersionWindow -PesterYmlPath $path
+            $window.InstallFloor.Major | Should -Not -Be $window.InstallCap.Major -Because 'this fixture deliberately has a runaway-ceiling mismatch (floor major 6, cap major 7)'
+        }
+
+        It 'flags a missing/absent -MaximumVersion cap' {
+            $path = Join-Path $script:FixtureDir 'missing-cap-pester.yml'
+            Set-Content -Path $path -Value @'
+name: fixture
+jobs:
+  pester:
+    steps:
+      - run: |
+          Install-Module -Name Pester -Force -SkipPublisherCheck -MinimumVersion 6.0.0
+          Import-Module Pester -MinimumVersion 6.0.0
+'@
+            { Get-PesterVersionWindow -PesterYmlPath $path } | Should -Throw -Because 'a missing -MaximumVersion cap is the exact runaway-ceiling scenario the guard must fail loudly on, not silently pass'
+        }
+
+        It 'fails loudly (not silently) when the pin line cannot be found at all' {
+            $path = Join-Path $script:FixtureDir 'no-pin-pester.yml'
+            Set-Content -Path $path -Value @'
+name: fixture
+jobs:
+  pester:
+    steps:
+      - run: echo "no Pester install here"
+'@
+            { Get-PesterVersionWindow -PesterYmlPath $path } | Should -Throw -Because 'the guard must never silently pass when it cannot locate the version pin at all'
+        }
+    }
+
+    Context 'Falsifiability: clause 1 generalizes to a novel helper-wrapped global: variant' {
+        BeforeAll {
+            $script:FixtureDir = Join-Path ([System.IO.Path]::GetTempPath()) "pmfg-global-novel-$([System.Guid]::NewGuid().ToString('N'))"
+            $null = New-Item -ItemType Directory -Path $script:FixtureDir -Force
+        }
+        AfterAll {
+            if (Test-Path $script:FixtureDir) { Remove-Item -Recurse -Force $script:FixtureDir }
+        }
+
+        It 'does not flag a novel helper-wrapped global-scope command pattern not copied from Install-GhMock' {
+            # A different helper name/shape than cost-rolling-history.Tests.ps1's
+            # Install-GhMock, proving clause 1 generalizes rather than special-
+            # casing the one known example. This helper wraps global:curl instead
+            # of global:gh, and is invoked from a BeforeEach rather than an It.
+            $path = Join-Path $script:FixtureDir 'novel-global.Tests.ps1'
+            Set-Content -Path $path -Value @'
+Describe 'x' {
+    function global:Install-CurlDouble {
+        param([string]$Body = 'ok')
+        function global:curl {
+            param([Parameter(ValueFromRemainingArguments = $true)]$RemainingArgs)
+            return $Body
+        }
+    }
+
+    BeforeEach {
+        Install-CurlDouble -Body 'stub-response'
+    }
+
+    It 'y' {
+        $result = curl 'https://example.invalid'
+        $result | Should -Be 'stub-response'
+    }
+}
+'@
+            $scan = Get-MockFallthroughFileScan -Path $path
+            $violations = Get-Clause1Violations -FileName 'novel-global.Tests.ps1' -Scan $scan -Allowlist @()
+            $violations | Should -BeNullOrEmpty -Because 'a command implemented exclusively via a helper-wrapped global:<cmd> function (no Mock cmdlet calls at all) never enters clause 1''s filtered-Mock-without-default precondition, regardless of the helper''s name or shape'
+        }
+    }
+}

--- a/.github/scripts/Tests/pester6-baseline-core.Tests.ps1
+++ b/.github/scripts/Tests/pester6-baseline-core.Tests.ps1
@@ -217,3 +217,44 @@ Describe 'pester6-baseline-core — discovery-time throw handling' {
         $script:CaptureResult2.Result.summary.discoveryErrors | Should -Be 1
     }
 }
+
+Describe 'pester6-baseline-core — malformed result-file handling (PR #828 G4 regression coverage)' {
+
+    BeforeAll {
+        if ($script:InstalledVersions.Count -eq 0) {
+            throw 'No Pester version is installed; cannot exercise the capture tool.'
+        }
+        $script:ProbeVersion3 = $script:InstalledVersions[0]
+    }
+
+    It 'T8: returns a graceful ExitCode=1 (not an uncaught throw) when the child process writes a malformed-JSON result file' {
+        # The child pwsh process is never actually spawned here: Start-Process is
+        # mocked so the test stays fast/deterministic while still exercising the
+        # real Invoke-Pester6BaselineCapture parse/catch path. The mock derives
+        # the result-file path the same way the function does (sibling of the
+        # launcher file inside the function's own temp dir) and writes malformed
+        # JSON there instead of running Pester.
+        #
+        # d-dead-filter-tripwire-v2 (pester-mock-fallthrough-guard.Tests.ps1):
+        # a same-file default (unfiltered) Mock is required alongside the
+        # filtered one, and the filtered Mock's -ParameterFilter must pair with
+        # an identical-filter `Should -Invoke -Times>=1` below. Invoke-
+        # Pester6BaselineCapture only ever calls Start-Process with 'pwsh', so
+        # the default here is an intentionally-unreachable guard.
+        Mock Start-Process { throw 'unexpected unfiltered Start-Process call in the malformed-result-file test' }
+        Mock Start-Process {
+            $fileIndex = [Array]::IndexOf($ArgumentList, '-File')
+            $launchFilePath = $ArgumentList[$fileIndex + 1].Trim('"')
+            $resultFilePath = Join-Path (Split-Path -Parent $launchFilePath) 'result.json'
+            Set-Content -LiteralPath $resultFilePath -Value '{ this is not valid json ][' -Encoding UTF8
+            return [pscustomobject]@{ ExitCode = 0 }
+        } -ParameterFilter { $FilePath -eq 'pwsh' }
+
+        { $script:MalformedCaptureResult = Invoke-Pester6BaselineCapture -TestsPath $script:RepoRoot -RequiredVersion $script:ProbeVersion3 } |
+            Should -Not -Throw -Because 'a malformed result file must be caught, not propagate as an uncaught exception (G4)'
+
+        $script:MalformedCaptureResult.ExitCode | Should -Be 1 -Because 'ConvertFrom-Json failing on malformed JSON must surface as a graceful ExitCode=1, exercising the catch block around pester6-baseline-core.ps1:309'
+        $script:MalformedCaptureResult.Result | Should -BeNullOrEmpty
+        Should -Invoke Start-Process -Times 1 -ParameterFilter { $FilePath -eq 'pwsh' }
+    }
+}

--- a/.github/scripts/Tests/pester6-baseline-core.Tests.ps1
+++ b/.github/scripts/Tests/pester6-baseline-core.Tests.ps1
@@ -1,0 +1,219 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Pester tests for the version-pinned, per-test-identity Pester baseline
+    capture tool (issue #818 / s2).
+
+.DESCRIPTION
+    Contract under test:
+      T1 - RequiredVersion is a mandatory parameter (no "newest installed" default)
+      T2 - the captured baseline records the Pester version actually imported,
+           and it matches whatever -RequiredVersion was requested, proving the
+           child process honors the pin rather than resolving ambiently
+      T3 - records carry full Describe > Context > It identity (not just counts)
+      T4 - a failed test's record carries a non-empty failure reason
+      T5 - a passed test's record carries an empty reason
+      T6 - a discovery-time throw in one file does not prevent a sibling file's
+           tests from running (the run is not crashed/collapsed)
+      T7 - the discovery-time throw is recorded as a distinct discovery-error
+           record carrying the throw's message, not silently dropped
+
+    NOTE: This file exercises the real child-pwsh subprocess path against a
+    small scratch fixture directory (not the full 186-file suite) — each
+    Invoke-Pester6BaselineCapture call spawns a fresh pwsh process, so this
+    file is slower than a pure-unit test file but still runs in low-single-
+    digit seconds per call. It is intentionally NOT registered in pester.yml's
+    CI run list (per the plan's non-goal: s2 does not touch pester.yml); CI
+    installs only a single pinned Pester major via pester.yml, and T2's
+    honoring proof needs at least two distinct installed majors to be
+    meaningful.
+#>
+
+BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:CoreFile = Join-Path $script:RepoRoot '.github/scripts/lib/pester6-baseline-core.ps1'
+
+    . $script:CoreFile
+
+    # Discover installed Pester versions to drive the RequiredVersion-honoring
+    # tests without hardcoding version numbers that may drift after this
+    # migration completes.
+    $script:InstalledVersions = @(
+        Get-Module -Name Pester -ListAvailable |
+            Select-Object -ExpandProperty Version |
+            Sort-Object -Descending -Unique |
+            ForEach-Object { $_.ToString() }
+    )
+
+    function script:New-BaselineFixture {
+        $dir = Join-Path ([System.IO.Path]::GetTempPath()) "pester6-baseline-fixture-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+
+        $mixedContent = @'
+Describe 'Fixture Suite' {
+    Context 'inner context' {
+        It 'passing behavior' { 1 | Should -Be 1 }
+        It 'failing behavior' { 1 | Should -Be 2 }
+    }
+}
+'@
+        Set-Content -Path (Join-Path $dir 'mixed.Tests.ps1') -Value $mixedContent -Encoding UTF8
+
+        $throwingContent = @'
+throw 'deliberate discovery-time throw for pester6-baseline-core.Tests.ps1'
+Describe 'Never reached' {
+    It 'never runs' { 1 | Should -Be 1 }
+}
+'@
+        Set-Content -Path (Join-Path $dir 'throwing.Tests.ps1') -Value $throwingContent -Encoding UTF8
+
+        return $dir
+    }
+}
+
+Describe 'pester6-baseline-core — RequiredVersion is mandatory and honored' {
+
+    It 'T1: RequiredVersion is a mandatory parameter on Invoke-Pester6BaselineCapture' {
+        $cmd = Get-Command Invoke-Pester6BaselineCapture
+        $param = $cmd.Parameters['RequiredVersion']
+        $param | Should -Not -BeNullOrEmpty
+        $isMandatory = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
+            ForEach-Object { $_.Mandatory } | Where-Object { $_ }
+        $isMandatory | Should -Not -BeNullOrEmpty -Because 'the tool exists specifically because run-pester-sharded.ps1 auto-resolves "newest installed" with no version selector; a default here would reintroduce that gap'
+    }
+
+    It 'T1b: RequiredVersion is a mandatory parameter on capture-pester6-baseline.ps1' {
+        $wrapperPath = Join-Path $script:RepoRoot '.github/scripts/capture-pester6-baseline.ps1'
+        Test-Path -LiteralPath $wrapperPath | Should -Be $true
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($wrapperPath, [ref]$null, [ref]$null)
+        $paramBlock = $ast.ParamBlock
+        $requiredVersionParam = $paramBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'RequiredVersion' }
+        $requiredVersionParam | Should -Not -BeNullOrEmpty
+        $hasMandatory = $requiredVersionParam.Attributes | Where-Object {
+            $_ -is [System.Management.Automation.Language.AttributeAst] -and $_.TypeName.Name -eq 'Parameter'
+        } | ForEach-Object {
+            $_.NamedArguments | Where-Object { $_.ArgumentName -eq 'Mandatory' }
+        }
+        $hasMandatory | Should -Not -BeNullOrEmpty -Because 'the CLI wrapper must not silently default to "newest installed" either'
+    }
+
+    It 'T1c: an unrecognized RequiredVersion fails loudly instead of silently falling through' {
+        $fixtureDir = script:New-BaselineFixture
+        try {
+            $result = Invoke-Pester6BaselineCapture -TestsPath $fixtureDir -RequiredVersion '999.999.999'
+            $result.ExitCode | Should -Be 1 -Because 'a non-installed version must fail the capture, not silently substitute a different one'
+        }
+        finally {
+            Remove-Item -LiteralPath $fixtureDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'T2: the captured baseline records the Pester version actually imported, matching the requested -RequiredVersion' {
+        if ($script:InstalledVersions.Count -lt 2) {
+            Set-ItResult -Skipped -Because 'this proof needs at least two distinct installed Pester majors; only one is present in this environment'
+            return
+        }
+
+        $fixtureDir = script:New-BaselineFixture
+        try {
+            foreach ($v in $script:InstalledVersions[0..1]) {
+                $result = Invoke-Pester6BaselineCapture -TestsPath $fixtureDir -RequiredVersion $v
+                $result.ExitCode | Should -Be 0 -Because "capture under Pester $v should succeed"
+                $result.Result.requiredVersion | Should -Be $v
+                $result.Result.importedVersion | Should -Be $v -Because 'the child process must import the exact requested version, not whatever resolves ambiently'
+            }
+        }
+        finally {
+            Remove-Item -LiteralPath $fixtureDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'pester6-baseline-core — test-identity + failure-reason capture' {
+
+    BeforeAll {
+        if ($script:InstalledVersions.Count -eq 0) {
+            throw 'No Pester version is installed; cannot exercise the capture tool.'
+        }
+        $script:ProbeVersion = $script:InstalledVersions[0]
+        $script:FixtureDir = script:New-BaselineFixture
+        $script:CaptureResult = Invoke-Pester6BaselineCapture -TestsPath $script:FixtureDir -RequiredVersion $script:ProbeVersion
+    }
+
+    AfterAll {
+        if (Test-Path -LiteralPath $script:FixtureDir) {
+            Remove-Item -LiteralPath $script:FixtureDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'T3a: capture succeeds against the fixture directory' {
+        $script:CaptureResult.ExitCode | Should -Be 0
+    }
+
+    It 'T3b: emits per-test identity records carrying the full Describe > Context > It path, not just aggregate counts' {
+        $testRecords = @($script:CaptureResult.Result.records | Where-Object { $_.kind -eq 'test' })
+        $testRecords.Count | Should -Be 2 -Because 'the fixture defines exactly two It blocks'
+
+        $passingRecord = $testRecords | Where-Object { $_.identity -match 'passing behavior' }
+        $passingRecord | Should -Not -BeNullOrEmpty
+        $passingRecord.identity | Should -Match 'Fixture Suite' -Because 'identity must carry the Describe name'
+        $passingRecord.identity | Should -Match 'inner context' -Because 'identity must carry the Context name'
+        $passingRecord.file | Should -Match 'mixed\.Tests\.ps1'
+    }
+
+    It 'T4: a failed test record carries a non-empty failure reason' {
+        $testRecords = @($script:CaptureResult.Result.records | Where-Object { $_.kind -eq 'test' })
+        $failingRecord = $testRecords | Where-Object { $_.identity -match 'failing behavior' }
+        $failingRecord | Should -Not -BeNullOrEmpty
+        $failingRecord.status | Should -Be 'Failed'
+        $failingRecord.reason | Should -Not -BeNullOrEmpty -Because 'a delta gate that only sees counts cannot tell a genuine regression from a pre-existing failure'
+        $failingRecord.reason | Should -Match 'Expected'
+    }
+
+    It 'T5: a passed test record carries an empty reason' {
+        $testRecords = @($script:CaptureResult.Result.records | Where-Object { $_.kind -eq 'test' })
+        $passingRecord = $testRecords | Where-Object { $_.identity -match 'passing behavior' }
+        $passingRecord.status | Should -Be 'Passed'
+        $passingRecord.reason | Should -BeNullOrEmpty
+    }
+
+    It 'T3c: the summary counts match the record-level detail' {
+        $summary = $script:CaptureResult.Result.summary
+        $summary.passed | Should -Be 1
+        $summary.failed | Should -Be 1
+    }
+}
+
+Describe 'pester6-baseline-core — discovery-time throw handling' {
+
+    BeforeAll {
+        if ($script:InstalledVersions.Count -eq 0) {
+            throw 'No Pester version is installed; cannot exercise the capture tool.'
+        }
+        $script:ProbeVersion2 = $script:InstalledVersions[0]
+        $script:FixtureDir2 = script:New-BaselineFixture
+        $script:CaptureResult2 = Invoke-Pester6BaselineCapture -TestsPath $script:FixtureDir2 -RequiredVersion $script:ProbeVersion2
+    }
+
+    AfterAll {
+        if (Test-Path -LiteralPath $script:FixtureDir2) {
+            Remove-Item -LiteralPath $script:FixtureDir2 -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'T6: a discovery-time throw in one file does not prevent a sibling file''s tests from running' {
+        $script:CaptureResult2.ExitCode | Should -Be 0 -Because 'the capture itself must not crash when one file throws at discovery time'
+        $testRecords = @($script:CaptureResult2.Result.records | Where-Object { $_.kind -eq 'test' })
+        $testRecords.Count | Should -Be 2 -Because 'mixed.Tests.ps1''s two tests must still be captured even though throwing.Tests.ps1 failed discovery'
+    }
+
+    It 'T7: the discovery-time throw is recorded as a distinct discovery-error record carrying the throw message' {
+        $discoveryRecords = @($script:CaptureResult2.Result.records | Where-Object { $_.kind -eq 'discovery-error' })
+        $discoveryRecords.Count | Should -Be 1 -Because 'exactly one fixture file throws at discovery time'
+        $discoveryRecords[0].file | Should -Match 'throwing\.Tests\.ps1'
+        $discoveryRecords[0].status | Should -Be 'DiscoveryError'
+        $discoveryRecords[0].reason | Should -Match 'deliberate discovery-time throw' -Because 'the record must carry the actual throw message, not collapse it silently'
+        $script:CaptureResult2.Result.summary.discoveryErrors | Should -Be 1
+    }
+}

--- a/.github/scripts/Tests/pester6-baseline-delta-core.Tests.ps1
+++ b/.github/scripts/Tests/pester6-baseline-delta-core.Tests.ps1
@@ -296,4 +296,15 @@ Describe 'pester6-baseline-delta-core — Invoke-Pester6BaselineDelta (JSON arti
         $result.ExitCode | Should -Be 1
         $result.Result | Should -BeNullOrEmpty
     }
+
+    It 'T8c: a BaselinePath file that EXISTS but contains malformed JSON fails gracefully via the try/catch, not the missing-file guard (PR #828 G1 regression coverage, distinct from T8b)' {
+        $malformedPath = Join-Path $script:FixtureDir 'malformed-baseline.json'
+        Set-Content -LiteralPath $malformedPath -Value '{ "requiredVersion": "5.7.1", "records": [ this is not valid json' -Encoding UTF8
+
+        { $script:MalformedDeltaResult = Invoke-Pester6BaselineDelta -BaselinePath $malformedPath -CandidatePath $script:CandidateJsonPath } |
+            Should -Not -Throw -Because 'Get-Content -ErrorAction Stop feeding ConvertFrom-Json on malformed JSON must be caught by the try/catch, not propagate uncaught (G1)'
+
+        $script:MalformedDeltaResult.ExitCode | Should -Be 1 -Because 'the file exists (passes both Test-Path guards) so this exercises the -ErrorAction Stop + catch path, not the earlier missing-file short-circuit T8b covers'
+        $script:MalformedDeltaResult.Result | Should -BeNullOrEmpty
+    }
 }

--- a/.github/scripts/Tests/pester6-baseline-delta-core.Tests.ps1
+++ b/.github/scripts/Tests/pester6-baseline-delta-core.Tests.ps1
@@ -1,0 +1,299 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Pester tests for the post-port acceptance delta gate (issue #818 / s7).
+
+.DESCRIPTION
+    Contract under test, exercised against small synthetic fixture record
+    arrays (not the real ~3400-test baseline artifacts):
+      T1 - a genuinely new failure (Failed in candidate, Passed in baseline)
+           is caught in newFailures and fails the gate
+      T2 - a reason-change on an already-red test (Failed in both, different
+           reason) is caught in reasonChanged and fails the gate (the
+           #566-laundering guard from stress-test finding M9)
+      T3 - a resolved failure (Failed in baseline, Passed in candidate) is
+           reported in `resolved` but does NOT fail the gate
+      T4 - a clean identical-failure-set (same identities, same statuses,
+           same reasons) passes
+      T5 - a discovery-error is treated as a failing status for both
+           newFailures and reasonChanged purposes
+      T6 - identity drift (renamed test) is reported via identityDrift and
+           annotated against the known-rename-file allowlist, without by
+           itself flipping the verdict
+      T7 - reason normalization ignores volatile substrings (timestamps,
+           GUIDs) so a reason that is substantively identical does not
+           false-positive as reasonChanged
+      T8 - the JSON-artifact I/O wrapper (Invoke-Pester6BaselineDelta) reads
+           two real files on disk and drives the same verdict logic
+#>
+
+BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:CoreFile = Join-Path $script:RepoRoot '.github/scripts/lib/pester6-baseline-delta-core.ps1'
+
+    . $script:CoreFile
+
+    function script:New-Rec {
+        param(
+            [string]$Identity,
+            [string]$File = 'fixture.Tests.ps1',
+            [string]$Status = 'Passed',
+            [string]$Reason = '',
+            [string]$Kind = 'test'
+        )
+        return [pscustomobject]@{
+            kind     = $Kind
+            identity = $Identity
+            file     = $File
+            status   = $Status
+            reason   = $Reason
+        }
+    }
+}
+
+Describe 'pester6-baseline-delta-core — newFailures (AC1 violation set)' {
+
+    It 'T1: a Passed-in-baseline test that is Failed in candidate is a new failure and fails the gate' {
+        $baseline = @(
+            script:New-Rec -Identity 'a.Tests.ps1 :: Suite > passes cleanly' -Status 'Passed'
+        )
+        $candidate = @(
+            script:New-Rec -Identity 'a.Tests.ps1 :: Suite > passes cleanly' -Status 'Failed' -Reason 'Expected 1, got 2'
+        )
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate
+
+        $delta.verdict | Should -Be 'Fail'
+        @($delta.newFailures).Count | Should -Be 1
+        $delta.newFailures[0].identity | Should -Be 'a.Tests.ps1 :: Suite > passes cleanly'
+        @($delta.reasonChanged).Count | Should -Be 0
+    }
+
+    It 'T1b: a test absent from the baseline entirely but Failed in candidate is also a new failure' {
+        $baseline = @(
+            script:New-Rec -Identity 'a.Tests.ps1 :: Suite > unrelated' -Status 'Passed'
+        )
+        $candidate = @(
+            script:New-Rec -Identity 'a.Tests.ps1 :: Suite > unrelated' -Status 'Passed'
+            script:New-Rec -Identity 'b.Tests.ps1 :: Suite > brand new failing test' -Status 'Failed' -Reason 'boom'
+        )
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate
+
+        $delta.verdict | Should -Be 'Fail'
+        @($delta.newFailures).Count | Should -Be 1
+        $delta.newFailures[0].identity | Should -Be 'b.Tests.ps1 :: Suite > brand new failing test'
+        $delta.newFailures[0].baselineStatus | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'pester6-baseline-delta-core — reasonChanged (#566-laundering guard)' {
+
+    It 'T2: a test Failed in both baseline and candidate, but with a different reason, is caught and fails the gate' {
+        $baseline = @(
+            script:New-Rec -Identity 'c.Tests.ps1 :: Suite > pre-existing red test' -Status 'Failed' -Reason 'unknown flag: --paginate'
+        )
+        $candidate = @(
+            script:New-Rec -Identity 'c.Tests.ps1 :: Suite > pre-existing red test' -Status 'Failed' -Reason 'NullReferenceException: object reference not set'
+        )
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate
+
+        $delta.verdict | Should -Be 'Fail' -Because 'a same-test reason-change must not be silently waved through as pre-existing (#566-laundering)'
+        @($delta.reasonChanged).Count | Should -Be 1
+        $delta.reasonChanged[0].identity | Should -Be 'c.Tests.ps1 :: Suite > pre-existing red test'
+        @($delta.newFailures).Count | Should -Be 0 -Because 'the identity already existed and was already failing, so it is a reason-change, not a new failure'
+    }
+
+    It 'T7: reason normalization ignores volatile substrings (timestamps, GUIDs) so a substantively identical reason does not false-positive' {
+        $baseline = @(
+            script:New-Rec -Identity 'd.Tests.ps1 :: Suite > flaky-ish red test' -Status 'Failed' -Reason 'captured at 2026-07-08T12:00:00.1234567Z with id 3fa85f64-5717-4562-b3fc-2c963f66afa6'
+        )
+        $candidate = @(
+            script:New-Rec -Identity 'd.Tests.ps1 :: Suite > flaky-ish red test' -Status 'Failed' -Reason 'captured at 2026-07-09T03:31:08.0000000Z with id 11111111-2222-3333-4444-555555555555'
+        )
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate
+
+        @($delta.reasonChanged).Count | Should -Be 0 -Because 'timestamps and GUIDs are volatile substrings, not a substantive reason change'
+        $delta.verdict | Should -Be 'Pass'
+    }
+}
+
+Describe 'pester6-baseline-delta-core — resolved (informational only)' {
+
+    It 'T3: a Failed-in-baseline test that is Passed in candidate is reported as resolved but does not fail the gate' {
+        $baseline = @(
+            script:New-Rec -Identity 'e.Tests.ps1 :: Suite > was red, now fixed' -Status 'Failed' -Reason 'Expected 0, got 1'
+        )
+        $candidate = @(
+            script:New-Rec -Identity 'e.Tests.ps1 :: Suite > was red, now fixed' -Status 'Passed'
+        )
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate
+
+        $delta.verdict | Should -Be 'Pass' -Because 'improvements never fail the gate'
+        @($delta.resolved).Count | Should -Be 1
+        $delta.resolved[0].identity | Should -Be 'e.Tests.ps1 :: Suite > was red, now fixed'
+        $delta.resolved[0].candidateStatus | Should -Be 'Passed'
+    }
+
+    It 'T3b: a Failed-in-baseline test entirely absent from candidate (e.g. deleted file) is also resolved, not a violation' {
+        $baseline = @(
+            script:New-Rec -Identity 'f.Tests.ps1 :: Suite > removed test' -Status 'Failed' -Reason 'gone now'
+        )
+        $candidate = @()
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate
+
+        $delta.verdict | Should -Be 'Pass'
+        @($delta.resolved).Count | Should -Be 1
+    }
+}
+
+Describe 'pester6-baseline-delta-core — clean identical-failure-set passes' {
+
+    It 'T4: identical baseline and candidate record sets (including a pre-existing failure) pass the gate cleanly' {
+        $records = @(
+            script:New-Rec -Identity 'g.Tests.ps1 :: Suite > passes' -Status 'Passed'
+            script:New-Rec -Identity 'g.Tests.ps1 :: Suite > skipped' -Status 'Skipped'
+            script:New-Rec -Identity 'g.Tests.ps1 :: Suite > pre-existing red' -Status 'Failed' -Reason 'Expected 0, got 1'
+        )
+        # Fresh copies so the two arrays are distinct object instances.
+        $baseline = @($records | ForEach-Object { $_.PSObject.Copy() })
+        $candidate = @($records | ForEach-Object { $_.PSObject.Copy() })
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate
+
+        $delta.verdict | Should -Be 'Pass'
+        @($delta.newFailures).Count | Should -Be 0
+        @($delta.reasonChanged).Count | Should -Be 0
+        @($delta.resolved).Count | Should -Be 0
+        @($delta.identityDrift.missingFromCandidate).Count | Should -Be 0
+        @($delta.identityDrift.newInCandidate).Count | Should -Be 0
+    }
+}
+
+Describe 'pester6-baseline-delta-core — discovery-error handling' {
+
+    It 'T5: a discovery-error is treated as a failing status for newFailures purposes' {
+        $baseline = @(
+            script:New-Rec -Identity 'h.Tests.ps1 :: <discovery>' -Status 'Passed' -Kind 'discovery-error'
+        )
+        $candidate = @(
+            script:New-Rec -Identity 'h.Tests.ps1 :: <discovery>' -Status 'DiscoveryError' -Reason 'parse error' -Kind 'discovery-error'
+        )
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate
+
+        $delta.verdict | Should -Be 'Fail'
+        @($delta.newFailures).Count | Should -Be 1
+        $delta.newFailures[0].status | Should -Be 'DiscoveryError'
+    }
+
+    It 'T5b: a discovery-error present in both, with a different reason, is a reasonChanged' {
+        $baseline = @(
+            script:New-Rec -Identity 'i.Tests.ps1 :: <discovery>' -Status 'DiscoveryError' -Reason 'old parse error' -Kind 'discovery-error'
+        )
+        $candidate = @(
+            script:New-Rec -Identity 'i.Tests.ps1 :: <discovery>' -Status 'DiscoveryError' -Reason 'new parse error' -Kind 'discovery-error'
+        )
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate
+
+        $delta.verdict | Should -Be 'Fail'
+        @($delta.reasonChanged).Count | Should -Be 1
+    }
+}
+
+Describe 'pester6-baseline-delta-core — identityDrift (renamed tests)' {
+
+    It 'T6: a renamed It (old identity gone, new identity appears in the same file) is reported via identityDrift and does not by itself fail the gate' {
+        $baseline = @(
+            script:New-Rec -Identity 'j.Tests.ps1 :: Suite > old <token> name' -File 'j.Tests.ps1' -Status 'Passed'
+        )
+        $candidate = @(
+            script:New-Rec -Identity 'j.Tests.ps1 :: Suite > old token-escaped name' -File 'j.Tests.ps1' -Status 'Passed'
+        )
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate -KnownRenameFiles @('j.Tests.ps1')
+
+        $delta.verdict | Should -Be 'Pass' -Because 'a passing test being renamed is not a failure-status transition'
+        @($delta.identityDrift.missingFromCandidate).Count | Should -Be 1
+        @($delta.identityDrift.newInCandidate).Count | Should -Be 1
+        $delta.identityDrift.missingFromCandidate[0].expectedRenameFile | Should -Be $true
+        $delta.identityDrift.newInCandidate[0].expectedRenameFile | Should -Be $true
+    }
+
+    It 'T6b: identity drift in a file NOT on the known-rename allowlist is still reported, flagged as unexpected' {
+        $baseline = @(
+            script:New-Rec -Identity 'k.Tests.ps1 :: Suite > vanished test' -File 'k.Tests.ps1' -Status 'Passed'
+        )
+        $candidate = @()
+
+        $delta = Compare-Pester6BaselineRecords -BaselineRecords $baseline -CandidateRecords $candidate -KnownRenameFiles @('j.Tests.ps1')
+
+        @($delta.identityDrift.missingFromCandidate).Count | Should -Be 1
+        $delta.identityDrift.missingFromCandidate[0].expectedRenameFile | Should -Be $false
+    }
+}
+
+Describe 'pester6-baseline-delta-core — Invoke-Pester6BaselineDelta (JSON artifact I/O)' {
+
+    BeforeAll {
+        $script:FixtureDir = Join-Path ([System.IO.Path]::GetTempPath()) "pester6-baseline-delta-fixture-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $script:FixtureDir -Force | Out-Null
+
+        $script:BaselineJsonPath = Join-Path $script:FixtureDir 'baseline.json'
+        $script:CandidateJsonPath = Join-Path $script:FixtureDir 'candidate.json'
+
+        $baselineArtifact = [ordered]@{
+            requiredVersion = '5.7.1'
+            summary         = [ordered]@{ totalTests = 2; passed = 1; failed = 1; skipped = 0; notRun = 0; discoveryErrors = 0 }
+            records         = @(
+                [ordered]@{ kind = 'test'; identity = 'x.Tests.ps1 :: Suite > ok'; file = 'x.Tests.ps1'; status = 'Passed'; reason = '' }
+                [ordered]@{ kind = 'test'; identity = 'x.Tests.ps1 :: Suite > pre-existing red'; file = 'x.Tests.ps1'; status = 'Failed'; reason = 'known issue' }
+            )
+        }
+        $candidateArtifactNewFailure = [ordered]@{
+            requiredVersion = '6.0.0'
+            summary         = [ordered]@{ totalTests = 2; passed = 1; failed = 1; skipped = 0; notRun = 0; discoveryErrors = 0 }
+            records         = @(
+                [ordered]@{ kind = 'test'; identity = 'x.Tests.ps1 :: Suite > ok'; file = 'x.Tests.ps1'; status = 'Failed'; reason = 'newly broken under 6.x' }
+                [ordered]@{ kind = 'test'; identity = 'x.Tests.ps1 :: Suite > pre-existing red'; file = 'x.Tests.ps1'; status = 'Failed'; reason = 'known issue' }
+            )
+        }
+
+        ($baselineArtifact | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $script:BaselineJsonPath -Encoding UTF8
+        ($candidateArtifactNewFailure | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $script:CandidateJsonPath -Encoding UTF8
+    }
+
+    AfterAll {
+        if (Test-Path -LiteralPath $script:FixtureDir) {
+            Remove-Item -LiteralPath $script:FixtureDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'T8: reads two JSON artifacts from disk, drives the same verdict logic, and reports ExitCode 1 on a real new failure' {
+        $outJson = Join-Path $script:FixtureDir 'delta.json'
+        $outMd = Join-Path $script:FixtureDir 'delta.md'
+
+        $result = Invoke-Pester6BaselineDelta -BaselinePath $script:BaselineJsonPath -CandidatePath $script:CandidateJsonPath -OutputJsonPath $outJson -OutputMarkdownPath $outMd
+
+        $result.ExitCode | Should -Be 1
+        $result.Result.verdict | Should -Be 'Fail'
+        @($result.Result.newFailures).Count | Should -Be 1
+        $result.Result.newFailures[0].identity | Should -Be 'x.Tests.ps1 :: Suite > ok'
+
+        Test-Path -LiteralPath $outJson | Should -Be $true
+        Test-Path -LiteralPath $outMd | Should -Be $true
+        (Get-Content -LiteralPath $outMd -Raw) | Should -Match 'FAIL'
+    }
+
+    It 'T8b: a missing BaselinePath fails loudly with ExitCode 1 instead of throwing an uncaught exception' {
+        $result = Invoke-Pester6BaselineDelta -BaselinePath (Join-Path $script:FixtureDir 'does-not-exist.json') -CandidatePath $script:CandidateJsonPath
+        $result.ExitCode | Should -Be 1
+        $result.Result | Should -BeNullOrEmpty
+    }
+}

--- a/.github/scripts/Tests/post-merge-cleanup.Tests.ps1
+++ b/.github/scripts/Tests/post-merge-cleanup.Tests.ps1
@@ -890,7 +890,7 @@ exit $LASTEXITCODE
             $deleteCalls.Count | Should -Be 0 -Because 'when gh is unavailable, branch must be treated as unmerged (safe default: do not delete)'
         }
 
-        It 'TC-Cherry-OrgRef: git cherry is called with origin/<defaultBranch> as the base ref (not bare <defaultBranch>)' {
+        It 'TC-Cherry-OrgRef: git cherry is called with the origin/ prefixed default-branch ref as the base ref (not the bare default-branch name)' {
             # Regression test for M1: Test-BranchMergedIntoDefault must use origin/$DefaultBranch
             # so it compares against the fetched remote tip, not a potentially stale local ref.
             $workDir = Join-Path $TestDrive 'cherry-org-ref'

--- a/.github/scripts/Tests/quick-validate.Tests.ps1
+++ b/.github/scripts/Tests/quick-validate.Tests.ps1
@@ -435,6 +435,7 @@ No gotchas section here.
 
         It 'reports SKIP when PSScriptAnalyzer not installed' {
             # Mock Get-Module to simulate PSScriptAnalyzer not being available
+            Mock Get-Module { }
             Mock Get-Module { return $null } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
 
             $root = & $script:NewFixture
@@ -445,6 +446,9 @@ No gotchas section here.
                 -GuidanceComplexityScriptPath $mockScript `
                 -ScriptsPath (Join-Path $root '.github/scripts')
 
+            # Sound invoke-pairing (d-dead-filter-tripwire-v2): assertion filter is textually
+            # identical to the narrow Mock's -ParameterFilter above.
+            Should -Invoke Get-Module -Times 1 -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
             $check = $result.Results | Where-Object { $_.Name -eq 'PSScriptAnalyzer' }
             $check.Passed | Should -Be 'SKIP' -Because 'PSScriptAnalyzer is not installed; check should be skipped, not passed or failed'
             $result.ExitCode | Should -Be 0 -Because 'SKIP should not poison the exit code when all other checks pass'
@@ -453,6 +457,7 @@ No gotchas section here.
 
         It 'reports PASS when PSScriptAnalyzer finds no issues' {
             # Mock Get-Module to simulate PSScriptAnalyzer being available
+            Mock Get-Module { }
             Mock Get-Module { return @{ Name = 'PSScriptAnalyzer'; Version = '1.22.0' } } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
             Mock Invoke-ScriptAnalyzer { return @() }
 
@@ -466,12 +471,16 @@ No gotchas section here.
                 -PSScriptAnalyzerSettingsPath $mockSettings `
                 -ScriptsPath (Join-Path $root '.github/scripts')
 
+            # Sound invoke-pairing (d-dead-filter-tripwire-v2): assertion filter is textually
+            # identical to the narrow Mock's -ParameterFilter above.
+            Should -Invoke Get-Module -Times 1 -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
             $check = $result.Results | Where-Object { $_.Name -eq 'PSScriptAnalyzer' }
             $check.Passed | Should -BeTrue -Because 'PSScriptAnalyzer found no issues'
         }
 
         It 'reports FAIL when PSScriptAnalyzer finds issues' {
             # Mock Get-Module to simulate PSScriptAnalyzer being available
+            Mock Get-Module { }
             Mock Get-Module { return @{ Name = 'PSScriptAnalyzer'; Version = '1.22.0' } } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
             Mock Invoke-ScriptAnalyzer {
                 return @(
@@ -490,6 +499,9 @@ No gotchas section here.
                 -PSScriptAnalyzerSettingsPath $mockSettings `
                 -ScriptsPath (Join-Path $root '.github/scripts')
 
+            # Sound invoke-pairing (d-dead-filter-tripwire-v2): assertion filter is textually
+            # identical to the narrow Mock's -ParameterFilter above.
+            Should -Invoke Get-Module -Times 1 -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
             $check = $result.Results | Where-Object { $_.Name -eq 'PSScriptAnalyzer' }
             $check.Passed | Should -BeFalse -Because 'PSScriptAnalyzer found 2 issues'
             $check.Detail | Should -Match '2' -Because 'detail should indicate the number of issues found'
@@ -685,6 +697,7 @@ None.
             $mockScript = & $script:NewMockComplexityScript -Dir $root -AgentsOverCeiling @()
 
             # Mock PSScriptAnalyzer as installed with no issues
+            Mock Get-Module { }
             Mock Get-Module { return @{ Name = 'PSScriptAnalyzer'; Version = '1.22.0' } } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
             Mock Invoke-ScriptAnalyzer { return @() }
 
@@ -696,6 +709,9 @@ None.
                 -PSScriptAnalyzerSettingsPath $mockSettings `
                 -ScriptsPath (Join-Path $root '.github/scripts')
 
+            # Sound invoke-pairing (d-dead-filter-tripwire-v2): assertion filter is textually
+            # identical to the narrow Mock's -ParameterFilter above.
+            Should -Invoke Get-Module -Times 1 -ParameterFilter { $Name -eq 'PSScriptAnalyzer' -and $ListAvailable }
             $result.ExitCode | Should -Be 0 -Because 'all checks pass in a clean fixture'
         }
 

--- a/.github/scripts/Tests/reporting-economy.Tests.ps1
+++ b/.github/scripts/Tests/reporting-economy.Tests.ps1
@@ -63,6 +63,10 @@ BeforeDiscovery {
     # Store counts for the count-guard test
     $script:DiscoveryInScopeCount  = $InScopeBodies.Count
     $script:DiscoveryExcludedCount = @($allBodies | Where-Object { ($_.BaseName -replace '\.agent$', '') -in $ExcludedBaseNames }).Count
+
+    if (@($script:DiscoveryInScopeRows).Count -eq 0) {
+        throw "no in-scope agent bodies found in $AgentsDirectory — coverage would silently vanish"
+    }
 }
 
 Describe 'Reporting-economy directive in specialist agent bodies' {

--- a/.github/scripts/capture-pester6-baseline.ps1
+++ b/.github/scripts/capture-pester6-baseline.ps1
@@ -1,0 +1,68 @@
+#Requires -Version 7.0
+<#!
+.SYNOPSIS
+    Thin wrapper for the version-pinned, per-test-identity Pester baseline
+    capture tool (issue #818 / s2).
+
+.DESCRIPTION
+    Entry-point guard + param declaration. All logic lives in
+    lib/pester6-baseline-core.ps1. Tests dot-source the core directly; this
+    wrapper is for CLI invocation.
+
+    This is a one-time acceptance/baseline tool for the #818 Pester 5→6
+    migration, not a standing CI job — it is deliberately not registered in
+    pester.yml.
+
+.PARAMETER TestsPath
+    Path to the directory containing .Tests.ps1 files.
+    Defaults to .github/scripts/Tests relative to the repo root.
+
+.PARAMETER RequiredVersion
+    The exact installed Pester version to run under (e.g. '5.7.1' or '6.0.0').
+    Mandatory — never auto-resolved to "newest installed".
+
+.PARAMETER OutputPath
+    Path to write the JSON result artifact to.
+    Defaults to .tmp/issue-818/baseline-<RequiredVersion>.json relative to the
+    repo root (NOT Documents/Design/ — that was an earlier mistake in this
+    plan's history that was explicitly corrected).
+#>
+[CmdletBinding()]
+param(
+    [string]$TestsPath = (Join-Path $PSScriptRoot 'Tests'),
+
+    [Parameter(Mandatory)]
+    [string]$RequiredVersion,
+
+    [string]$OutputPath
+)
+
+$isDotSourced = $MyInvocation.InvocationName -eq '.'
+
+. "$PSScriptRoot/lib/pester6-baseline-core.ps1"
+
+if (-not $isDotSourced) {
+    if (-not $OutputPath) {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+        $OutputPath = Join-Path $repoRoot ".tmp/issue-818/baseline-$RequiredVersion.json"
+    }
+
+    $result = Invoke-Pester6BaselineCapture `
+        -TestsPath $TestsPath `
+        -RequiredVersion $RequiredVersion `
+        -OutputPath $OutputPath
+
+    if ($result.ExitCode -eq 0) {
+        Write-Host "Baseline captured: $OutputPath"
+        Write-Host ("  Pester {0} — total={1} passed={2} failed={3} skipped={4} notRun={5} discoveryErrors={6}" -f `
+            $result.Result.importedVersion, `
+            $result.Result.summary.totalTests, `
+            $result.Result.summary.passed, `
+            $result.Result.summary.failed, `
+            $result.Result.summary.skipped, `
+            $result.Result.summary.notRun, `
+            $result.Result.summary.discoveryErrors)
+    }
+
+    exit $result.ExitCode
+}

--- a/.github/scripts/compare-pester6-baseline.ps1
+++ b/.github/scripts/compare-pester6-baseline.ps1
@@ -1,0 +1,63 @@
+#Requires -Version 7.0
+<#!
+.SYNOPSIS
+    Thin wrapper for the post-port acceptance delta gate (issue #818 / s7).
+
+.DESCRIPTION
+    Entry-point guard + param declaration. All logic lives in
+    lib/pester6-baseline-delta-core.ps1. Tests dot-source the core directly;
+    this wrapper is for CLI invocation.
+
+    This is a one-time acceptance-evidence tool for the #818 Pester 5->6
+    migration, not a standing CI job.
+
+.PARAMETER BaselinePath
+    Path to the baseline `capture-pester6-baseline.ps1` JSON artifact
+    (the pre-port / accepted-failures reference).
+
+.PARAMETER CandidatePath
+    Path to the candidate `capture-pester6-baseline.ps1` JSON artifact
+    (the run being evaluated against the baseline).
+
+.PARAMETER OutputJsonPath
+    Path to write the full delta result as JSON. Optional.
+
+.PARAMETER OutputMarkdownPath
+    Path to write the PR-evidence Markdown verdict report. Optional.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$BaselinePath,
+
+    [Parameter(Mandatory)]
+    [string]$CandidatePath,
+
+    [string]$OutputJsonPath,
+
+    [string]$OutputMarkdownPath
+)
+
+$isDotSourced = $MyInvocation.InvocationName -eq '.'
+
+. "$PSScriptRoot/lib/pester6-baseline-delta-core.ps1"
+
+if (-not $isDotSourced) {
+    $result = Invoke-Pester6BaselineDelta `
+        -BaselinePath $BaselinePath `
+        -CandidatePath $CandidatePath `
+        -OutputJsonPath $OutputJsonPath `
+        -OutputMarkdownPath $OutputMarkdownPath
+
+    if ($null -ne $result.Result) {
+        Write-Host ("Verdict: {0} — {1}" -f $result.Result.verdict, $result.Result.verdictReason)
+        Write-Host ("  newFailures={0} reasonChanged={1} resolved={2} identityDrift(missing={3}, new={4})" -f `
+            @($result.Result.newFailures).Count, `
+            @($result.Result.reasonChanged).Count, `
+            @($result.Result.resolved).Count, `
+            @($result.Result.identityDrift.missingFromCandidate).Count, `
+            @($result.Result.identityDrift.newInCandidate).Count)
+    }
+
+    exit $result.ExitCode
+}

--- a/.github/scripts/lib/pester6-baseline-core.ps1
+++ b/.github/scripts/lib/pester6-baseline-core.ps1
@@ -1,0 +1,314 @@
+#Requires -Version 7.0
+<#!
+.SYNOPSIS
+    Pure-logic library for the version-pinned, per-test-identity Pester baseline
+    capture tool (issue #818 / s2).
+
+.DESCRIPTION
+    Fixes the gap the plan's adversarial review proved in `run-pester-sharded.ps1`
+    (see .github/scripts/lib/pester-sharded-core.ps1): each shard spawns a fresh pwsh process with
+    no Pester version selector (auto-resolves whatever is newest-installed), and it
+    emits only per-file {File,Passed,Failed,TotalCount} aggregates — no test
+    identity, no failure reason. That is too coarse for AC1's delta-neutral gate,
+    which must tell a genuine 6.x regression apart from a pre-existing (#566) or
+    same-test reason-changed failure.
+
+    This library captures, per test, across the WHOLE suite in one Invoke-Pester
+    pass: the fully-qualified Describe > Context > It identity (prefixed with the
+    path of the file relative to TestsPath, since identity is not guaranteed
+    globally unique across files), pass/fail/skip/not-run status, and the failure message
+    when failed. A discovery-time throw in one file (a `throw` at file scope, a
+    parse error, etc.) is recorded as a distinct `discovery-error` record rather
+    than silently collapsing or crashing the run — Pester already isolates
+    discovery failures per-container, so one broken file does not prevent the
+    rest of the suite from running; this library surfaces that isolation as an
+    identifiable record instead of leaving it implicit.
+
+    The Pester version is never auto-resolved. -RequiredVersion is mandatory and
+    is honored via `Import-Module Pester -RequiredVersion <version> -Force` inside
+    an isolated child pwsh process (the current session may already have a
+    different Pester version imported), so the captured baseline is reproducible
+    and labeled with the exact version that produced it.
+
+    Exposes:
+      - Get-Pester6BaselineLauncherScript : build the child-process launcher script content
+      - Invoke-Pester6BaselineCapture     : orchestrate the isolated run and return the parsed result
+#>
+
+# ---------------------------------------------------------------------------
+# Internal: build the child-process launcher script content.
+# The launcher is written to a temp .ps1 file so paths do not require complex
+# inline string escaping when passed to pwsh (same pattern as the
+# Get-ShardLauncherScript function in .github/scripts/lib/pester-sharded-core.ps1).
+# ---------------------------------------------------------------------------
+function Get-Pester6BaselineLauncherScript {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TestsPath,
+
+        [Parameter(Mandatory)]
+        [string]$RequiredVersion,
+
+        [Parameter(Mandatory)]
+        [string]$ResultFilePath
+    )
+
+    # Single-quote literals in a PowerShell here-string are safe; the caller's
+    # paths/version are embedded via @"..."@ substitution below.
+    return @"
+#Requires -Version 7.0
+`$ErrorActionPreference = 'Stop'
+try {
+    Import-Module Pester -RequiredVersion '$RequiredVersion' -Force -ErrorAction Stop
+
+    `$importedVersion = (Get-Module -Name Pester | Select-Object -First 1).Version.ToString()
+
+    `$cfg = New-PesterConfiguration
+    `$cfg.Run.Path = @('$($TestsPath -replace "'", "''")')
+    `$cfg.Run.PassThru = `$true
+    `$cfg.Run.Exit = `$false
+    `$cfg.Output.Verbosity = 'None'
+
+    `$r = Invoke-Pester -Configuration `$cfg
+
+    `$testsPathFull = (Resolve-Path -LiteralPath '$($TestsPath -replace "'", "''")').Path
+
+    `$records = [System.Collections.Generic.List[object]]::new()
+
+    # `$t.Path is UNEXPANDED: data-driven -ForEach instances of one templated
+    # Describe/Context/It name (e.g. 'handles case <n>') all share the same
+    # literal '<n>' token, collapsing distinct instances onto one identity.
+    # `$t.ExpandedPath is Pester's own per-instance-expanded dot-joined path
+    # string (confirmed via live probe against Pester 6.0.0 and 5.7.1 test
+    # result objects: it expands BOTH group-level and leaf-level -ForEach
+    # templating, e.g. 'Group ForEach probe.group alpha.checks value'), so
+    # each -ForEach instance USUALLY gets a distinct identity string this way.
+    #
+    # But `.ExpandedPath` alone is still an insufficient identity key on its
+    # own: it only disambiguates when the -ForEach/-TestCases templated name
+    # string actually references the varying data. When a test author writes
+    # a fixed literal It name and relies on -ForEach purely for data variation
+    # (a legitimate, common Pester pattern -- e.g. an It named 'keeps
+    # same-tip duplicate branches blocked for rename and cleanup' with
+    # -ForEach @(@{RequestedAction='rename'}, @{RequestedAction='cleanup'})
+    # and no <RequestedAction> token anywhere in the name), every instance
+    # expands to the IDENTICAL name/path and collapses onto one base
+    # identity. The two passes below detect genuine collisions and append a
+    # synthetic ordinal disambiguator ONLY to colliding groups, leaving every
+    # already-unique identity unchanged so most of the suite's identities
+    # stay stable.
+    `$testEntries = [System.Collections.Generic.List[object]]::new()
+    foreach (`$t in @(`$r.Tests)) {
+        `$fileFull = [string]`$t.ScriptBlock.File
+        `$relFile = if (`$fileFull -and `$fileFull.StartsWith(`$testsPathFull)) {
+            `$fileFull.Substring(`$testsPathFull.Length).TrimStart('\', '/')
+        } else {
+            Split-Path -Leaf `$fileFull
+        }
+        `$expandedPath = [string]`$t.ExpandedPath
+        `$baseIdentity = "`$relFile :: `$expandedPath"
+
+        `$reason = ''
+        if (@(`$t.ErrorRecord).Count -gt 0) {
+            `$reason = ((@(`$t.ErrorRecord) | ForEach-Object { `$_.Exception.Message }) -join ' | ')
+        }
+
+        `$testEntries.Add([ordered]@{
+            baseIdentity = `$baseIdentity
+            file         = `$relFile
+            status       = [string]`$t.Result
+            reason       = `$reason
+        }) | Out-Null
+    }
+
+    `$identityCounts = @{}
+    foreach (`$entry in `$testEntries) {
+        `$key = `$entry.baseIdentity
+        if (`$identityCounts.ContainsKey(`$key)) { `$identityCounts[`$key]++ } else { `$identityCounts[`$key] = 1 }
+    }
+
+    `$identitySeen = @{}
+    foreach (`$entry in `$testEntries) {
+        `$key = `$entry.baseIdentity
+        `$total = `$identityCounts[`$key]
+        if (`$total -gt 1) {
+            if (`$identitySeen.ContainsKey(`$key)) { `$identitySeen[`$key]++ } else { `$identitySeen[`$key] = 1 }
+            `$ordinal = `$identitySeen[`$key]
+            `$identity = "`$key [instance `$ordinal of `$total]"
+        } else {
+            `$identity = `$key
+        }
+
+        `$records.Add([ordered]@{
+            kind     = 'test'
+            identity = `$identity
+            file     = `$entry.file
+            status   = `$entry.status
+            reason   = `$entry.reason
+        }) | Out-Null
+    }
+
+    `$discoveryErrorCount = 0
+    foreach (`$c in @(`$r.Containers)) {
+        `$errs = @(`$c.ErrorRecord)
+        if (`$errs.Count -gt 0) {
+            `$discoveryErrorCount++
+            `$fileFull = [string]`$c.Item
+            `$relFile = if (`$fileFull -and `$fileFull.StartsWith(`$testsPathFull)) {
+                `$fileFull.Substring(`$testsPathFull.Length).TrimStart('\', '/')
+            } else {
+                Split-Path -Leaf `$fileFull
+            }
+            `$reason = ((`$errs | ForEach-Object { `$_.Exception.Message }) -join ' | ')
+            `$records.Add([ordered]@{
+                kind     = 'discovery-error'
+                identity = "`$relFile :: <discovery>"
+                file     = `$relFile
+                status   = 'DiscoveryError'
+                reason   = `$reason
+            }) | Out-Null
+        }
+    }
+
+    `$summary = [ordered]@{
+        totalTests      = [int]`$r.TotalCount
+        passed          = [int]`$r.PassedCount
+        failed          = [int]`$r.FailedCount
+        skipped         = [int]`$r.SkippedCount
+        notRun          = [int]`$r.NotRunCount
+        discoveryErrors = `$discoveryErrorCount
+    }
+
+    `$obj = [ordered]@{
+        requiredVersion = '$RequiredVersion'
+        importedVersion = `$importedVersion
+        testsPath       = `$testsPathFull
+        capturedAt      = (Get-Date).ToUniversalTime().ToString('o')
+        summary         = `$summary
+        records         = `$records
+    }
+
+    `$obj | ConvertTo-Json -Depth 6 -Compress | Set-Content -LiteralPath '$($ResultFilePath -replace "'", "''")' -Encoding UTF8
+    exit 0
+}
+catch {
+    `$failObj = [ordered]@{
+        requiredVersion = '$RequiredVersion'
+        error           = `$_.Exception.Message
+        capturedAt      = (Get-Date).ToUniversalTime().ToString('o')
+    }
+    `$failObj | ConvertTo-Json -Compress | Set-Content -LiteralPath '$($ResultFilePath -replace "'", "''")' -Encoding UTF8
+    Write-Error `$_
+    exit 2
+}
+"@
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-Pester6BaselineCapture
+# ---------------------------------------------------------------------------
+function Invoke-Pester6BaselineCapture {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TestsPath,
+
+        # Mandatory and never defaulted: this tool exists specifically because
+        # `run-pester-sharded.ps1` auto-resolves "newest installed" Pester with
+        # no version selector. A default here would reintroduce that gap.
+        [Parameter(Mandatory)]
+        [string]$RequiredVersion,
+
+        [string]$OutputPath
+    )
+
+    # Function-scoped override only — does not leak to the caller. Every early
+    # exit below pairs a Write-Error with a graceful `return [pscustomobject]
+    # @{ ExitCode = 1; ... }`, but Write-Error is only non-terminating when
+    # $ErrorActionPreference is 'Continue'. When this function is invoked from
+    # inside an OUTER Invoke-Pester run whose ambient $ErrorActionPreference is
+    # 'Stop' (Pester test scriptblocks commonly run with EAP=Stop), each
+    # Write-Error below would otherwise become a terminating error that skips
+    # the following `return` entirely, propagating an uncaught exception
+    # instead of the intended graceful ExitCode=1 result. Pinning EAP locally
+    # makes the graceful-return contract hold regardless of nesting context.
+    $ErrorActionPreference = 'Continue'
+
+    $resolvedTestsPath = $TestsPath
+    if (-not [System.IO.Path]::IsPathRooted($resolvedTestsPath)) {
+        $resolved = Resolve-Path $resolvedTestsPath -ErrorAction SilentlyContinue
+        if ($null -ne $resolved) { $resolvedTestsPath = $resolved.Path }
+    }
+
+    if (-not (Test-Path -LiteralPath $resolvedTestsPath -PathType Container)) {
+        Write-Error "TestsPath not found: $resolvedTestsPath"
+        return [pscustomobject]@{ ExitCode = 1; Result = $null }
+    }
+
+    # Fail loudly (not silently) if the exact requested version is not installed,
+    # rather than letting Import-Module -RequiredVersion fail deep inside the
+    # child process with a less actionable message.
+    $available = @(Get-Module -Name Pester -ListAvailable | Where-Object { $_.Version.ToString() -eq $RequiredVersion })
+    if ($available.Count -eq 0) {
+        Write-Error "Pester $RequiredVersion is not installed (Get-Module Pester -ListAvailable found no exact match). Install it before capturing this baseline."
+        return [pscustomobject]@{ ExitCode = 1; Result = $null }
+    }
+
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "pester6-baseline-$([System.Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    $resultFile = Join-Path $tempDir 'result.json'
+    $launchFile = Join-Path $tempDir 'launcher.ps1'
+
+    try {
+        $launchContent = Get-Pester6BaselineLauncherScript -TestsPath $resolvedTestsPath -RequiredVersion $RequiredVersion -ResultFilePath $resultFile
+        [System.IO.File]::WriteAllText($launchFile, $launchContent, [System.Text.UTF8Encoding]::new($false))
+
+        $proc = $null
+        try {
+            # Explicitly quote the -File value: Start-Process builds the child
+            # process command line by concatenating -ArgumentList elements with
+            # spaces rather than re-quoting each element, so an unquoted temp
+            # path containing a space (e.g. a scratch dir under a "Program
+            # Files"-style or user-provided spaced location) truncates at the
+            # first space and pwsh receives a broken path token (confirmed via
+            # empirical repro: pwsh exits 64 with a truncated path).
+            $proc = Start-Process pwsh -ArgumentList @('-NoProfile', '-NonInteractive', '-File', "`"$launchFile`"") -NoNewWindow -Wait -PassThru
+        }
+        catch {
+            $proc = $null
+        }
+
+        $exitCode = if ($null -ne $proc) { $proc.ExitCode } else { 99 }
+
+        if (-not (Test-Path -LiteralPath $resultFile)) {
+            Write-Error "Baseline capture produced no result file (child process exit code: $exitCode). Presumed crash."
+            return [pscustomobject]@{ ExitCode = 1; Result = $null }
+        }
+
+        $parsed = Get-Content -LiteralPath $resultFile -Raw | ConvertFrom-Json
+
+        if ($exitCode -ne 0 -or $null -ne $parsed.error) {
+            $msg = if ($null -ne $parsed.error) { $parsed.error } else { "child process exit code $exitCode" }
+            Write-Error "Baseline capture failed: $msg"
+            return [pscustomobject]@{ ExitCode = 1; Result = $parsed }
+        }
+
+        if ($OutputPath) {
+            $outDir = Split-Path -Parent $OutputPath
+            if ($outDir -and -not (Test-Path -LiteralPath $outDir)) {
+                New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+            }
+            ($parsed | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+        }
+
+        return [pscustomobject]@{ ExitCode = 0; Result = $parsed }
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempDir) {
+            Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/.github/scripts/lib/pester6-baseline-core.ps1
+++ b/.github/scripts/lib/pester6-baseline-core.ps1
@@ -288,7 +288,7 @@ function Invoke-Pester6BaselineCapture {
             return [pscustomobject]@{ ExitCode = 1; Result = $null }
         }
 
-        $parsed = Get-Content -LiteralPath $resultFile -Raw | ConvertFrom-Json
+        $parsed = Get-Content -LiteralPath $resultFile -Raw -ErrorAction Stop | ConvertFrom-Json
 
         if ($exitCode -ne 0 -or $null -ne $parsed.error) {
             $msg = if ($null -ne $parsed.error) { $parsed.error } else { "child process exit code $exitCode" }
@@ -301,10 +301,14 @@ function Invoke-Pester6BaselineCapture {
             if ($outDir -and -not (Test-Path -LiteralPath $outDir)) {
                 New-Item -ItemType Directory -Path $outDir -Force | Out-Null
             }
-            ($parsed | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+            ($parsed | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $OutputPath -Encoding UTF8 -ErrorAction Stop
         }
 
         return [pscustomobject]@{ ExitCode = 0; Result = $parsed }
+    }
+    catch {
+        Write-Error "Failed to read, parse, or write the baseline result: $($_.Exception.Message)"
+        return [pscustomobject]@{ ExitCode = 1; Result = $null }
     }
     finally {
         if (Test-Path -LiteralPath $tempDir) {

--- a/.github/scripts/lib/pester6-baseline-delta-core.ps1
+++ b/.github/scripts/lib/pester6-baseline-delta-core.ps1
@@ -64,8 +64,9 @@ function ConvertTo-Pester6NormalizedReason {
 
     $normalized = $Reason
 
-    # ISO8601-ish timestamps, e.g. 2026-07-09T01:38:10.7318036Z or with offsets.
-    $normalized = [regex]::Replace($normalized, '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?', '<timestamp>')
+    # ISO8601-ish timestamps, e.g. 2026-07-09T01:38:10.7318036Z, with offsets,
+    # or the space-separated variant (2026-07-09 01:38:10).
+    $normalized = [regex]::Replace($normalized, '\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?', '<timestamp>')
 
     # GUIDs (with or without dashes, case-insensitive).
     $normalized = [regex]::Replace($normalized, '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}', '<guid>')
@@ -291,8 +292,8 @@ function Invoke-Pester6BaselineDelta {
     }
 
     try {
-        $baselineArtifact = Get-Content -LiteralPath $BaselinePath -Raw | ConvertFrom-Json
-        $candidateArtifact = Get-Content -LiteralPath $CandidatePath -Raw | ConvertFrom-Json
+        $baselineArtifact = Get-Content -LiteralPath $BaselinePath -Raw -ErrorAction Stop | ConvertFrom-Json
+        $candidateArtifact = Get-Content -LiteralPath $CandidatePath -Raw -ErrorAction Stop | ConvertFrom-Json
     }
     catch {
         Write-Error "Failed to parse baseline/candidate JSON: $($_.Exception.Message)"
@@ -325,7 +326,7 @@ function Invoke-Pester6BaselineDelta {
         if ($outDir -and -not (Test-Path -LiteralPath $outDir)) {
             New-Item -ItemType Directory -Path $outDir -Force | Out-Null
         }
-        ($result | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $OutputJsonPath -Encoding UTF8
+        ($result | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $OutputJsonPath -Encoding UTF8 -ErrorAction Stop
     }
 
     if ($OutputMarkdownPath) {
@@ -334,7 +335,7 @@ function Invoke-Pester6BaselineDelta {
             New-Item -ItemType Directory -Path $outDir -Force | Out-Null
         }
         $md = Get-Pester6BaselineDeltaMarkdown -Result $result
-        Set-Content -LiteralPath $OutputMarkdownPath -Value $md -Encoding UTF8
+        Set-Content -LiteralPath $OutputMarkdownPath -Value $md -Encoding UTF8 -ErrorAction Stop
     }
 
     $exitCode = if ($delta.verdict -eq 'Pass') { 0 } else { 1 }

--- a/.github/scripts/lib/pester6-baseline-delta-core.ps1
+++ b/.github/scripts/lib/pester6-baseline-delta-core.ps1
@@ -1,0 +1,438 @@
+#Requires -Version 7.0
+<#!
+.SYNOPSIS
+    Pure-logic library for the post-port acceptance delta gate (issue #818 / s7).
+
+.DESCRIPTION
+    Consumes two `capture-pester6-baseline.ps1` (s2) JSON artifacts — a baseline
+    and a candidate — and computes the machine-checked AC1 delta the plan's
+    stress-test (M4/M11/M9) required: `acceptance_failures subset-of
+    baseline_failures`, made reason-aware so a same-test reason-change cannot
+    silently launder a new defect into an existing #566 entry.
+
+    Four classifications, all keyed on the baseline runner's per-test
+    `identity` string (`<relFile> :: <Describe > Context > It>`):
+
+      - newFailures    : Failed/DiscoveryError in candidate, Passed/Skipped/
+                         NotRun/absent in baseline. This is the AC1 violation
+                         set; it must be empty for the gate to PASS.
+      - reasonChanged   : Failed/DiscoveryError in BOTH artifacts, but the
+                         (normalized) failure reason differs. The #566-
+                         laundering guard from stress-test finding M9 — a test
+                         red for reason A must not silently become red for
+                         reason B and get waved through as pre-existing. Must
+                         also be empty for PASS.
+      - resolved        : Failed/DiscoveryError in baseline, Passed/Skipped/
+                         NotRun/absent in candidate. Informational only —
+                         improvements never fail the gate.
+      - identityDrift   : identity strings present in one artifact's records
+                         but entirely absent from the other, independent of
+                         status. Renamed `It` names (s4's angle-bracket-token
+                         rephrasing) surface here rather than as a spurious
+                         newFailure/resolved pair on an unrelated identity.
+                         Informational — annotated against a known-rename file
+                         allowlist for reviewer convenience, but never gates
+                         the verdict on its own.
+
+    Verdict is PASS iff newFailures.Count -eq 0 AND reasonChanged.Count -eq 0.
+
+    Exposes:
+      - ConvertTo-Pester6NormalizedReason : strip volatile substrings (ISO8601
+        timestamps, GUIDs) from a failure-reason string before comparison
+      - Compare-Pester6BaselineRecords    : pure-logic delta over two record
+        arrays (used directly by the Pester test with small synthetic fixtures)
+      - Invoke-Pester6BaselineDelta       : I/O wrapper — loads two baseline
+        JSON artifacts by path, runs the comparison, and optionally persists
+        the JSON delta + a Markdown verdict report
+#>
+
+# ---------------------------------------------------------------------------
+# ConvertTo-Pester6NormalizedReason
+# ---------------------------------------------------------------------------
+function ConvertTo-Pester6NormalizedReason {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Reason
+    )
+
+    if ([string]::IsNullOrEmpty($Reason)) {
+        return ''
+    }
+
+    $normalized = $Reason
+
+    # ISO8601-ish timestamps, e.g. 2026-07-09T01:38:10.7318036Z or with offsets.
+    $normalized = [regex]::Replace($normalized, '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?', '<timestamp>')
+
+    # GUIDs (with or without dashes, case-insensitive).
+    $normalized = [regex]::Replace($normalized, '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}', '<guid>')
+
+    # Collapse CRLF/LF and repeated whitespace so line-ending drift alone
+    # cannot register as a reason change.
+    $normalized = $normalized -replace '\r\n', "`n"
+    $normalized = ($normalized -replace '\s+', ' ').Trim()
+
+    return $normalized
+}
+
+# ---------------------------------------------------------------------------
+# Internal: failing-status predicate. A test/discovery-error record counts as
+# "failing" for delta purposes when its status is Failed or DiscoveryError;
+# Passed, Skipped, and NotRun are all "non-failing".
+# ---------------------------------------------------------------------------
+function script:Test-Pester6RecordIsFailing {
+    param([Parameter(Mandatory)][AllowNull()]$Record)
+    if ($null -eq $Record) { return $false }
+    return @('Failed', 'DiscoveryError') -contains [string]$Record.status
+}
+
+# ---------------------------------------------------------------------------
+# Internal: build an identity -> record lookup. Duplicate identities within a
+# single artifact's records are a LOUD error, not last-write-wins: after the
+# M1 fix (pester6-baseline-core.ps1's launcher now builds identity from
+# Pester's per-instance-expanded `ExpandedPath` instead of the unexpanded
+# `Path`) PLUS the follow-up ordinal-tiebreaker fix (the launcher now detects
+# genuinely colliding `ExpandedPath` groups -- e.g. a -ForEach case whose It
+# name has no templated token referencing the varying data -- and appends a
+# synthetic "[instance N of M]" disambiguator to every instance in that
+# group), a genuine -ForEach data-driven test collision reaching this map
+# builder is no longer possible for legitimate capture artifacts: two
+# distinct Pester test instances can never share one identity string. This
+# throw stays as a defensive invariant check, not a live guard against an
+# expected condition. A collision reaching this function now indicates a
+# real identity-construction defect (or corrupted/hand-built artifact) that
+# should fail fast and name the exact colliding identity, rather than
+# silently overwriting one record with another and hiding a coverage gap.
+# ---------------------------------------------------------------------------
+function script:ConvertTo-Pester6RecordMap {
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Records)
+    $map = [ordered]@{}
+    foreach ($r in $Records) {
+        if ($null -eq $r -or [string]::IsNullOrEmpty([string]$r.identity)) { continue }
+        $identity = [string]$r.identity
+        if ($map.Contains($identity)) {
+            throw "Duplicate test identity found while building the baseline/candidate record map: '$identity'. This should be impossible after the M1 ExpandedPath-based identity fix; investigate the capture artifact instead of silently keeping the last record."
+        }
+        $map[$identity] = $r
+    }
+    return $map
+}
+
+# ---------------------------------------------------------------------------
+# Compare-Pester6BaselineRecords
+# ---------------------------------------------------------------------------
+function Compare-Pester6BaselineRecords {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$BaselineRecords,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$CandidateRecords,
+
+        # Files with deliberate s4 It-name rephrasing; identity drift confined
+        # to these files is expected, not a coverage-loss signal. Passing no
+        # list simply means every drift is reported as "unexpected" — the
+        # comparison logic itself is unaffected either way.
+        [string[]]$KnownRenameFiles = @()
+    )
+
+    $baselineMap = script:ConvertTo-Pester6RecordMap -Records $BaselineRecords
+    $candidateMap = script:ConvertTo-Pester6RecordMap -Records $CandidateRecords
+
+    $newFailures = [System.Collections.Generic.List[object]]::new()
+    $reasonChanged = [System.Collections.Generic.List[object]]::new()
+    $resolved = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($identity in $candidateMap.Keys) {
+        $candidateRecord = $candidateMap[$identity]
+        $baselineRecord = if ($baselineMap.Contains($identity)) { $baselineMap[$identity] } else { $null }
+
+        $candidateFailing = script:Test-Pester6RecordIsFailing -Record $candidateRecord
+        $baselineFailing = script:Test-Pester6RecordIsFailing -Record $baselineRecord
+
+        if ($candidateFailing -and -not $baselineFailing) {
+            $newFailures.Add([ordered]@{
+                identity        = $identity
+                file            = [string]$candidateRecord.file
+                status          = [string]$candidateRecord.status
+                reason          = [string]$candidateRecord.reason
+                baselineStatus  = if ($null -ne $baselineRecord) { [string]$baselineRecord.status } else { $null }
+            }) | Out-Null
+        }
+        elseif ($candidateFailing -and $baselineFailing) {
+            $normalizedBaselineReason = ConvertTo-Pester6NormalizedReason -Reason ([string]$baselineRecord.reason)
+            $normalizedCandidateReason = ConvertTo-Pester6NormalizedReason -Reason ([string]$candidateRecord.reason)
+            if ($normalizedBaselineReason -ne $normalizedCandidateReason) {
+                $reasonChanged.Add([ordered]@{
+                    identity        = $identity
+                    file            = [string]$candidateRecord.file
+                    baselineReason  = [string]$baselineRecord.reason
+                    candidateReason = [string]$candidateRecord.reason
+                }) | Out-Null
+            }
+        }
+    }
+
+    foreach ($identity in $baselineMap.Keys) {
+        $baselineRecord = $baselineMap[$identity]
+        $candidateRecord = if ($candidateMap.Contains($identity)) { $candidateMap[$identity] } else { $null }
+
+        $baselineFailing = script:Test-Pester6RecordIsFailing -Record $baselineRecord
+        $candidateFailing = script:Test-Pester6RecordIsFailing -Record $candidateRecord
+
+        if ($baselineFailing -and -not $candidateFailing) {
+            $resolved.Add([ordered]@{
+                identity        = $identity
+                file            = [string]$baselineRecord.file
+                baselineStatus  = [string]$baselineRecord.status
+                candidateStatus = if ($null -ne $candidateRecord) { [string]$candidateRecord.status } else { $null }
+            }) | Out-Null
+        }
+    }
+
+    # Identity drift: symmetric difference of identity keys, independent of
+    # status — this is the lens that catches a rename (old identity vanishes,
+    # new identity appears) that the failing/non-failing joins above would
+    # otherwise miss entirely (a rename between two Passed tests never
+    # touches newFailures/resolved).
+    $missingFromCandidate = [System.Collections.Generic.List[object]]::new()
+    foreach ($identity in $baselineMap.Keys) {
+        if (-not $candidateMap.Contains($identity)) {
+            $r = $baselineMap[$identity]
+            $file = [string]$r.file
+            $missingFromCandidate.Add([ordered]@{
+                identity           = $identity
+                file               = $file
+                baselineStatus     = [string]$r.status
+                expectedRenameFile = [bool]($KnownRenameFiles -contains $file)
+            }) | Out-Null
+        }
+    }
+
+    $newInCandidate = [System.Collections.Generic.List[object]]::new()
+    foreach ($identity in $candidateMap.Keys) {
+        if (-not $baselineMap.Contains($identity)) {
+            $r = $candidateMap[$identity]
+            $file = [string]$r.file
+            $newInCandidate.Add([ordered]@{
+                identity           = $identity
+                file               = $file
+                candidateStatus    = [string]$r.status
+                expectedRenameFile = [bool]($KnownRenameFiles -contains $file)
+            }) | Out-Null
+        }
+    }
+
+    $verdict = if ($newFailures.Count -eq 0 -and $reasonChanged.Count -eq 0) { 'Pass' } else { 'Fail' }
+    $verdictReason = if ($verdict -eq 'Pass') {
+        'newFailures and reasonChanged are both empty.'
+    }
+    else {
+        $parts = [System.Collections.Generic.List[string]]::new()
+        if ($newFailures.Count -gt 0) { $parts.Add("$($newFailures.Count) new failure(s)") | Out-Null }
+        if ($reasonChanged.Count -gt 0) { $parts.Add("$($reasonChanged.Count) reason-change(s) on already-red test(s)") | Out-Null }
+        ($parts -join '; ')
+    }
+
+    return [ordered]@{
+        verdict       = $verdict
+        verdictReason = $verdictReason
+        newFailures   = @($newFailures)
+        reasonChanged = @($reasonChanged)
+        resolved      = @($resolved)
+        identityDrift = [ordered]@{
+            missingFromCandidate = @($missingFromCandidate)
+            newInCandidate       = @($newInCandidate)
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-Pester6BaselineDelta
+# ---------------------------------------------------------------------------
+function Invoke-Pester6BaselineDelta {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$BaselinePath,
+
+        [Parameter(Mandatory)]
+        [string]$CandidatePath,
+
+        [string[]]$KnownRenameFiles = @(
+            'NamingRegisterLivingSurface.Tests.ps1',
+            'frame-predicate-never-identifier.Tests.ps1',
+            'migration-scan-enforcement.Tests.ps1',
+            'frame-credit-ledger-core.Tests.ps1',
+            'post-merge-cleanup.Tests.ps1',
+            'frame-credit-ledger-orchestrator.Tests.ps1'
+        ),
+
+        [string]$OutputJsonPath,
+
+        [string]$OutputMarkdownPath
+    )
+
+    $ErrorActionPreference = 'Continue'
+
+    if (-not (Test-Path -LiteralPath $BaselinePath -PathType Leaf)) {
+        Write-Error "BaselinePath not found: $BaselinePath"
+        return [pscustomobject]@{ ExitCode = 1; Result = $null }
+    }
+    if (-not (Test-Path -LiteralPath $CandidatePath -PathType Leaf)) {
+        Write-Error "CandidatePath not found: $CandidatePath"
+        return [pscustomobject]@{ ExitCode = 1; Result = $null }
+    }
+
+    try {
+        $baselineArtifact = Get-Content -LiteralPath $BaselinePath -Raw | ConvertFrom-Json
+        $candidateArtifact = Get-Content -LiteralPath $CandidatePath -Raw | ConvertFrom-Json
+    }
+    catch {
+        Write-Error "Failed to parse baseline/candidate JSON: $($_.Exception.Message)"
+        return [pscustomobject]@{ ExitCode = 1; Result = $null }
+    }
+
+    $baselineRecords = @($baselineArtifact.records)
+    $candidateRecords = @($candidateArtifact.records)
+
+    $delta = Compare-Pester6BaselineRecords -BaselineRecords $baselineRecords -CandidateRecords $candidateRecords -KnownRenameFiles $KnownRenameFiles
+
+    $result = [ordered]@{
+        baselinePath      = $BaselinePath
+        candidatePath     = $CandidatePath
+        baselineVersion   = [string]$baselineArtifact.requiredVersion
+        candidateVersion  = [string]$candidateArtifact.requiredVersion
+        baselineSummary   = $baselineArtifact.summary
+        candidateSummary  = $candidateArtifact.summary
+        verdict           = $delta.verdict
+        verdictReason     = $delta.verdictReason
+        newFailures       = $delta.newFailures
+        reasonChanged     = $delta.reasonChanged
+        resolved          = $delta.resolved
+        identityDrift     = $delta.identityDrift
+        comparedAt        = (Get-Date).ToUniversalTime().ToString('o')
+    }
+
+    if ($OutputJsonPath) {
+        $outDir = Split-Path -Parent $OutputJsonPath
+        if ($outDir -and -not (Test-Path -LiteralPath $outDir)) {
+            New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+        }
+        ($result | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $OutputJsonPath -Encoding UTF8
+    }
+
+    if ($OutputMarkdownPath) {
+        $outDir = Split-Path -Parent $OutputMarkdownPath
+        if ($outDir -and -not (Test-Path -LiteralPath $outDir)) {
+            New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+        }
+        $md = Get-Pester6BaselineDeltaMarkdown -Result $result
+        Set-Content -LiteralPath $OutputMarkdownPath -Value $md -Encoding UTF8
+    }
+
+    $exitCode = if ($delta.verdict -eq 'Pass') { 0 } else { 1 }
+    return [pscustomobject]@{ ExitCode = $exitCode; Result = $result }
+}
+
+# ---------------------------------------------------------------------------
+# Get-Pester6BaselineDeltaMarkdown — render the delta result as a PR-evidence
+# Markdown report.
+# ---------------------------------------------------------------------------
+function Get-Pester6BaselineDeltaMarkdown {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Result
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $verdictLabel = if ($Result.verdict -eq 'Pass') { 'PASS' } else { 'FAIL' }
+
+    $lines.Add('# Issue #818 s7 — Post-port acceptance delta verdict') | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add("**Verdict: $verdictLabel** — $($Result.verdictReason)") | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add("- Baseline: ``$($Result.baselinePath)`` (Pester $($Result.baselineVersion)) — total=$($Result.baselineSummary.totalTests) passed=$($Result.baselineSummary.passed) failed=$($Result.baselineSummary.failed) skipped=$($Result.baselineSummary.skipped) notRun=$($Result.baselineSummary.notRun) discoveryErrors=$($Result.baselineSummary.discoveryErrors)") | Out-Null
+    $lines.Add("- Candidate: ``$($Result.candidatePath)`` (Pester $($Result.candidateVersion)) — total=$($Result.candidateSummary.totalTests) passed=$($Result.candidateSummary.passed) failed=$($Result.candidateSummary.failed) skipped=$($Result.candidateSummary.skipped) notRun=$($Result.candidateSummary.notRun) discoveryErrors=$($Result.candidateSummary.discoveryErrors)") | Out-Null
+    $lines.Add("- Compared at: $($Result.comparedAt)") | Out-Null
+    $lines.Add('') | Out-Null
+
+    $lines.Add("## newFailures (AC1 violation set) — $(@($Result.newFailures).Count)") | Out-Null
+    $lines.Add('') | Out-Null
+    if (@($Result.newFailures).Count -eq 0) {
+        $lines.Add('_None._') | Out-Null
+    }
+    else {
+        foreach ($f in @($Result.newFailures)) {
+            $lines.Add("- ``$($f.identity)`` — $($f.status): $($f.reason)") | Out-Null
+        }
+    }
+    $lines.Add('') | Out-Null
+
+    $lines.Add("## reasonChanged (#566-laundering guard) — $(@($Result.reasonChanged).Count)") | Out-Null
+    $lines.Add('') | Out-Null
+    if (@($Result.reasonChanged).Count -eq 0) {
+        $lines.Add('_None._') | Out-Null
+    }
+    else {
+        foreach ($f in @($Result.reasonChanged)) {
+            $lines.Add("- ``$($f.identity)``") | Out-Null
+            $lines.Add("  - baseline reason: $($f.baselineReason)") | Out-Null
+            $lines.Add("  - candidate reason: $($f.candidateReason)") | Out-Null
+        }
+    }
+    $lines.Add('') | Out-Null
+
+    $lines.Add("## resolved (informational, never fails the gate) — $(@($Result.resolved).Count)") | Out-Null
+    $lines.Add('') | Out-Null
+    if (@($Result.resolved).Count -eq 0) {
+        $lines.Add('_None._') | Out-Null
+    }
+    else {
+        foreach ($f in @($Result.resolved)) {
+            $lines.Add("- ``$($f.identity)`` — $($f.baselineStatus) -> $($f.candidateStatus)") | Out-Null
+        }
+    }
+    $lines.Add('') | Out-Null
+
+    $missing = @($Result.identityDrift.missingFromCandidate)
+    $new = @($Result.identityDrift.newInCandidate)
+    $lines.Add("## identityDrift (informational) — $($missing.Count) missing, $($new.Count) new") | Out-Null
+    $lines.Add('') | Out-Null
+    $unexpectedMissing = @($missing | Where-Object { -not $_.expectedRenameFile })
+    $unexpectedNew = @($new | Where-Object { -not $_.expectedRenameFile })
+    if ($unexpectedMissing.Count -gt 0 -or $unexpectedNew.Count -gt 0) {
+        $lines.Add('**Unexpected drift outside the known s4 rename files — review individually:**') | Out-Null
+        foreach ($f in $unexpectedMissing) {
+            $lines.Add("- MISSING (was $($f.baselineStatus)): ``$($f.identity)``") | Out-Null
+        }
+        foreach ($f in $unexpectedNew) {
+            $lines.Add("- NEW (is $($f.candidateStatus)): ``$($f.identity)``") | Out-Null
+        }
+        $lines.Add('') | Out-Null
+    }
+    $expectedMissing = @($missing | Where-Object { $_.expectedRenameFile })
+    $expectedNew = @($new | Where-Object { $_.expectedRenameFile })
+    if ($expectedMissing.Count -gt 0 -or $expectedNew.Count -gt 0) {
+        $lines.Add('<details><summary>Expected drift from s4 It-name rephrasing</summary>') | Out-Null
+        $lines.Add('') | Out-Null
+        foreach ($f in $expectedMissing) {
+            $lines.Add("- MISSING (was $($f.baselineStatus)): ``$($f.identity)``") | Out-Null
+        }
+        foreach ($f in $expectedNew) {
+            $lines.Add("- NEW (is $($f.candidateStatus)): ``$($f.identity)``") | Out-Null
+        }
+        $lines.Add('') | Out-Null
+        $lines.Add('</details>') | Out-Null
+    }
+
+    return ($lines -join "`n")
+}

--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -12,15 +12,18 @@ jobs:
       - name: Install Pester
         shell: pwsh
         run: |
-          # Pin to the 5.x line. `-Force -MinimumVersion 5.0.0` alone pulls the
-          # newest available major, which as of 2026-07 is Pester 6.0.0 — a
-          # breaking major (unmatched Mocks throw instead of falling through to
-          # the underlying command) that this suite, authored against Pester 5's
-          # mock model, is not migrated to. The `-MaximumVersion` cap keeps CI on
-          # the framework version the suite is validated against. Pester 6
-          # migration is tracked separately in issue #818.
-          Install-Module -Name Pester -Force -SkipPublisherCheck -MinimumVersion 5.0.0 -MaximumVersion 5.999.999
-          Import-Module Pester -MaximumVersion 5.999.999
+          # This suite is validated against Pester 6.0.0. The window below
+          # (`-MinimumVersion 6.0.0 -MaximumVersion 6.999.999`) holds CI on
+          # that major while floating patches/minors within it, so routine
+          # releases never require a workflow edit. `-Force -MinimumVersion`
+          # alone pulls the newest available major, which is a breaking-change
+          # risk (Pester 6 itself broke unmatched-Mock fall-through behavior
+          # relative to 5.x); the `-MaximumVersion` ceiling prevents CI from
+          # silently jumping majors again. Both the floor and the ceiling are
+          # bumped together, deliberately, on the next major migration — issue
+          # #818 is the precedent for how that migration is done.
+          Install-Module -Name Pester -Force -SkipPublisherCheck -MinimumVersion 6.0.0 -MaximumVersion 6.999.999
+          Import-Module Pester -MinimumVersion 6.0.0 -MaximumVersion 6.999.999
           Install-Module -Name powershell-yaml -Force -SkipPublisherCheck
       - name: Run Pester tests (issue #243 audit-paths drift gate + grammar + safety)
         shell: pwsh
@@ -58,7 +61,11 @@ jobs:
             '.github/scripts/Tests/naming-register-policy.Tests.ps1',
             # reporting-economy directive gate — registered per d-ci-gate-registration (#471)
             '.github/scripts/Tests/reporting-economy.Tests.ps1',
-            '.github/scripts/Tests/reporting-economy-spotcheck.Tests.ps1'
+            '.github/scripts/Tests/reporting-economy-spotcheck.Tests.ps1',
+            # Pester mock fall-through guard — issue #818 s6 (d-dead-filter-tripwire-v2)
+            '.github/scripts/Tests/pester-mock-fallthrough-guard.Tests.ps1',
+            # Post-port acceptance delta-gate core — issue #818 s7
+            '.github/scripts/Tests/pester6-baseline-delta-core.Tests.ps1'
           )
           $config.Run.Exit = $true
           $config.Output.Verbosity = 'Detailed'

--- a/Documents/Design/pester-6-migration.md
+++ b/Documents/Design/pester-6-migration.md
@@ -1,0 +1,90 @@
+# Pester 5→6 Migration
+
+**Date**: 2026-07-09
+**Issue**: #818 — CI: migrate Pester test suite to 6.x (pinned to 5.x as interim)
+**Purpose**: Unpin `.github/workflows/pester.yml` from the Pester 5.x hold-pin to a 6.x major-version window, port every test file that relied on Pester 5's removed mock fall-through behavior, and add a standing guard so the fall-through anti-pattern cannot silently regress.
+
+---
+
+## Problem
+
+Pester 6 changed unmatched-`Mock` behavior: when a `Mock <cmd> -ParameterFilter {...}` is active and a call matches no filter, Pester 6 **throws** instead of Pester 5's silent fall-through to the underlying command. `.github/workflows/pester.yml` originally installed Pester with `-MinimumVersion 5.0.0` and no ceiling, which auto-resolved to 6.0.0 as soon as it shipped and turned the `pester` CI check red on every open PR (PR #815 CI triage).
+
+The deeper issue is not just breakage — it is honesty. Several tests in this repo relied on Pester 5's fall-through to pass: a test defines a `global:<cmd>` catch-all function, layers a narrow `Mock <cmd> -ParameterFilter {...}` on top, and the assertion the author believes ran (the narrow, filtered path) never actually ran because the filter was dead — the call fell through to the catch-all and the test still went green by coincidence. The confirmed instance: `code-review-deferral-integration.Tests.ps1`'s "integrated routed:defer path" test had a filter `{ $args[0] -eq 'issue' }` that never bound, because `gh` is a mocked function whose remaining args land in `$RemainingArgs`, not the automatic `$args`. `pester ✓` did not mean what contributors believed it meant.
+
+PR #815 shipped an interim `-MaximumVersion 5.999.999` hold-pin to restore green CI. This document records the migration that replaces that hold with a durable fix: port the suite, unpin to a 6.x window, and add a guard that makes the honesty property a standing, machine-checked contract rather than a one-time cleanup.
+
+Full history, the customer framing, and the full adversarial-review trail live on [issue #818](https://github.com/Grimblaz/agent-orchestra/issues/818); the `<!-- plan-issue-818 -->` comment carries the approved 7-step plan, Verification Evidence, and Named Decisions.
+
+## Implemented Surface
+
+| File | Role |
+| --- | --- |
+| `.github/workflows/pester.yml` | Install/Import lines carry the `-MinimumVersion 6.0.0 -MaximumVersion 6.999.999` window (both lines); guard registered in the CI-scoped run list |
+| `.github/scripts/Tests/pester-mock-fallthrough-guard.Tests.ps1` | New standing guard — 3-clause contract (D2 below) |
+| `.github/scripts/capture-pester6-baseline.ps1` + `.github/scripts/lib/pester6-baseline-core.ps1` | One-time baseline-capture tooling (D3 below) |
+| `.github/scripts/compare-pester6-baseline.ps1` + `.github/scripts/lib/pester6-baseline-delta-core.ps1` | One-time acceptance delta-gate tooling (D3 below) |
+| 6 ported test files (see D1) | Layered-mock porting idiom applied per-site |
+| 2 non-mock discovery fixes (see D1) | Break-class fixes found via baseline diffing |
+
+## Design Decisions
+
+### D1 — Porting idiom: layered Pester-native mocks, per-site not mechanical
+
+Each fall-through-reliant site ports to Pester 6's official idiom: one default (unfiltered) `Mock <cmd>` that reproduces the old catch-all's dispatch logic, plus narrow `-ParameterFilter` mocks layered on top for per-test overrides. The port was deliberately **per-site**, not a mechanical find-replace, because two classes of latent bugs only surface when a human reads what the filter was actually meant to intercept:
+
+1. **Filter predicate narrowing.** A filter like `{ $args[0] -eq 'issue' }` is too broad if it was meant to intercept `issue view --json body` specifically — a broad filter also matches unrelated calls (e.g. `Add-FollowUpIssue`'s `issue create` or its `--json id` node-lookup call) and produces new, different dead-filter bugs even after the syntax is "fixed."
+2. **Remaining-args rebinding.** The suite mocks functions whose actual parameter name varies: `$Args` (~55 sites), `$ghArgs` (12 sites), `$RemainingArgs` (4 sites) — not the automatic `$args`, which those functions never populate. Capital `$Args` also shadows the automatic `$args`, so a hardcoded rename manufactures new dead filters instead of fixing the existing ones. Native-command mocks (no wrapping function) keep `$args`.
+
+Two porting tiers applied, driven by the migration-scan's per-file throw-condition classification (whether the code-under-test ever makes a call that would actually miss the filter):
+
+- **Behavior-preserving ports** (2 files: `code-review-deferral-integration.Tests.ps1`, `cost-walker.Tests.ps1`) — the default mock body must reproduce the prior fall-through behavior exactly (fixture delegation, `$LASTEXITCODE` side effects, call-through to the real cmdlet where a test depends on real behavior), because the code-under-test genuinely relies on multiple call shapes hitting the mock.
+- **Guard-coherence-only ports** (4 files: `Get-AcTermsFromIssue.Tests.ps1`, `frame-validate.Tests.ps1`, `quick-validate.Tests.ps1`, `cost-walker-copilot.Tests.ps1`) — the code-under-test only ever makes calls that match the existing filter, so no behavior rewrite was needed; these files took only the guard-coherence edit (a default mock, or an allowlist entry) plus sound invoke-pairing.
+
+The same audit also found two **non-mock** break-class bugs via baseline diffing rather than static scan: `create-improvement-issue.Tests.ps1` had a hard Pester-version pin, and `frame-audit-report.Tests.ps1` had a `BeforeAll`/`BeforeDiscovery` timing bug. Several more files received mechanical fixes for empty `-ForEach`/`-TestCases` coverage guards and unpaired `<...>` name tokens.
+
+### D2 — Standing guard: sound invoke-pairing (supersedes the design-phase mechanism)
+
+`.github/scripts/Tests/pester-mock-fallthrough-guard.Tests.ps1` is a new meta-test, modeled on `script-safety-contract.Tests.ps1`'s precedent (AST-based scan — not text/regex over source — a centralized `$allowlist` with per-entry justification, self-exclusion, and falsifiability fixtures), registered in `pester.yml`'s CI-scoped run list. It enforces three clauses:
+
+1. **Fall-through shape.** Any command with ≥1 filtered `Mock -ParameterFilter` and no same-file default (unfiltered) `Mock` is flagged, unless the `(File, Command)` site is allowlisted. This fires regardless of whether a `global:<cmd>` catch-all is present, because ~166 of the repo's 186 test files never run in CI — static coverage is the only signal available for files outside the run list.
+2. **Sound invoke-pairing.** This is the load-bearing decision `d-dead-filter-tripwire-v2`, which **supersedes** the design-phase decision `d-dead-filter-tripwire`. The design-phase mechanism required only that a filtered `Mock -ParameterFilter {F}` be paired, somewhere in the same file, with *any* `Should -Invoke` on the same command. Plan stress-test finding M3 proved this unsound: `Should -Invoke` evaluates its *own* filter argument independently of the `Mock`'s filter, so a `Should -Invoke <cmd> -ParameterFilter {F'}` with a *different, correct* filter `F'` passes cleanly even while the `Mock`'s own filter `F` never matched a single call — the dead filter stays dead and undetected. The shipped v2 mechanism requires the pairing to use a **textually identical** (whitespace-normalized) filter and asserts `-Times N` with `N >= 1`: `Mock <cmd> -ParameterFilter {F}` must pair, in the same file, with `Should -Invoke <cmd> -Times N (N>=1) -ParameterFilter {F}` (the same `F`, not a different filter for the same command). Because a dead `Mock` filter matches zero calls, its identically-filtered `Should -Invoke -Times >=1` assertion necessarily fails — the dead filter can no longer hide behind an unrelated, correctly-filtered assertion. The escape hatch is a justified allowlist entry at **per-mock-site** (`File` + `Command`) granularity; one allowlist exempts a site from both clause 1 and clause 2 rather than inventing two exemption mechanisms.
+3. **Version-window, fail-loud.** The validated Pester major is derived from `pester.yml`'s `Install-Module` line `-MinimumVersion` floor (single source of truth). Both the `Install-Module` and `Import-Module` lines must carry a `-MaximumVersion` whose major equals that floor, and the floor major must be ≥ 6. If the pin cannot be located or parsed, the guard fails loudly (a named test failure) rather than silently reporting a pass.
+
+**Known non-blocking limitations** (raised in adversarial code review, judge-ruled sustained-but-non-blocking, documented here as known scope for future maintainers rather than fixed in this PR):
+
+- **File-scope, not Pester-scope, grouping.** Clauses 1 and 2 group `Mock`/`Should -Invoke` sites by command name across the *entire file's* AST, not per `Describe`/`Context` block. A file with multiple independent scopes that each mock the same command differently is evaluated as one combined group — the guard cannot distinguish "this scope's filtered mock is dead" from "some other scope in the file happens to have a matching default or pairing."
+- **Major-only version-window check.** Clause 3 validates only that the major version component matches across floor/cap and meets the ≥6 floor; it does not re-validate on every 6.x minor/patch release. This is deliberate — see D4's acceptance of intra-major semver drift — but means the guard would not catch a 6.x minor introducing new breaking mock semantics.
+
+### D3 — One-time baseline/delta acceptance-gate tooling (not standing CI)
+
+AC1's "zero new failures under 6.x" acceptance criterion needed to be executable and machine-checked rather than eyeballed, because the full 186-file suite has pre-existing failures owned by #566 that must not be silently absorbed into or laundered through this migration. Two new script pairs, both following the repo's lib+wrapper+Pester-tests Script Library Convention, deliver this:
+
+- **`capture-pester6-baseline.ps1` + `lib/pester6-baseline-core.ps1`** — runs the full suite under an explicit, mandatory `-RequiredVersion` (never "newest installed") and captures **per-test identity** (full `Describe > Context > It` path) plus **failure reason** for every non-passing test. `-ForEach`/`-TestCases` instances whose own name doesn't vary with their case data would otherwise collapse to duplicate identities in the result set — a real bug found and fixed during code review (not present in the original plan) — so the capture tool disambiguates only the colliding groups with a synthetic `[instance N of M]` ordinal suffix, leaving every already-unique identity untouched.
+- **`compare-pester6-baseline.ps1` + `lib/pester6-baseline-delta-core.ps1`** — diffs a baseline artifact against a candidate artifact at test-identity level and computes `newFailures` (AC1 violations) and `reasonChanged` (the **#566-laundering guard**: a test that is failing in both the baseline and the candidate, but for a *different reason*, would otherwise silently pass a naive identity-only diff while actually representing a new, unrelated defect masquerading as a pre-existing one). The verdict is PASS iff both sets are empty.
+
+Both tools are **one-time acceptance-evidence tooling for this migration, not standing CI infrastructure** — they are deliberately not registered in `pester.yml` and their output artifacts live under `.tmp/issue-818/`, not `Documents/Design/` (an earlier plan draft proposed committing baseline JSON under `Documents/Design/`; that was corrected before implementation, and the corrected path is documented directly in the wrapper scripts' own parameter docs).
+
+### D4 — Unpin shape: major-version window, not a floor-only unpin
+
+`pester.yml`'s `Install-Module` and `Import-Module` lines both carry `-MinimumVersion 6.0.0 -MaximumVersion 6.999.999`, with a rewritten comment block naming the contract: floor = validated major, cap = next breaking major, both bumped together deliberately on the next major migration. A floor-only unpin (`-MinimumVersion 6.0.0`, no cap) was rejected — it would re-run this exact incident on Pester 7's release day. Intra-major (6.x minor/patch) drift is accepted as ordinary semver trust, consistent with the repo's existing unpinned `powershell-yaml` install; an intra-major re-validation gate was considered and dismissed as over-engineering against this posture.
+
+## Rejected Alternatives
+
+- **Bare invoke-pairing (any `Should -Invoke` on the same command, any filter)** — the design-phase mechanism, proven unsound at plan stress-test (M3) and superseded by D2's identical-filter + `-Times ≥1` requirement.
+- **Fold all behavior into `global:` functions with no `Mock` layering** — loses `Should -Invoke` assertion integration, which the sound invoke-pairing rule depends on.
+- **Per-subcommand explicit filtered mocks covering every call, no default layer** — verbose, brittle, and still throws on any missed call; the default-mock layer is strictly safer.
+- **Docs-only convention or runtime-throw-only guard** — an unenforced convention erodes over time, and a runtime throw never fires in CI for the ~166 files outside the CI-scoped run list; a default mock would silence the throw entirely for those files (the exact gap the escalated finding F3 identified).
+- **Full-suite green under 6.x, absorbing #566** — multiplies scope with work unrelated to the Pester migration; delta-neutral acceptance keeps #566 as the pre-existing-failure home.
+- **Floor-only unpin** — see D4.
+- **Scattered suppression comments for guard exceptions** — no audit chokepoint; the centralized, per-entry-justified `$allowlist` follows the `script-safety-contract.Tests.ps1` precedent instead.
+
+## Verification Evidence
+
+Full 186-file suite, identical counts under both Pester 5.7.1 and 6.0.0 post-port: total=3417, passed=3388, failed=1, skipped=28, discoveryErrors=0. The 1 remaining failure is `credit-input-marker-roundtrip.Tests.ps1`'s pre-existing #566-owned `--paginate` issue, unchanged before and after the migration. CI-scoped 22-file run list: 430/430 green under 6.0.0. The post-port delta gate (D3) verdict is **PASS** — zero new failures, zero reason-changes.
+
+Adversarial code review (standard 5-pass prosecution → defense → judge pipeline) found 15 findings, 7 sustained, 4 requiring fixes before merge: an `-ForEach` identity-collapse gap in the baseline tooling (with a second-round fix after the first attempt proved incomplete for non-parameterized `-ForEach` names — see D3), an unquoted `Start-Process` argument that broke on spaced paths, and 2 missed/introduced unpaired `<...>` name tokens. The remaining 3 sustained findings were documentation nits.
+
+## Source of Truth
+
+This document records the design shipped for issue #818. The implementation source of truth is `.github/workflows/pester.yml`, `.github/scripts/Tests/pester-mock-fallthrough-guard.Tests.ps1`, and the ported test files themselves. Full decision history, the design-phase adversarial challenge (12 sustained findings), and the plan-phase stress-test (17 sustained findings, including the `d-dead-filter-tripwire` → `d-dead-filter-tripwire-v2` supersession) live on [issue #818](https://github.com/Grimblaz/agent-orchestra/issues/818).


### PR DESCRIPTION
## Summary

Migrates the `.github/scripts/Tests/` Pester suite from a Pester 5.x hold-pin to a 6.x major-version window, ports every test file that relied on Pester 5's removed mock fall-through, and adds a standing guard meta-test so the mock-honesty regression this issue exists to fix cannot silently recur.

Full design/plan/review history ΓÇö customer framing, design decisions, the approved 7-step plan, and the full adversarial-review trail (design-challenge 12 findings, plan-stress-test 17 findings, code-review 15 findings) ΓÇö lives on [issue #818](https://github.com/Grimblaz/agent-orchestra/issues/818).

## What changed

- **6 mock-fallthrough files ported** to Pester 6's layered-mock idiom (default mock + narrowed filter + sound invoke-pairing): 2 behavior-preserving ports (`code-review-deferral-integration.Tests.ps1`, `cost-walker.Tests.ps1`), 4 guard-coherence-only (`Get-AcTermsFromIssue.Tests.ps1`, `frame-validate.Tests.ps1`, `quick-validate.Tests.ps1`, `cost-walker-copilot.Tests.ps1`).
- **Non-mock break-class fixes**: 2 discovery-time throws found via baseline diffing rather than static scan (`create-improvement-issue.Tests.ps1`'s hard version pin, `frame-audit-report.Tests.ps1`'s `BeforeAll`/`BeforeDiscovery` timing bug), plus empty-`-ForEach` coverage guards and unpaired `<...>` name-token fixes across several more files.
- **`.github/workflows/pester.yml`** unpinned to `-MinimumVersion 6.0.0 -MaximumVersion 6.999.999` on both Install-Module and Import-Module lines ΓÇö a deliberate major-ceiling remains by design (`d-unpin-shape`).
- **New standing guard** ΓÇö `.github/scripts/Tests/pester-mock-fallthrough-guard.Tests.ps1`: 3 clauses (fall-through-shape AST scan, sound invoke-pairing via identical-filter + `-Times ΓëÑ1`, version-window fail-loud), falsifiability fixtures, centralized justified allowlist. Registered in the CI-scoped list.
- **New one-time acceptance-evidence tooling** (not standing CI infra): `capture-pester6-baseline.ps1` + `lib/pester6-baseline-core.ps1` (version-pinned, per-test-identity full-suite capture) and `compare-pester6-baseline.ps1` + `lib/pester6-baseline-delta-core.ps1` (reason-aware delta gate distinguishing genuine new failures from pre-existing #566-owned ones).
- **Design doc**: `Documents/Design/pester-6-migration.md`.

## Validation evidence

- **CI-scoped 22-file run list**: 430/430 passed under Pester 6.0.0.
- **Full 186-file suite**, identical counts under both Pester 5.7.1 and 6.0.0 post-port: `total=3417 passed=3388 failed=1 skipped=28 discoveryErrors=0`. The 1 remaining failure is `credit-input-marker-roundtrip.Tests.ps1`'s pre-existing #566-owned `--paginate` issue ΓÇö unchanged before and after this migration.
- **Post-port delta gate**: **PASS** ΓÇö 0 new failures, 0 reason-changes, 0 identity drift.
- **Migration completeness scan**: clean (no remaining `5.x`-only Pester CI pins, no remaining dead `$args[0]` Mock filter patterns).

## Review Mode

Standard 5-pass adversarial review (2 generalist + 3 specialist) ΓåÆ defense ΓåÆ judge.

## Adversarial Review Score Table

| Finding | Severity | Ruling | Fix |
|---|---|---|---|
| M1 ΓÇö `-ForEach` identity collapse in new baseline tooling | high | sustained | Fixed (2 rounds ΓÇö see below) |
| M2 ΓÇö missed/introduced unpaired `<...>` name tokens | low | sustained | Fixed |
| M3 ΓÇö guard's file-scope (not Pester-scope) mock grouping | low | sustained | Documented as known limitation (non-blocking) |
| M5 ΓÇö unquoted `Start-Process` argument breaks on spaced paths | medium | sustained | Fixed |
| M7 ΓÇö `Test-Path` call-through mock drops non-`-LiteralPath` params | low | sustained | Documented as latent trap (non-blocking) |
| M11 ΓÇö clause-2 filter normalization misses brace-adjacent whitespace | low | sustained | Documented as follow-up (non-blocking, fail-safe direction) |
| M15 ΓÇö 3 documentation nits (stale comment, path round-trip, misleading variable name) | low | sustained | Fixed |
| M4, M6, M8, M9, M10, M12, M13, M14 | low | defense-sustained | No fix required (real facts, deliberate/fail-safe/unreachable) |

**Prosecution depth**: 5-pass panel (sonnet + fable generalists, 3├ù opus specialists) ΓåÆ 23 raw findings ΓåÆ merged to 15 ΓåÆ defense (opus) ΓåÆ judge (fable). M1's fix required a second round after the first attempt (expanded-name identity) proved incomplete for `-ForEach` cases whose `It` name doesn't reference its own case data (`branch-authority-gate.Tests.ps1`) ΓÇö resolved with a synthetic per-instance ordinal tiebreaker, re-verified with 0 duplicate identity groups (down from 81) and a clean delta-gate PASS.

## CE Gate

**Surface**: CLI/CI (`pester` GitHub Actions check).

| ID | Type | Class | Result | Evidence | Source | Evidence Type |
|---|---|---|---|---|---|---|
| S1 | Functional | auto | PASS | CI-scoped list green under unpinned 6.x (430/430) | Experience-Owner (live re-run) | live-interaction |
| S2 | Intent | manual | PASS | Dead filter under default mock caught by sound invoke-pairing, not passed silently ΓÇö fixture source read + live-verified | Experience-Owner | live-interaction |
| S3 | Functional | auto | PASS | Every ported filter's paired `Should -Invoke` proves binding (31 filtered mocks confirmed non-vacuously covered) | Experience-Owner | live-interaction |

`Γ£à CE Gate passed ΓÇö intent match: strong` ΓÇö all scenarios passed, no defects found, design intent fully achieved.

## Process gaps found

- ΓÜá∩╕Å **L2 gate-skip reconciliation** (warn-only) flagged 6 decision_ids (`d-honesty-regression-guard`, `d-ac1-scope-interpretation`, `d-unpin-shape`, `d-guard-mechanism`, `design-challenge-818-F3`, `plan-stress-818-M3`) as "load-bearing 'asked' token has no corresponding recorded decision." All 6 were genuinely asked and recorded in this session's `engagement-record-*-818` comments ΓÇö this reads as a matching/lookup gap in `gate-reconciliation-core.ps1`, not a real process violation. Non-blocking; flagged for investigation as a follow-up.
- ΓÜá∩╕Å **newcomer-audit lane FAILED TO RUN** ΓÇö `skills/naming-register-policy/scripts/newcomer-audit.ps1` does not exist in this repo checkout (the skill directory has no `scripts/` subdirectory at all, only `SKILL.md`/`assets`/`schemas`). Findings unknown, treat as unaudited. Non-blocking per the gate's fail-open contract; pre-existing repo gap, out of scope for #818.

Closes #818

<!-- pipeline-metrics
pr_number: 818
branch: feature/issue-818-pester-6-migration
metrics_version: 4
frame_version: 1
credits:
  - port: experience
    adapter: work-adapter
    status: passed
    evidence: 'issue #818; experience completion marker posted'
  - port: design
    adapter: work-adapter
    status: passed
    evidence: 'issue #818; design completion marker posted'
  - port: plan
    adapter: work-adapter
    status: passed
    evidence: 'issue #818; plan completion marker posted'
  - port: orchestration
    adapter: scope-classification
    status: passed
    evidence: 'issue #818; scope-classification announced (deterministic rubric)'
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Pester 6 baseline capture and comparison tools for test validation.
  * Introduced a new guard test to catch mock fall-through and invocation mismatches.
  * Expanded CI to run the new Pester 6-related test suites.

* **Bug Fixes**
  * Improved test coverage and failure detection so missing or empty fixture sets no longer pass silently.
  * Strengthened several existing tests to better verify expected command usage and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->