### PR TITLE
fix(#800): Set-IssueParent.ps1 attach-existing primitive + OrphanClaimWarnings orphan-drift detector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-agent workflow system. Pipeline-based agent orchestration: Issue -> Design -> Plan -> Implement -> Review -> PR.",
-    "version": "3.3.6"
+    "version": "3.3.7"
   },
   "plugins": [
     {
       "name": "agent-orchestra",
       "source": "./",
       "description": "Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-      "version": "3.3.6",
+      "version": "3.3.7",
       "author": {
         "name": "Grimblaz"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestra",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "agents": [
     "./agents/code-conductor.md",
     "./agents/code-critic.md",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent-orchestra",
   "metadata": {
     "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot",
-    "version": "3.3.6"
+    "version": "3.3.7"
   },
   "owner": {
     "name": "Grimblaz"
@@ -12,7 +12,7 @@
       "name": "agent-orchestra",
       "source": ".",
       "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system for GitHub Copilot with 16 specialized agents, a shared skill library, and pipeline orchestration.",
-      "version": "3.3.6"
+      "version": "3.3.7"
     }
   ]
 }

--- a/.github/scripts/Tests/Set-IssueParent.Tests.ps1
+++ b/.github/scripts/Tests/Set-IssueParent.Tests.ps1
@@ -70,6 +70,10 @@ Describe 'Set-IssueParent' {
             $joined | Out-File -FilePath $global:SipLogFile -Append -Encoding UTF8
             $global:SipGhCallCount++
 
+            if ($joined -match 'repo\s+view') {
+                $global:LASTEXITCODE = 0
+                return 'Grimblaz/agent-orchestra'
+            }
             if ($joined -match 'api\s+graphql') {
                 $fIdx = [array]::IndexOf($RemainingArgs, '-f')
                 $queryArg = if ($fIdx -ge 0 -and $fIdx + 1 -lt $RemainingArgs.Count) { $RemainingArgs[$fIdx + 1] } else { '' }
@@ -101,6 +105,10 @@ Describe 'Set-IssueParent' {
                 }
             }
             if ($joined -match 'issue\s+view\s+\d+\s+--json\s+id\s+--jq\s+\.id') {
+                if ($global:SipParentViewFail) {
+                    $global:LASTEXITCODE = 1
+                    return $null
+                }
                 $global:LASTEXITCODE = 0
                 return "I_parent_$($global:SipTestParent)"
             }
@@ -131,6 +139,7 @@ Describe 'Set-IssueParent' {
         $global:SipCapturedEditBody = $null
         $global:SipMockChildBody = 'Some existing body text.'
         $global:SipMockChildParentNumber = $null
+        $global:SipParentViewFail = $false
         $global:LASTEXITCODE = 0
     }
 
@@ -233,6 +242,19 @@ Describe 'Set-IssueParent' {
             $global:SipCapturedEditBody | Should -Not -BeNullOrEmpty
             $global:SipCapturedEditBody | Should -Not -Match ([regex]::Escape('<!-- parent-link-mode: text-fallback -->'))
             $global:SipCapturedEditBody | Should -Not -Match "(?m)^Parent: #$($global:SipTestParent)$"
+        }
+    }
+
+    Context 'Parent-resolution failure (M13)' {
+        It 'exits non-zero via the "addSubIssue prerequisite failed" path when the parent pre-check (gh issue view) fails and parentId resolves to null' {
+            $global:SipParentViewFail = $true
+
+            $output = & $script:ScriptFile -ParentIssueNumber $global:SipTestParent -ChildIssueNumber $global:SipTestChild 2>&1
+
+            $LASTEXITCODE | Should -Not -Be 0
+            $global:SipAddSubIssueCallCount | Should -Be 0
+            ($output | Out-String) | Should -Match 'addSubIssue prerequisite failed' `
+                -Because 'a failed gh issue view parent pre-check must resolve parentId to null and hit the addSubIssue prerequisite failed error path, not the GraphQL mutation retry path'
         }
     }
 

--- a/.github/scripts/Tests/Set-IssueParent.Tests.ps1
+++ b/.github/scripts/Tests/Set-IssueParent.Tests.ps1
@@ -1,0 +1,248 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Pester coverage for skills/safe-operations/scripts/Set-IssueParent.ps1
+    (plan-issue-800 s2, AC1/AC2/AC4).
+
+.DESCRIPTION
+    Unlike Add-FollowUpIssue.ps1 (which is dot-sourced for its exported
+    functions and never calls `exit`), Set-IssueParent.ps1 is a standalone
+    top-level script that calls `exit 0` / `exit 1` directly. Dot-sourcing a
+    script with top-level `exit` merges scopes and terminates the *calling*
+    process (this would kill the Pester runner). Invoking it via the call
+    operator (`& $ScriptFile @params`) instead only exits that script's own
+    invocation and leaves `$LASTEXITCODE` set correctly in the caller -
+    verified empirically before writing this suite.
+
+    `gh` is mocked via a `function global:gh` shim (as in
+    Add-FollowUpIssue.Tests.ps1), because global functions remain visible to
+    a call-operator-invoked script in the same process. All mock STATE uses
+    `$global:` (not `$script:`) variables, including inside the `gh` mock
+    body itself. This was verified necessary empirically: `$script:` inside
+    a `function global:name` resolves *dynamically* to whichever .ps1
+    file's script scope is currently executing on the call stack, not
+    lexically to the scope where the function was defined. Since the mock
+    runs while Set-IssueParent.ps1 (a different script file) is executing
+    on the call stack, `$script:` references inside the mock silently
+    resolved to Set-IssueParent.ps1's own (empty) script scope instead of
+    this test file's Pester-module scope, making state invisible in both
+    directions. `$global:` has no such ambiguity.
+
+    Mis-invocation coverage (PF20) intentionally never invokes the script
+    with a missing mandatory parameter - that can prompt-hang a non-
+    interactive host. Instead it asserts mandatory-ness via `Get-Command`
+    parameter metadata.
+#>
+
+Describe 'Set-IssueParent' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:ScriptFile = Join-Path $script:RepoRoot 'skills/safe-operations/scripts/Set-IssueParent.ps1'
+
+        if (-not (Test-Path $script:ScriptFile)) {
+            throw "Set-IssueParent.ps1 not found at $script:ScriptFile"
+        }
+
+        # Temporary directory for the physical gh-call log.
+        $global:SipTempDir = Join-Path ([System.IO.Path]::GetTempPath()) "gh-mock-setparent-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $global:SipTempDir -Force | Out-Null
+        $global:SipLogFile = Join-Path $global:SipTempDir 'gh-call.log'
+
+        # Fixed test issue numbers used across all scenarios.
+        $global:SipTestParent = 610
+        $global:SipTestChild = 999
+
+        # --- gh mock -----------------------------------------------------
+        # Distinguishes the three `gh api graphql` call shapes used by the
+        # script by inspecting the `-f "query=..."` payload:
+        #   * contains "addSubIssue"      -> the attach mutation
+        #   * otherwise                   -> the child id/body/parent pre-check
+        # `gh issue edit ... --body X` mutates $global:SipMockChildBody so a
+        # second invocation's pre-check reflects the prior run's write -
+        # required for the repeated-failure idempotency scenario.
+        #
+        # All state below is $global: (never $script:) - see file header.
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$RemainingArgs)
+            $joined = $RemainingArgs -join ' '
+            $joined | Out-File -FilePath $global:SipLogFile -Append -Encoding UTF8
+            $global:SipGhCallCount++
+
+            if ($joined -match 'api\s+graphql') {
+                $fIdx = [array]::IndexOf($RemainingArgs, '-f')
+                $queryArg = if ($fIdx -ge 0 -and $fIdx + 1 -lt $RemainingArgs.Count) { $RemainingArgs[$fIdx + 1] } else { '' }
+
+                if ($queryArg -match 'addSubIssue') {
+                    $global:SipAddSubIssueCallCount++
+                    $global:SipGraphqlAttempt++
+                    if ($global:SipGraphqlFailAll) {
+                        $global:LASTEXITCODE = 1
+                        return $null
+                    }
+                    $global:LASTEXITCODE = 0
+                    return '{"data":{"addSubIssue":{"issue":{"title":"Child"}}}}'
+                } else {
+                    # Child pre-check: id / body / parent { number }.
+                    $global:LASTEXITCODE = 0
+                    $respObj = [ordered]@{
+                        data = [ordered]@{
+                            repository = [ordered]@{
+                                issue = [ordered]@{
+                                    id     = "I_child_$($global:SipTestChild)"
+                                    body   = $global:SipMockChildBody
+                                    parent = if ($null -eq $global:SipMockChildParentNumber) { $null } else { [ordered]@{ number = $global:SipMockChildParentNumber } }
+                                }
+                            }
+                        }
+                    }
+                    return ($respObj | ConvertTo-Json -Depth 10 -Compress)
+                }
+            }
+            if ($joined -match 'issue\s+view\s+\d+\s+--json\s+id\s+--jq\s+\.id') {
+                $global:LASTEXITCODE = 0
+                return "I_parent_$($global:SipTestParent)"
+            }
+            if ($joined -match 'issue\s+edit') {
+                $idx = [array]::IndexOf($RemainingArgs, '--body')
+                if ($idx -ge 0 -and $idx + 1 -lt $RemainingArgs.Count) {
+                    $global:SipCapturedEditBody = $RemainingArgs[$idx + 1]
+                    $global:SipEditCallCount++
+                    # Simulate persistence so a subsequent invocation's
+                    # pre-check reads back this run's write.
+                    $global:SipMockChildBody = $global:SipCapturedEditBody
+                }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+            $global:LASTEXITCODE = 0
+            return ''
+        }
+    }
+
+    BeforeEach {
+        if (Test-Path $global:SipLogFile) { Remove-Item $global:SipLogFile -Force }
+        $global:SipGhCallCount = 0
+        $global:SipGraphqlAttempt = 0
+        $global:SipGraphqlFailAll = $false
+        $global:SipAddSubIssueCallCount = 0
+        $global:SipEditCallCount = 0
+        $global:SipCapturedEditBody = $null
+        $global:SipMockChildBody = 'Some existing body text.'
+        $global:SipMockChildParentNumber = $null
+        $global:LASTEXITCODE = 0
+    }
+
+    AfterAll {
+        if (Get-Command gh -ErrorAction SilentlyContinue) {
+            Remove-Item Function:\gh -ErrorAction SilentlyContinue
+        }
+        if (Test-Path $global:SipTempDir) {
+            Remove-Item -Recurse -Force $global:SipTempDir -ErrorAction SilentlyContinue
+        }
+        Remove-Variable -Name Sip* -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    Context 'Success' {
+        It 'attaches the child via addSubIssue and exits 0 when the child has no existing parent' {
+            & $script:ScriptFile -ParentIssueNumber $global:SipTestParent -ChildIssueNumber $global:SipTestChild
+
+            $LASTEXITCODE | Should -Be 0
+            $global:SipAddSubIssueCallCount | Should -Be 1
+        }
+    }
+
+    Context 'Mis-invocation (PF20)' {
+        # PF20: never invoke the script with a missing mandatory param - that
+        # can prompt-hang a non-interactive host. Assert mandatory-ness via
+        # Get-Command parameter metadata instead.
+        BeforeAll {
+            $script:Cmd = Get-Command $script:ScriptFile
+        }
+
+        It 'declares ParentIssueNumber as a mandatory parameter' {
+            $attr = $script:Cmd.Parameters['ParentIssueNumber'].Attributes |
+                Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+            $attr.Mandatory | Should -Be $true
+        }
+
+        It 'declares ChildIssueNumber as a mandatory parameter' {
+            $attr = $script:Cmd.Parameters['ChildIssueNumber'].Attributes |
+                Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+            $attr.Mandatory | Should -Be $true
+        }
+    }
+
+    Context 'Attach-failure path' {
+        It 'exits non-zero and splices a Parent claim + text-fallback marker when GraphQL retries are exhausted' {
+            $global:SipGraphqlFailAll = $true
+
+            & $script:ScriptFile -ParentIssueNumber $global:SipTestParent -ChildIssueNumber $global:SipTestChild
+
+            $LASTEXITCODE | Should -Not -Be 0
+            $global:SipCapturedEditBody | Should -Not -BeNullOrEmpty
+            $global:SipCapturedEditBody | Should -Match "(?m)^Parent: #$($global:SipTestParent)$"
+            $global:SipCapturedEditBody | Should -Match ([regex]::Escape('<!-- parent-link-mode: text-fallback -->'))
+        }
+    }
+
+    Context 'Repeated-failure idempotency' {
+        It 'produces exactly one Parent claim line and one marker after two consecutive failed runs' {
+            $global:SipGraphqlFailAll = $true
+
+            & $script:ScriptFile -ParentIssueNumber $global:SipTestParent -ChildIssueNumber $global:SipTestChild
+            $firstExit = $LASTEXITCODE
+            & $script:ScriptFile -ParentIssueNumber $global:SipTestParent -ChildIssueNumber $global:SipTestChild
+            $secondExit = $LASTEXITCODE
+
+            $firstExit | Should -Not -Be 0
+            $secondExit | Should -Not -Be 0
+
+            $finalBody = $global:SipCapturedEditBody
+            $finalBody | Should -Not -BeNullOrEmpty
+
+            $claimMatches = [regex]::Matches($finalBody, "(?m)^Parent: #$($global:SipTestParent)$")
+            $claimMatches.Count | Should -Be 1
+
+            $markerMatches = [regex]::Matches($finalBody, [regex]::Escape('<!-- parent-link-mode: text-fallback -->'))
+            $markerMatches.Count | Should -Be 1
+        }
+    }
+
+    Context 'Re-parent guard' {
+        It 'exits non-zero and never attempts an attach when the child is already attached to a different parent' {
+            $global:SipMockChildParentNumber = 555
+
+            & $script:ScriptFile -ParentIssueNumber $global:SipTestParent -ChildIssueNumber $global:SipTestChild
+
+            $LASTEXITCODE | Should -Not -Be 0
+            $global:SipAddSubIssueCallCount | Should -Be 0
+        }
+    }
+
+    Context 'Already-correct-parent' {
+        It 'exits 0, attempts no attach, and strips a stale text-fallback marker when the child is already attached to the requested parent' {
+            $global:SipMockChildParentNumber = $global:SipTestParent
+            $global:SipMockChildBody = "Parent: #$($global:SipTestParent)`n`nSome body`n<!-- parent-link-mode: text-fallback -->"
+
+            & $script:ScriptFile -ParentIssueNumber $global:SipTestParent -ChildIssueNumber $global:SipTestChild
+
+            $LASTEXITCODE | Should -Be 0
+            $global:SipAddSubIssueCallCount | Should -Be 0
+            $global:SipCapturedEditBody | Should -Not -BeNullOrEmpty
+            $global:SipCapturedEditBody | Should -Not -Match ([regex]::Escape('<!-- parent-link-mode: text-fallback -->'))
+            $global:SipCapturedEditBody | Should -Not -Match "(?m)^Parent: #$($global:SipTestParent)$"
+        }
+    }
+
+    Context 'Self-reference' {
+        It 'exits non-zero and makes no gh calls when ParentIssueNumber equals ChildIssueNumber' {
+            & $script:ScriptFile -ParentIssueNumber $global:SipTestChild -ChildIssueNumber $global:SipTestChild
+
+            $LASTEXITCODE | Should -Not -Be 0
+            $global:SipGhCallCount | Should -Be 0
+            Test-Path $global:SipLogFile | Should -Be $false
+        }
+    }
+}

--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -690,6 +690,37 @@ Describe 'Get-PortfolioBuckets v2 — OrphanClaimWarnings (#800 B1)' {
         $warning | Should -Not -Match "`n" -Because 'interpolation must never carry a newline (log-injection guard, consistent with M9 elsewhere in this renderer)'
         $warning | Should -Not -Match '\(\?' -Because 'no raw regex syntax may leak into the interpolated message'
     }
+
+    It 'M11: an OrphanClaimWarnings entry renders into Format-PortfolioMarkdown output' {
+        # Render-surface coverage gap (M11): prior tests only asserted the bucket
+        # computation and the CI ::warning:: emission; nothing asserted the warning
+        # text actually reaches the rendered Markdown board via Format-PortfolioMarkdown.
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
+        $orphan = New-IssueState -Number 907 -State 'OPEN' -Parent $null `
+            -SubIssues @{ totalCount = 0; nodes = @() } `
+            -Body "Parent: #762`n`nSome other body content."
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $orphan)
+        $output  = Format-PortfolioMarkdown -bucketModel $buckets -timestamp '2026-06-25T00:00:00Z'
+
+        $output | Should -Match '⚠️ open issue #907 claims a parent \(#762\) but has no sub-issue link' `
+            -Because 'M11: OrphanClaimWarnings entries must actually appear in the rendered Markdown output, not only in the bucket model'
+    }
+
+    It 'M12: the marker-only #unknown fallback fires when the text-fallback marker is present but neither claim regex captures a digit' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
+        $orphan = New-IssueState -Number 908 -State 'OPEN' -Parent $null `
+            -SubIssues @{ totalCount = 0; nodes = @() } `
+            -Body "<!-- parent-link-mode: text-fallback -->`nNo parseable claim text here at all."
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $orphan)
+
+        $warning = @($buckets.OrphanClaimWarnings | Where-Object { $_ -match '#908' })[0]
+        $warning | Should -Not -BeNullOrEmpty -Because 'the text-fallback marker alone must still fire the detector'
+        $warning | Should -Match '#unknown' -Because 'M12: neither claim regex captured a digit, so the message must fall back to the literal #unknown token'
+    }
 }
 
 # ===========================================================================
@@ -2380,7 +2411,7 @@ umbrellas: [101]
             # claim). Get-PortfolioBuckets stays pure; the CI ::warning:: emission lives
             # at render-portfolio.ps1:1050-1054, gated on $env:GITHUB_ACTIONS -eq 'true'.
             $previousGithubActions = $env:GITHUB_ACTIONS
-            $orphanJson = '{"data":{"repository":{"issue":{"number":900,"title":"Orphan claim umbrella","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","body":"<!-- parent-link-mode: text-fallback -->\nParent: #761","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":null,"subIssues":{"totalCount":0,"nodes":[]}}}}}'
+            $orphanJson = '{"data":{"repository":{"issue":{"number":900,"title":"Orphan claim umbrella","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","body":"Parent: #761\n<!-- parent-link-mode: text-fallback -->","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":null,"subIssues":{"totalCount":0,"nodes":[]}}}}}'
             $probeJson  = '{"data":{"repository":{"issue":{"parent":null,"subIssues":{"totalCount":0}}}}}'
 
             function global:gh {
@@ -2437,7 +2468,7 @@ umbrellas: [900]
         It 'OrphanClaimWarnings ::warning:: is NOT emitted when GITHUB_ACTIONS is unset, even though the board still warns (#800 B1)' {
             # Same orphan-claim fixture as above; only the environment differs.
             $previousGithubActions = $env:GITHUB_ACTIONS
-            $orphanJson = '{"data":{"repository":{"issue":{"number":900,"title":"Orphan claim umbrella","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","body":"<!-- parent-link-mode: text-fallback -->\nParent: #761","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":null,"subIssues":{"totalCount":0,"nodes":[]}}}}}'
+            $orphanJson = '{"data":{"repository":{"issue":{"number":900,"title":"Orphan claim umbrella","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","body":"Parent: #761\n<!-- parent-link-mode: text-fallback -->","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":null,"subIssues":{"totalCount":0,"nodes":[]}}}}}'
             $probeJson  = '{"data":{"repository":{"issue":{"parent":null,"subIssues":{"totalCount":0}}}}}'
 
             function global:gh {

--- a/.github/scripts/Tests/render-portfolio.Tests.ps1
+++ b/.github/scripts/Tests/render-portfolio.Tests.ps1
@@ -83,7 +83,8 @@ function New-IssueState {
         [string]    $ClosedAt     = $null,
         [string]    $CreatedAt    = '2025-01-01T00:00:00Z',
         [hashtable] $Parent       = $null,
-        [hashtable] $SubIssues    = $null
+        [hashtable] $SubIssues    = $null,
+        [string]    $Body         = $null
     )
     return [PSCustomObject]@{
         number        = $Number
@@ -97,6 +98,7 @@ function New-IssueState {
         totalCount    = 1  # default rendered count = totalCount (no overflow)
         parent        = $Parent
         subIssues     = $SubIssues
+        body          = $Body
     }
 }
 
@@ -567,6 +569,126 @@ Describe 'Get-PortfolioBuckets v2' {
         $rcNums = @($buckets.RecentlyClosed | ForEach-Object { $_.number })
         $rcNums | Should -Contain 700 -Because '#700 closed within 14-day window must appear in RecentlyClosed'
         $rcNums | Should -Not -Contain 701 -Because '#701 closed 30 days ago is outside the window'
+    }
+}
+
+# ===========================================================================
+Describe 'Get-PortfolioBuckets v2 — OrphanClaimWarnings (#800 B1)' {
+# ===========================================================================
+# Warn-only detector: OPEN issues where .parent is $null but the body claims a
+# parent via one of two per-producer patterns, or carries the text-fallback
+# marker. Per-producer regex discipline is the load-bearing invariant here —
+# a 5-pass adversarial plan stress-test (plan-issue-800 PF1, judge ruling:
+# sustained/critical) caught that a uniformly first-line-anchored design would
+# silently miss the real §2b-ter mid-line residue format. Case (c) below is
+# that exact regression guard and must never be weakened or removed.
+
+    It '(a) fires on an OPEN issue with the text-fallback marker + null parent' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
+        $orphan = New-IssueState -Number 900 -State 'OPEN' -Parent $null `
+            -SubIssues @{ totalCount = 0; nodes = @() } `
+            -Body "<!-- parent-link-mode: text-fallback -->`nParent: #761"
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $orphan)
+
+        $buckets.OrphanClaimWarnings | Should -Not -BeNullOrEmpty -Because 'text-fallback marker + null parent must fire (a)'
+        ($buckets.OrphanClaimWarnings -join "`n") | Should -Match '#900' -Because 'the warning must name the orphaned issue #900'
+    }
+
+    It '(b) fires on an OPEN issue with a first-line Parent: #N claim + null parent' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
+        $orphan = New-IssueState -Number 901 -State 'OPEN' -Parent $null `
+            -SubIssues @{ totalCount = 0; nodes = @() } `
+            -Body "Parent: #762`n`nSome other body content."
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $orphan)
+
+        $buckets.OrphanClaimWarnings | Should -Not -BeNullOrEmpty -Because 'first-line Parent: #N claim + null parent must fire (b)'
+        ($buckets.OrphanClaimWarnings -join "`n") | Should -Match '#901' -Because 'the warning must name the orphaned issue #901'
+        ($buckets.OrphanClaimWarnings -join "`n") | Should -Match '#762' -Because 'the warning must interpolate the claimed parent #762'
+    }
+
+    It '(c) CRITICAL REGRESSION GUARD — fires on an OPEN issue with mid-line "Board positioning: ...placement=parent #N; ..." residue + null parent (PF1)' {
+        # This is exactly the real §2b-ter positioning-residue format
+        # (skills/safe-operations/SKILL.md:163): "Board positioning: priority=<h|m|l>;
+        # placement=<standalone|parent #N>; rationale=<one line>". An earlier
+        # uniformly-line-anchored design would NEVER match this because the token
+        # appears mid-line, not at column 0 — the plan stress-test caught this as a
+        # critical defect. This test must exist and must pass against the current
+        # implementation; do not weaken or skip it.
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
+        $orphan = New-IssueState -Number 902 -State 'OPEN' -Parent $null `
+            -SubIssues @{ totalCount = 0; nodes = @() } `
+            -Body "Some intro text.`n`nBoard positioning: priority=medium; placement=parent #761; rationale=tracked under umbrella 761`n`nMore body content."
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $orphan)
+
+        $buckets.OrphanClaimWarnings | Should -Not -BeNullOrEmpty `
+            -Because 'PF1 regression guard: mid-line "placement=parent #N" residue + null parent MUST fire even though it is not first-line-anchored'
+        ($buckets.OrphanClaimWarnings -join "`n") | Should -Match '#902' -Because 'the warning must name the orphaned issue #902'
+        ($buckets.OrphanClaimWarnings -join "`n") | Should -Match '#761' -Because 'the warning must interpolate the claimed parent #761 from the mid-line residue'
+    }
+
+    It '(d) does NOT fire on a correctly-attached child even if the body also contains claim text' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' -SubIssues @{
+            totalCount = 1
+            nodes = @( @{ number = 903; state = 'OPEN' } )
+        }
+        $attachedChild = New-IssueState -Number 903 -State 'OPEN' -Parent @{ number = 476 } `
+            -SubIssues @{ totalCount = 0; nodes = @() } `
+            -Body "<!-- parent-link-mode: text-fallback -->`nParent: #476`n`nBoard positioning: priority=medium; placement=parent #476; rationale=x"
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $attachedChild)
+
+        $orphanNums = @(($buckets.OrphanClaimWarnings) | Where-Object { $_ -match '#903' })
+        $orphanNums | Should -BeNullOrEmpty -Because 'a correctly-attached child (.parent set) must never be flagged, regardless of stray claim text in its body (d)'
+    }
+
+    It '(e) does NOT fire on a CLOSED issue matching the same claim conditions' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
+        $closedOrphan = New-IssueState -Number 904 -State 'CLOSED' -Parent $null `
+            -SubIssues @{ totalCount = 0; nodes = @() } `
+            -Body "<!-- parent-link-mode: text-fallback -->`nParent: #761"
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $closedOrphan)
+
+        $orphanNums = @(($buckets.OrphanClaimWarnings) | Where-Object { $_ -match '#904' })
+        $orphanNums | Should -BeNullOrEmpty -Because 'a CLOSED issue must never be flagged even if it matches the same claim conditions (e — OPEN-only invariant)'
+    }
+
+    It '(f) does NOT fire on a mid-body prose mention of "Parent: #5" that is not the body first line' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
+        $proseIssue = New-IssueState -Number 905 -State 'OPEN' -Parent $null `
+            -SubIssues @{ totalCount = 0; nodes = @() } `
+            -Body "Some discussion.`n`n...see the note about Parent: #5 in the other thread..."
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $proseIssue)
+
+        $orphanNums = @(($buckets.OrphanClaimWarnings) | Where-Object { $_ -match '#905' })
+        $orphanNums | Should -BeNullOrEmpty -Because 'a mid-body prose mention of "Parent: #N" that is NOT the first line must not fire — proves the first-line anchor excludes prose mentions elsewhere in the body (f)'
+    }
+
+    It 'digit-only interpolation: emitted message contains only the clean captured digit group, never regex artifacts' {
+        $spec = ConvertFrom-SequenceSpec -yamlText (New-ValidSpecYaml -Umbrellas @(476))
+        $umbrella476 = New-IssueState -Number 476 -State 'OPEN' -SubIssues @{ totalCount = 0; nodes = @() }
+        $orphan = New-IssueState -Number 906 -State 'OPEN' -Parent $null `
+            -SubIssues @{ totalCount = 0; nodes = @() } `
+            -Body "Board positioning: priority=medium; placement=parent #761; rationale=tracked under umbrella 761"
+
+        $buckets = Get-PortfolioBuckets -spec $spec -issueStateObjects @($umbrella476, $orphan)
+
+        $warning = @($buckets.OrphanClaimWarnings | Where-Object { $_ -match '#906' })[0]
+        $warning | Should -Not -BeNullOrEmpty
+        $warning | Should -Match '#761\b' -Because 'the claimed parent number must interpolate cleanly as #761'
+        $warning | Should -Not -Match '#761\d' -Because 'no trailing digits or artifacts may be appended to the captured group'
+        $warning | Should -Not -Match "`n" -Because 'interpolation must never carry a newline (log-injection guard, consistent with M9 elsewhere in this renderer)'
+        $warning | Should -Not -Match '\(\?' -Because 'no raw regex syntax may leak into the interpolated message'
     }
 }
 
@@ -2249,6 +2371,121 @@ umbrellas: [101]
             finally {
                 Remove-Item function:global:gh -ErrorAction SilentlyContinue
                 if (Test-Path $tempSpecLeaf2) { Remove-Item $tempSpecLeaf2 -Force -ErrorAction SilentlyContinue }
+            }
+        }
+
+        It 'OrphanClaimWarnings ::warning:: is emitted to the information stream when GITHUB_ACTIONS=true (#800 B1)' {
+            # Fixture: umbrella #900 is itself the orphan-claiming issue (OPEN, parent
+            # null, body carries the text-fallback marker + first-line Parent: #761
+            # claim). Get-PortfolioBuckets stays pure; the CI ::warning:: emission lives
+            # at render-portfolio.ps1:1050-1054, gated on $env:GITHUB_ACTIONS -eq 'true'.
+            $previousGithubActions = $env:GITHUB_ACTIONS
+            $orphanJson = '{"data":{"repository":{"issue":{"number":900,"title":"Orphan claim umbrella","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","body":"<!-- parent-link-mode: text-fallback -->\nParent: #761","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":null,"subIssues":{"totalCount":0,"nodes":[]}}}}}'
+            $probeJson  = '{"data":{"repository":{"issue":{"parent":null,"subIssues":{"totalCount":0}}}}}'
+
+            function global:gh {
+                param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+                if ($ghArgs -contains 'edit') { $script:GhEditCallCount++; $global:LASTEXITCODE = 0; return }
+                if ($ghArgs -contains 'list') {
+                    if ($ghArgs -contains 'closed') { $global:LASTEXITCODE = 0; return '[]' }
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":900,"title":"Orphan claim umbrella","labels":[],"createdAt":"2026-01-01T00:00:00Z"}]'
+                }
+                if ($ghArgs -contains 'api') {
+                    $queryStr = $ghArgs | Where-Object { $_ -like 'query=*' } | Select-Object -Last 1
+                    $issueNum = 0
+                    if ($queryStr -match 'issue\(number:\s*(\d+)') { $issueNum = [int]$Matches[1] }
+                    $global:LASTEXITCODE = 0
+                    if ($issueNum -eq 704) { return $probeJson }
+                    return $orphanJson
+                }
+                if ($ghArgs -contains 'view') {
+                    $global:LASTEXITCODE = 0
+                    return '{"body":"# Control Tower\n\nNo portfolio block yet."}'
+                }
+                $global:LASTEXITCODE = 0
+            }
+
+            $tempSpecOrphan = New-TempSpecPath
+            @'
+schema_version: 2
+control_tower: 704
+recently_closed_days: 14
+umbrellas: [900]
+'@ | Set-Content -Path $tempSpecOrphan -Encoding UTF8
+
+            try {
+                $env:GITHUB_ACTIONS = 'true'
+                # Capture information stream (6) — Write-Host output goes here (M6 convention).
+                $output = Invoke-PortfolioRender -specPath $tempSpecOrphan 6>&1
+                $annotations = @($output | Where-Object { $_ -match '::warning::' -and $_ -match '#900' })
+                $annotations.Count | Should -BeGreaterThan 0 `
+                    -Because 'an OrphanClaimWarnings entry must be echoed as a CI ::warning:: annotation when GITHUB_ACTIONS=true (#800 B1)'
+                $annotations[0].ToString() | Should -Match '#761' -Because 'the annotation must interpolate the claimed parent #761'
+            }
+            finally {
+                Remove-Item function:global:gh -ErrorAction SilentlyContinue
+                if ($null -eq $previousGithubActions) {
+                    Remove-Item env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
+                } else {
+                    $env:GITHUB_ACTIONS = $previousGithubActions
+                }
+                if (Test-Path $tempSpecOrphan) { Remove-Item $tempSpecOrphan -Force -ErrorAction SilentlyContinue }
+            }
+        }
+
+        It 'OrphanClaimWarnings ::warning:: is NOT emitted when GITHUB_ACTIONS is unset, even though the board still warns (#800 B1)' {
+            # Same orphan-claim fixture as above; only the environment differs.
+            $previousGithubActions = $env:GITHUB_ACTIONS
+            $orphanJson = '{"data":{"repository":{"issue":{"number":900,"title":"Orphan claim umbrella","state":"OPEN","closedAt":null,"createdAt":"2026-01-01T00:00:00Z","body":"<!-- parent-link-mode: text-fallback -->\nParent: #761","labels":{"totalCount":0,"nodes":[]},"blockedBy":{"totalCount":0,"nodes":[]},"parent":null,"subIssues":{"totalCount":0,"nodes":[]}}}}}'
+            $probeJson  = '{"data":{"repository":{"issue":{"parent":null,"subIssues":{"totalCount":0}}}}}'
+
+            function global:gh {
+                param([Parameter(ValueFromRemainingArguments)][string[]]$ghArgs)
+                if ($ghArgs -contains 'edit') { $script:GhEditCallCount++; $global:LASTEXITCODE = 0; return }
+                if ($ghArgs -contains 'list') {
+                    if ($ghArgs -contains 'closed') { $global:LASTEXITCODE = 0; return '[]' }
+                    $global:LASTEXITCODE = 0
+                    return '[{"number":900,"title":"Orphan claim umbrella","labels":[],"createdAt":"2026-01-01T00:00:00Z"}]'
+                }
+                if ($ghArgs -contains 'api') {
+                    $queryStr = $ghArgs | Where-Object { $_ -like 'query=*' } | Select-Object -Last 1
+                    $issueNum = 0
+                    if ($queryStr -match 'issue\(number:\s*(\d+)') { $issueNum = [int]$Matches[1] }
+                    $global:LASTEXITCODE = 0
+                    if ($issueNum -eq 704) { return $probeJson }
+                    return $orphanJson
+                }
+                if ($ghArgs -contains 'view') {
+                    $global:LASTEXITCODE = 0
+                    return '{"body":"# Control Tower\n\nNo portfolio block yet."}'
+                }
+                $global:LASTEXITCODE = 0
+            }
+
+            $tempSpecOrphan2 = New-TempSpecPath
+            @'
+schema_version: 2
+control_tower: 704
+recently_closed_days: 14
+umbrellas: [900]
+'@ | Set-Content -Path $tempSpecOrphan2 -Encoding UTF8
+
+            try {
+                Remove-Item env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
+                $output = Invoke-PortfolioRender -specPath $tempSpecOrphan2 6>&1
+                $annotations = @($output | Where-Object { $_ -match '::warning::' })
+                $annotations.Count | Should -Be 0 `
+                    -Because 'no ::warning:: annotation may be emitted when GITHUB_ACTIONS is unset, even though the same orphan claim exists (#800 B1 gating)'
+            }
+            finally {
+                Remove-Item function:global:gh -ErrorAction SilentlyContinue
+                if ($null -eq $previousGithubActions) {
+                    Remove-Item env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
+                } else {
+                    $env:GITHUB_ACTIONS = $previousGithubActions
+                }
+                if (Test-Path $tempSpecOrphan2) { Remove-Item $tempSpecOrphan2 -Force -ErrorAction SilentlyContinue }
             }
         }
     }

--- a/.github/scripts/Tests/safe-operations-2b-bis-contract.Tests.ps1
+++ b/.github/scripts/Tests/safe-operations-2b-bis-contract.Tests.ps1
@@ -61,12 +61,11 @@ Describe 'safe-operations §2b-bis / §2b-ter board-positioning contract' -Tag '
         # literal leading cell text and requires the Mechanism cell to name
         # Set-IssueParent, not Add-FollowUpIssue.
         #
-        # EXPECTED RED right now: #800 s5 (the doc-fix step that rewrites this row) has
-        # NOT landed yet — s4 (this test) runs before s5 per the plan's frame-spine
-        # depends_on graph. This is the same documented pre-landing red-state pattern as
-        # the #774 s2 contract test; do not weaken this assertion to pass prematurely.
+        # STATUS: #800 s5 (the doc-fix step that rewrote this row) has landed and this
+        # suite is GREEN. Kept as a standing regression guard against reverting the
+        # Parent-edge row back to Add-FollowUpIssue.
         $script:Content | Should -Match '(?m)^\|\s*\*\*Parent edge\*\*\s*\(`Set-IssueParent -ParentIssueNumber N`\)' `
-            -Because '§2b-ter lever-mapping table Parent-edge row must name Set-IssueParent as the attach-existing mechanism (#800 A2 — expected RED until s5 lands)'
+            -Because '§2b-ter lever-mapping table Parent-edge row must name Set-IssueParent as the attach-existing mechanism (#800 A2)'
 
         $script:Content | Should -Not -Match '(?m)^\|\s*\*\*Parent edge\*\*.*Add-FollowUpIssue' `
             -Because 'the Parent-edge row must not still reference Add-FollowUpIssue once #800 s5 lands (regression guard against reverting to the stale mechanism)'

--- a/.github/scripts/Tests/safe-operations-2b-bis-contract.Tests.ps1
+++ b/.github/scripts/Tests/safe-operations-2b-bis-contract.Tests.ps1
@@ -48,9 +48,28 @@ Describe 'safe-operations §2b-bis / §2b-ter board-positioning contract' -Tag '
             -Because '§2b-ter residue format must name both standalone and parent-edge placement options'
     }
 
-    It '§2b-ter lever-mapping table documents priority label and parent-edge mechanisms' {
-        $script:Content | Should -Match '(?is)2b-ter.{0,800}Add-FollowUpIssue' `
-            -Because '§2b-ter must document Add-FollowUpIssue as the parent-edge mechanism in the lever-mapping table'
+    It '§2b-ter lever-mapping table Parent-edge row documents Set-IssueParent as the attach-existing mechanism (#800 A2 / PF7)' {
+        # Tightened per #800 s4 (PF7, judge ruling: sustained/medium). The prior assertion
+        # was '(?is)2b-ter.{0,800}Add-FollowUpIssue' — a loose proximity match that is
+        # satisfied by ANY Add-FollowUpIssue mention within 800 chars of the "2b-ter"
+        # heading, including unrelated prose at §2b-ter:144/:148/:169 (create-then-attach
+        # guidance, the automated-path carve-out). That loose match would keep passing
+        # even after #800 s5 rewrites the lever-mapping table's Parent-edge row to name
+        # Set-IssueParent (the new standalone attach-existing script from #800 A2) —
+        # silently certifying a now-false "Add-FollowUpIssue is the parent-edge mechanism"
+        # claim. This assertion targets the "Parent edge" table row specifically by its
+        # literal leading cell text and requires the Mechanism cell to name
+        # Set-IssueParent, not Add-FollowUpIssue.
+        #
+        # EXPECTED RED right now: #800 s5 (the doc-fix step that rewrites this row) has
+        # NOT landed yet — s4 (this test) runs before s5 per the plan's frame-spine
+        # depends_on graph. This is the same documented pre-landing red-state pattern as
+        # the #774 s2 contract test; do not weaken this assertion to pass prematurely.
+        $script:Content | Should -Match '(?m)^\|\s*\*\*Parent edge\*\*\s*\(`Set-IssueParent -ParentIssueNumber N`\)' `
+            -Because '§2b-ter lever-mapping table Parent-edge row must name Set-IssueParent as the attach-existing mechanism (#800 A2 — expected RED until s5 lands)'
+
+        $script:Content | Should -Not -Match '(?m)^\|\s*\*\*Parent edge\*\*.*Add-FollowUpIssue' `
+            -Because 'the Parent-edge row must not still reference Add-FollowUpIssue once #800 s5 lands (regression guard against reverting to the stale mechanism)'
     }
 
     It '§2b-ter lever table pins correct Get-PriorityKey numeric values matching render-portfolio.ps1' {

--- a/.github/scripts/Tests/set-issue-parent-doc-contract.Tests.ps1
+++ b/.github/scripts/Tests/set-issue-parent-doc-contract.Tests.ps1
@@ -1,0 +1,124 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    AST/Get-Command-bound doc-to-script contract test locking the §2b-bis
+    fenced invocation example in skills/safe-operations/SKILL.md to the
+    Set-IssueParent.ps1 script interface (plan-issue-800 s2, AC4).
+
+.DESCRIPTION
+    Regression guard for the judge-note flagged in plan-issue-800 (PF11-
+    adjacent, "worth closing even though it wasn't a formally sustained
+    finding"): a doc reference reverting to Add-FollowUpIssue.ps1, or a
+    parameter-token drift between the doc and the script, must fail this
+    test.
+
+    Text isolation (finding the §2b-bis section, its fenced code block, and
+    the one invocation line inside it) uses plain string/regex splitting -
+    that part is not load-bearing. The CORE assertions - script filename
+    identity and parameter-token set equality - are bound via the
+    PowerShell language parser (AST) over the isolated line and via
+    Get-Command against the real script, per plan-issue-800 M10 ("bind the
+    contract test to the param block via AST/Get-Command rather than prose
+    regex to avoid the brittleness the existing 2b-bis contract test
+    demonstrates").
+
+    EXPECTED RED STATE: skills/safe-operations/SKILL.md has NOT been fixed
+    yet at the time this test is authored (plan-issue-800 step s5 - doc
+    fixes at all five drift sites - is dispatched AFTER this step, s2). The
+    §2b-bis fenced example still invokes `Add-FollowUpIssue.ps1
+    -ParentIssueNumber ...`, so the "invokes Set-IssueParent.ps1 by
+    filename" test below is EXPECTED TO FAIL until s5 lands. This is the
+    correct, intended red state for this step - do not weaken the
+    assertion to pass prematurely against the unfixed doc.
+#>
+
+Describe 'Set-IssueParent doc-to-script contract (SKILL.md §2b-bis)' -Tag 'contract' {
+
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+        $script:SafeOpsPath = Join-Path $script:RepoRoot 'skills/safe-operations/SKILL.md'
+        $script:ScriptPath = Join-Path $script:RepoRoot 'skills/safe-operations/scripts/Set-IssueParent.ps1'
+        $script:Content = Get-Content -Path $script:SafeOpsPath -Raw -ErrorAction Stop
+
+        # --- Text isolation only (NOT the core assertion): locate the
+        # §2b-bis section, its first fenced ```powershell block, and the one
+        # line inside it that invokes a skills/safe-operations/scripts/*.ps1
+        # helper (the "CORRECT — umbrella child" attach-existing example). ---
+        $sectionMatch = [regex]::Match(
+            $script:Content,
+            '(?s)### 2b-bis\..*?(?=\r?\n### )'
+        )
+        if (-not $sectionMatch.Success) {
+            throw "Could not locate the §2b-bis section in $($script:SafeOpsPath)"
+        }
+        $section = $sectionMatch.Value
+
+        $fenceMatch = [regex]::Match($section, '(?s)```powershell\r?\n(.*?)```')
+        if (-not $fenceMatch.Success) {
+            throw "Could not locate a fenced powershell block inside the §2b-bis section of $($script:SafeOpsPath)"
+        }
+        $fenceBody = $fenceMatch.Groups[1].Value
+
+        $invocationLine = ($fenceBody -split '\r?\n') |
+            Where-Object { $_ -match 'skills/safe-operations/scripts/\S+\.ps1' } |
+            Select-Object -First 1
+
+        if (-not $invocationLine) {
+            throw "Could not find a skills/safe-operations/scripts/*.ps1 invocation line inside the §2b-bis fenced example"
+        }
+        $script:InvocationLine = $invocationLine.Trim()
+
+        # --- Core assertion binding: parse the isolated line with the
+        # PowerShell language parser (AST), not prose regex (M10). ---
+        $tokens = $null
+        $parseErrors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            $script:InvocationLine, [ref]$tokens, [ref]$parseErrors
+        )
+        $commandAst = $ast.Find({ param($node) $node -is [System.Management.Automation.Language.CommandAst] }, $true)
+        if (-not $commandAst) {
+            throw "AST parse of the isolated §2b-bis invocation line produced no CommandAst: $($script:InvocationLine)"
+        }
+
+        # CommandElements[0] is the `pwsh` launcher; CommandElements[1] is
+        # the script path argument.
+        $scriptPathText = $commandAst.CommandElements[1].Extent.Text.Trim('"', "'")
+        $script:DocScriptFileName = Split-Path -Path $scriptPathText -Leaf
+
+        $script:DocFlagTokens = @(
+            $commandAst.CommandElements |
+                Where-Object { $_ -is [System.Management.Automation.Language.CommandParameterAst] } |
+                ForEach-Object { $_.ParameterName }
+        )
+    }
+
+    It 'extraction produced a non-empty script filename and at least one flag token (self-check on the extraction mechanics)' {
+        $script:DocScriptFileName | Should -Not -BeNullOrEmpty
+        $script:DocFlagTokens.Count | Should -BeGreaterThan 0
+    }
+
+    It 'the §2b-bis fenced example invokes Set-IssueParent.ps1 by filename (regression guard: a revert to Add-FollowUpIssue.ps1 must fail this test)' {
+        $script:DocScriptFileName | Should -Be 'Set-IssueParent.ps1' `
+            -Because 'plan-issue-800 step s5 must repoint the §2b-bis attach-existing example at the new standalone Set-IssueParent.ps1 script; EXPECTED RED until s5 lands'
+    }
+
+    It 'the documented flag tokens match exactly the actual Set-IssueParent.ps1 parameter set' {
+        if (-not (Test-Path $script:ScriptPath)) {
+            throw "Set-IssueParent.ps1 not found at $($script:ScriptPath)"
+        }
+        $cmd = Get-Command -Name $script:ScriptPath
+
+        $commonParams = @(
+            [System.Management.Automation.PSCmdlet]::CommonParameters +
+            [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
+        )
+        $actualParamNames = @(
+            $cmd.Parameters.Keys | Where-Object { $commonParams -notcontains $_ }
+        )
+
+        # Order-independent set comparison.
+        @($script:DocFlagTokens | Sort-Object) | Should -Be @($actualParamNames | Sort-Object) `
+            -Because 'the doc example flags must be exactly -ParentIssueNumber and -ChildIssueNumber with no drift from the actual script param block'
+    }
+}

--- a/.github/scripts/Tests/set-issue-parent-doc-contract.Tests.ps1
+++ b/.github/scripts/Tests/set-issue-parent-doc-contract.Tests.ps1
@@ -23,14 +23,12 @@
     regex to avoid the brittleness the existing 2b-bis contract test
     demonstrates").
 
-    EXPECTED RED STATE: skills/safe-operations/SKILL.md has NOT been fixed
-    yet at the time this test is authored (plan-issue-800 step s5 - doc
-    fixes at all five drift sites - is dispatched AFTER this step, s2). The
-    §2b-bis fenced example still invokes `Add-FollowUpIssue.ps1
-    -ParentIssueNumber ...`, so the "invokes Set-IssueParent.ps1 by
-    filename" test below is EXPECTED TO FAIL until s5 lands. This is the
-    correct, intended red state for this step - do not weaken the
-    assertion to pass prematurely against the unfixed doc.
+    STATUS: plan-issue-800 step s5 (the doc-fix step that repoints the
+    §2b-bis fenced example at Set-IssueParent.ps1) has landed. This suite
+    is GREEN: the "invokes Set-IssueParent.ps1 by filename" test below now
+    passes against the fixed doc. Kept as a standing regression guard - a
+    future revert to `Add-FollowUpIssue.ps1 -ParentIssueNumber ...` in the
+    §2b-bis example, or any parameter-token drift, must fail this test.
 #>
 
 Describe 'Set-IssueParent doc-to-script contract (SKILL.md §2b-bis)' -Tag 'contract' {
@@ -100,7 +98,7 @@ Describe 'Set-IssueParent doc-to-script contract (SKILL.md §2b-bis)' -Tag 'cont
 
     It 'the §2b-bis fenced example invokes Set-IssueParent.ps1 by filename (regression guard: a revert to Add-FollowUpIssue.ps1 must fail this test)' {
         $script:DocScriptFileName | Should -Be 'Set-IssueParent.ps1' `
-            -Because 'plan-issue-800 step s5 must repoint the §2b-bis attach-existing example at the new standalone Set-IssueParent.ps1 script; EXPECTED RED until s5 lands'
+            -Because 'plan-issue-800 step s5 repointed the §2b-bis attach-existing example at the standalone Set-IssueParent.ps1 script; this guards against a future revert'
     }
 
     It 'the documented flag tokens match exactly the actual Set-IssueParent.ps1 parameter set' {

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -6,7 +6,7 @@
 .DESCRIPTION
     Implements the Renderer Contract:
       - ConvertFrom-SequenceSpec  : parse flat YAML sequence spec (no ConvertFrom-Yaml)
-      - Get-PortfolioBuckets      : classify issues into ActiveUmbrella/ActiveChildren/RankedUmbrellas/Triage/RecentlyClosed/DriftWarnings/IntegrityWarnings
+      - Get-PortfolioBuckets      : classify issues into ActiveUmbrella/ActiveChildren/RankedUmbrellas/Triage/RecentlyClosed/DriftWarnings/IntegrityWarnings/OrphanClaimWarnings
       - Format-PortfolioMarkdown  : render bucket model to Markdown
       - Get-SplicedBody           : idempotent splice into issue body
       - Invoke-PortfolioRender    : full pipeline end-to-end
@@ -195,12 +195,13 @@ function Get-SubIssueNodes {
 # Get-PortfolioBuckets v2
 # Classifies issueStateObjects into the v2 model:
 #   ActiveUmbrella, ActiveChildren, RankedUmbrellas, Triage, TriageResidualCount,
-#   DriftWarnings, IntegrityWarnings, RecentlyClosed
+#   DriftWarnings, IntegrityWarnings, OrphanClaimWarnings, RecentlyClosed
 #
 # issueStateObjects fields (v2):
 #   .number (int), .state ('OPEN'/'CLOSED'), .title (string), .labels (string[])
 #   .blockedBy (int[]), .closedAt (string ISO or $null), .createdAt (string ISO)
 #   .parent (hashtable {number} | $null), .subIssues (hashtable {totalCount, nodes[{number,state}]} | $null)
+#   .body (string or $null) — used only by OrphanClaimWarnings detection
 # ---------------------------------------------------------------------------
 function Get-PortfolioBuckets {
     param(
@@ -217,9 +218,10 @@ function Get-PortfolioBuckets {
     $umbrellaSet     = [System.Collections.Generic.HashSet[int]]::new()
     foreach ($u in $umbrellaList) { $null = $umbrellaSet.Add([int]$u) }
 
-    $driftWarnings     = [System.Collections.Generic.List[string]]::new()
-    $integrityWarnings = [System.Collections.Generic.List[string]]::new()
-    $driftWarnedNums   = [System.Collections.Generic.HashSet[int]]::new()
+    $driftWarnings       = [System.Collections.Generic.List[string]]::new()
+    $integrityWarnings   = [System.Collections.Generic.List[string]]::new()
+    $driftWarnedNums     = [System.Collections.Generic.HashSet[int]]::new()
+    $orphanClaimWarnings = [System.Collections.Generic.List[string]]::new()
 
     # Build lookup: number → issue state object
     $issueByNumber = @{}
@@ -280,6 +282,61 @@ function Get-PortfolioBuckets {
                 $integrityWarnings.Add("⚠️ umbrella #${umbNum}: subIssues.totalCount=$tc but only $($nodes.Count) nodes returned (possible truncation)")
             }
         }
+    }
+
+    # ---------------------------------------------------------------------------
+    # OrphanClaimWarnings (B1 / #800): warn-only detector for OPEN issues whose
+    # body claims a parent but have no actual sub-issue edge (.parent is $null).
+    #
+    # Per-producer regex discipline (design-challenge PF1 / plan-stress-test PF1
+    # — a 5-pass adversarial plan stress-test caught this as a CRITICAL defect
+    # in the original uniformly-anchored design):
+    #   - `Parent: #N` is FIRST-LINE-ANCHORED: the Add-FollowUpIssue.ps1 /
+    #     Set-IssueParent.ps1 text-fallback producer writes it as the body's
+    #     literal first line, so anchoring here avoids false positives from
+    #     prose mentions elsewhere in the body.
+    #   - `placement=parent #N` is INTENTIONALLY UNANCHORED: the §2b-ter
+    #     creation-time positioning-residue producer (skills/safe-operations/
+    #     SKILL.md:163, format "Board positioning: priority=<h|m|l>;
+    #     placement=parent #N; rationale=<one line>") writes it mid-line,
+    #     never at column 0. Anchoring this pattern would silently miss the
+    #     exact real-world Class-B incidents (#816/#817/#818) that motivated
+    #     this detector.
+    #   - The `<!-- parent-link-mode: text-fallback -->` marker is the primary,
+    #     false-positive-free signal and is checked independently of both
+    #     regexes.
+    #
+    # Interpolation safety: only the captured digit group is ever interpolated
+    # into the warning message (never raw Match.Value, which could carry a
+    # newline or other characters) — this guards against forging additional
+    # workflow-command text into the CI ::warning:: output emitted downstream.
+    # ---------------------------------------------------------------------------
+    $firstLineParentPattern = '(?m)^Parent: #(\d+)'
+    $placementParentPattern = 'placement=parent #(\d+)'
+    $textFallbackMarker     = '<!-- parent-link-mode: text-fallback -->'
+
+    foreach ($issue in $issueStateObjects) {
+        if ($issue.state -ne 'OPEN') { continue }
+        if ($null -ne $issue.parent) { continue }
+
+        $body = $issue.body
+        if ([string]::IsNullOrEmpty($body)) { continue }
+
+        $hasMarker    = $body.Contains($textFallbackMarker)
+        $firstLineHit = [regex]::Match($body, $firstLineParentPattern)
+        $placementHit = [regex]::Match($body, $placementParentPattern)
+
+        if (-not $hasMarker -and -not $firstLineHit.Success -and -not $placementHit.Success) { continue }
+
+        # Digit-only interpolation: prefer the first-line producer's captured
+        # group, then the placement-residue producer's; fall back to a safe
+        # literal in the edge case where only the marker fired without either
+        # regex matching (never interpolate raw match/body text).
+        $claimedParent = if ($firstLineHit.Success) { $firstLineHit.Groups[1].Value }
+                          elseif ($placementHit.Success) { $placementHit.Groups[1].Value }
+                          else { 'unknown' }
+
+        $orphanClaimWarnings.Add("⚠️ open issue #$($issue.number) claims a parent (#$claimedParent) but has no sub-issue link")
     }
 
     # ---------------------------------------------------------------------------
@@ -414,6 +471,7 @@ function Get-PortfolioBuckets {
         TriageResidualCount = $residualCount
         DriftWarnings       = $driftWarnings.ToArray()
         IntegrityWarnings   = $integrityWarnings.ToArray()
+        OrphanClaimWarnings = $orphanClaimWarnings.ToArray()
         RecentlyClosed      = $recentlyClosed.ToArray()
     }
 }
@@ -422,7 +480,8 @@ function Get-PortfolioBuckets {
 # Format-PortfolioMarkdown v2
 # Renders v2 bucket model to Markdown string.
 # Three-zone layout: Active / Umbrellas (ranked) / Triage / Recently closed
-# Warnings (DriftWarnings + IntegrityWarnings) appear after zones, before footer.
+# Warnings (DriftWarnings + IntegrityWarnings + OrphanClaimWarnings) appear
+# after zones, before footer.
 # Footer: "portfolio content unchanged since {timestamp} — rendered by render-portfolio.ps1"
 # Get-SplicedBody strips the footer line for idempotency comparison — do not move it.
 # ---------------------------------------------------------------------------
@@ -510,6 +569,11 @@ function Format-PortfolioMarkdown {
     }
     if ($bucketModel.IntegrityWarnings) {
         foreach ($warn in $bucketModel.IntegrityWarnings) {
+            $null = $sb.AppendLine($warn)
+        }
+    }
+    if ($bucketModel.OrphanClaimWarnings) {
+        foreach ($warn in $bucketModel.OrphanClaimWarnings) {
             $null = $sb.AppendLine($warn)
         }
     }
@@ -722,6 +786,7 @@ query {
       state
       closedAt
       createdAt
+      body
       labels(first: 50) { totalCount nodes { name } }
       blockedBy(first: 50) {
         totalCount
@@ -821,6 +886,7 @@ query {
             state               = $issueData.state
             closedAt            = $issueData.closedAt
             createdAt           = $issueData.createdAt
+            body                = $issueData.body
             labels              = $labels
             blockedBy           = $openBlockers
             blockerInPlan       = $blockerInPlan
@@ -857,6 +923,7 @@ query {
       state
       closedAt
       createdAt
+      body
       labels(first: 50) { totalCount nodes { name } }
       blockedBy(first: 50) {
         totalCount
@@ -917,6 +984,7 @@ query {
             state               = $issueData.state
             closedAt            = $issueData.closedAt
             createdAt           = $issueData.createdAt
+            body                = $issueData.body
             labels              = $labels
             blockedBy           = $openBlockers
             blockerInPlan       = $blockerInPlan
@@ -974,6 +1042,16 @@ query {
     $buckets = Get-PortfolioBuckets `
         -spec $spec `
         -issueStateObjects $issueStates.ToArray()
+
+    # 5b. CI ::warning:: per OrphanClaimWarnings entry (B1 / #800). Get-PortfolioBuckets
+    # stays pure (no I/O) — the warning strings it returns already interpolate only the
+    # captured digit group (never raw body/match text), so it is safe to echo them
+    # verbatim here as CI annotations.
+    if ($env:GITHUB_ACTIONS -eq 'true' -and $buckets.OrphanClaimWarnings) {
+        foreach ($warn in $buckets.OrphanClaimWarnings) {
+            Write-Host "::warning::$warn"
+        }
+    }
 
     # 6. Format content block
     $timestamp    = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
@@ -1038,7 +1116,8 @@ function New-IssueState {
         [string]    $ClosedAt     = $null,
         [string]    $CreatedAt    = '2025-01-01T00:00:00Z',
         [hashtable] $Parent       = $null,
-        [hashtable] $SubIssues    = $null
+        [hashtable] $SubIssues    = $null,
+        [string]    $Body         = $null
     )
     return [PSCustomObject]@{
         number        = $Number
@@ -1052,6 +1131,7 @@ function New-IssueState {
         totalCount    = 1  # default rendered count = totalCount (no overflow)
         parent        = $Parent
         subIssues     = $SubIssues
+        body          = $Body
     }
 }
 

--- a/.github/scripts/render-portfolio.ps1
+++ b/.github/scripts/render-portfolio.ps1
@@ -294,7 +294,12 @@ function Get-PortfolioBuckets {
     #   - `Parent: #N` is FIRST-LINE-ANCHORED: the Add-FollowUpIssue.ps1 /
     #     Set-IssueParent.ps1 text-fallback producer writes it as the body's
     #     literal first line, so anchoring here avoids false positives from
-    #     prose mentions elsewhere in the body.
+    #     prose mentions elsewhere in the body. The pattern intentionally has
+    #     no `(?m)` flag (M3 fix): `^` must anchor to the true start of the
+    #     string only, matching the writer's LeadingClaimPattern semantics —
+    #     `(?m)` would make `^` match the start of every line, so a
+    #     `Parent: #N` line anywhere in the body (not just the first line)
+    #     would be treated as a first-line claim.
     #   - `placement=parent #N` is INTENTIONALLY UNANCHORED: the §2b-ter
     #     creation-time positioning-residue producer (skills/safe-operations/
     #     SKILL.md:163, format "Board positioning: priority=<h|m|l>;
@@ -311,7 +316,7 @@ function Get-PortfolioBuckets {
     # newline or other characters) — this guards against forging additional
     # workflow-command text into the CI ::warning:: output emitted downstream.
     # ---------------------------------------------------------------------------
-    $firstLineParentPattern = '(?m)^Parent: #(\d+)'
+    $firstLineParentPattern = '^Parent: #(\d+)'
     $placementParentPattern = 'placement=parent #(\d+)'
     $textFallbackMarker     = '<!-- parent-link-mode: text-fallback -->'
 
@@ -332,11 +337,20 @@ function Get-PortfolioBuckets {
         # group, then the placement-residue producer's; fall back to a safe
         # literal in the edge case where only the marker fired without either
         # regex matching (never interpolate raw match/body text).
-        $claimedParent = if ($firstLineHit.Success) { $firstLineHit.Groups[1].Value }
-                          elseif ($placementHit.Success) { $placementHit.Groups[1].Value }
-                          else { 'unknown' }
+        #
+        # M6: when BOTH patterns match with DIFFERENT captured numbers, that
+        # is a genuine conflicting-claim signal (not just a preference
+        # ordering) — report both numbers rather than silently dropping one.
+        if ($firstLineHit.Success -and $placementHit.Success -and
+                $firstLineHit.Groups[1].Value -ne $placementHit.Groups[1].Value) {
+            $orphanClaimWarnings.Add("⚠️ open issue #$($issue.number) claims a parent (#$($firstLineHit.Groups[1].Value), #$($placementHit.Groups[1].Value) — conflicting claims) but has no sub-issue link")
+        } else {
+            $claimedParent = if ($firstLineHit.Success) { $firstLineHit.Groups[1].Value }
+                              elseif ($placementHit.Success) { $placementHit.Groups[1].Value }
+                              else { 'unknown' }
 
-        $orphanClaimWarnings.Add("⚠️ open issue #$($issue.number) claims a parent (#$claimedParent) but has no sub-issue link")
+            $orphanClaimWarnings.Add("⚠️ open issue #$($issue.number) claims a parent (#$claimedParent) but has no sub-issue link")
+        }
     }
 
     # ---------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to agent-orchestra will be documented in this file.
 
+## [3.3.7] — 2026-07-09
+
+### Fixed
+
+- `Set-IssueParent.ps1` (new): attach-existing sub-issue primitive with loud (non-zero exit) failure and a detectable `Parent: #N` + `text-fallback` body-marker splice, extracted from `Add-FollowUpIssue.ps1`'s embedded GraphQL linking, so the documented umbrella-attach command is no longer a silent no-op (#800).
+- `render-portfolio.ps1`: added a warn-only `OrphanClaimWarnings` bucket (tracker body + CI `::warning::`) flagging open issues that claim a parent with no real sub-issue link, using per-producer regex anchoring so the mid-line `placement=parent #N` residue format is caught (#800).
+- `safe-operations/SKILL.md`: corrected five 2b-bis/2b-ter drift sites that referenced a nonexistent `Add-FollowUpIssue` attach-existing capability, pointing them at `Set-IssueParent.ps1` (#800).
+- `Set-IssueParent.ps1`: fixed PowerShell stderr capture — `2>$variable` does not capture stderr (it is a file-redirect operator); replaced with `2>&1` stream separation by ErrorRecord type so failure diagnostics are surfaced without corrupting JSON/GraphQL parsing on successful gh calls (#800, PR review).
+
 ## [3.3.6] — 2026-07-08
 
 ### Added

--- a/Documents/Design/control-tower-v2.md
+++ b/Documents/Design/control-tower-v2.md
@@ -120,6 +120,8 @@ Warnings are **additive** `⚠️` lines appended after the zones. They never fa
 
 **Integrity warnings** flag possible fetch truncation: when an umbrella's `subIssues.totalCount` does not equal the number of `nodes` actually returned (`⚠️ umbrella #N: subIssues.totalCount=X but only Y nodes returned (possible truncation)`). This is the safety net for the connection-cap dependency below — it is a warn tier, so the board still renders.
 
+**Orphan-claim warnings** (`OrphanClaimWarnings`, computed by `Get-PortfolioBuckets` in `render-portfolio.ps1`) are a warn-only tier that fires for an **open** issue with `.parent == null` whose body nonetheless claims a parent — detected via the `<!-- parent-link-mode: text-fallback -->` marker or either producer regex (first-line `Parent: #N`, or the mid-line `placement=parent #N` §2b-ter residue) — surfacing the board-vs-body mismatch (`⚠️ open issue #N claims a parent (#M) but has no sub-issue link`).
+
 A separate **unresolved** warning fires when a listed umbrella could not be fully resolved (issue not found, or incomplete blocker data).
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > ⚠️ **GitHub Copilot / VS Code support is frozen and retiring after 2026-08-31.**
 > Claude Code is the actively supported path. See [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md) for details and the reach-out channel if you depend on Copilot support.
 
-[![Version](https://img.shields.io/badge/version-v3.3.6-blue.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-v3.3.7-blue.svg)](../../releases)
 [![Ready for Production](https://img.shields.io/badge/status-production%20ready-green.svg)](../../releases)
 
 A multi-agent workflow system that orchestrates AI-assisted software development through specialized Claude Code agents. *(GitHub Copilot/VS Code: frozen and retiring after 2026-08-31 — see [COPILOT-DEPRECATION.md](Documents/Design/copilot-deprecation.md))*

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestra",
   "description": "⚠️ Copilot/VS Code support frozen, retiring after 2026-08-31 — see https://github.com/Grimblaz/agent-orchestra/blob/main/Documents/Design/copilot-deprecation.md. Claude Code is the supported path. Multi-agent workflow system with 16 specialized agents and a shared skill library.",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "author": {
     "name": "Grimblaz"
   },

--- a/skills/safe-operations/SKILL.md
+++ b/skills/safe-operations/SKILL.md
@@ -118,16 +118,16 @@ gh issue create --title "..." --body "..."
 
 Every new issue created by any agent **MUST** be placed under a tracked umbrella **or** left as an ungrouped open issue that the portfolio renderer auto-derives into Triage — this rule is additive to the §2b priority mandate and does not replace it. The intent is unchanged: **a new issue must not silently disappear from the control-tower tracker.** Under Control Tower v2 the mechanism changed (see [Documents/Design/control-tower-v2.md](../../Documents/Design/control-tower-v2.md)).
 
-- **Parent umbrella (child issue)** — if the work is scoped to a tracked initiative, attach the new issue as a native sub-issue of an existing sequenced umbrella. Use `Add-FollowUpIssue` (canonical sub-issue attach) immediately after `gh issue create`.
-- **New umbrella → insert at rank** — if you are creating a *new umbrella* (an issue that will own sub-issues), you **MUST** also insert its number into `Documents/Planning/sequence.yaml`'s `umbrellas:` inline list at the correct priority rank. `sequence.yaml` is the **canonical home** for umbrella ranking — do **not** add a routing-tables JSON entry. Then attach the umbrella's own children as native sub-issues with `Add-FollowUpIssue`, exactly as for any other umbrella.
+- **Parent umbrella (child issue)** — if the work is scoped to a tracked initiative, attach the new issue as a native sub-issue of an existing sequenced umbrella. Either create-and-attach in one step with `Add-FollowUpIssue` (canonical create-and-attach helper), or run `gh issue create` first and then attach the already-created issue with `Set-IssueParent` (canonical attach-existing helper).
+- **New umbrella → insert at rank** — if you are creating a *new umbrella* (an issue that will own sub-issues), you **MUST** also insert its number into `Documents/Planning/sequence.yaml`'s `umbrellas:` inline list at the correct priority rank. `sequence.yaml` is the **canonical home** for umbrella ranking — do **not** add a routing-tables JSON entry. Then attach the umbrella's own children as native sub-issues with `Set-IssueParent`, exactly as for any other umbrella.
 - **Triage (ungrouped open issue)** — if no umbrella applies, just create the issue. Under v2 the renderer **derives** Triage from parent-edge data (open ∧ no parent ∧ no sub-issues ∧ not listed in `umbrellas:`), so an ungrouped open issue is always a Triage **candidate** under the v2 derivation rules — it is never silently excluded from the board count, though it may fall below the cap-5 rendering fold (see Caveat below). The `--label triage` flag is now **optional/advisory** (a human-readable hint only); it is **no longer load-bearing** for Triage placement, because v2 removed the triage-label query entirely. **Caveat**: Triage is capped at 5 issues and sorted priority-first (`Get-PriorityKey` order). An unlabeled issue resolves to `Get-PriorityKey = 3` (lowest rank tier) and may fall below the fold if the Triage bucket is already full. See [Documents/Design/control-tower-v2.md](../../Documents/Design/control-tower-v2.md) for cap and ranking mechanics.
 
 ```powershell
-# CORRECT — umbrella child (use the canonical Add-FollowUpIssue helper):
+# CORRECT — umbrella child (create the issue, then attach it as an existing child with Set-IssueParent):
 $url = gh issue create --title "..." --body "..." --label "priority: medium"
-# Extract number and attach to umbrella using the canonical helper:
+# Extract number and attach the already-created issue to the umbrella with Set-IssueParent:
 $issueNum = $url -replace '.*/', ''
-pwsh skills/safe-operations/scripts/Add-FollowUpIssue.ps1 -ParentIssueNumber 425 -ChildIssueNumber $issueNum
+pwsh skills/safe-operations/scripts/Set-IssueParent.ps1 -ParentIssueNumber 425 -ChildIssueNumber $issueNum
 
 # CORRECT — new umbrella: create it, insert its number into sequence.yaml umbrellas: at
 # the right rank, then attach its children as sub-issues. The sequence.yaml edit is
@@ -145,14 +145,14 @@ Before every `gh issue create` or `Add-FollowUpIssue` call, the agent **must** m
 
 **(a) What priority label to apply** — the label controls `Get-PriorityKey` rank within Triage and umbrella children. A deliberate choice of `priority: low` (or no label, which resolves to the lowest rank tier) is a valid and acceptable outcome when the issue genuinely represents low-urgency work.
 
-**(b) Parent-or-standalone** — attach to an active umbrella via `Add-FollowUpIssue`, or leave as a standalone issue that auto-derives into Triage. A deliberate "low priority / standalone / may not stay on board" decision is a valid and acceptable outcome.
+**(b) Parent-or-standalone** — attach to an active umbrella via `Set-IssueParent`, or leave as a standalone issue that auto-derives into Triage. A deliberate "low priority / standalone / may not stay on board" decision is a valid and acceptable outcome.
 
 **Lever mapping — what the filer controls and its board effect**:
 
 | Lever | Mechanism | Board effect |
 | --- | --- | --- |
 | **Priority label** (`--label priority:h/m/l`) | Sets `Get-PriorityKey` = 0 (high), 1 (medium), or 2 (low) | Affects rank/sort order within Triage or umbrella children; no label → `Get-PriorityKey = 3` (lowest tier, may fall below Triage fold if bucket is full) |
-| **Parent edge** (`Add-FollowUpIssue -ParentIssueNumber N`) | Attaches issue as ActiveChildren of a tracked umbrella | Places issue in the umbrella's children section; requires a spec-listed active umbrella |
+| **Parent edge** (`Set-IssueParent -ParentIssueNumber N`) | Attaches issue as ActiveChildren of a tracked umbrella | Places issue in the umbrella's children section; requires a spec-listed active umbrella |
 | **Standalone** (bare `gh issue create`) | No parent edge set | Auto-derives into Triage under v2 derivation rules |
 
 > **Render-derived buckets (NOT filer-controllable)**: RecentlyClosed, DriftWarnings, and IntegrityWarnings are computed by the renderer from issue state and relationship data — the filer cannot directly place an issue in these zones. See [Documents/Design/control-tower-v2.md](../../Documents/Design/control-tower-v2.md) for cap-5 and priority-ranking mechanics; do not copy those numbers or formulas here.

--- a/skills/safe-operations/scripts/Set-IssueParent.ps1
+++ b/skills/safe-operations/scripts/Set-IssueParent.ps1
@@ -68,10 +68,21 @@ function Remove-StaleParentClaim {
         Marker hygiene: idempotently strip a leading "Parent: #N" claim line
         and a trailing text-fallback marker left by a prior failed run.
         Safe to call on a body with no stale claim/marker (no-op).
+
+    .DESCRIPTION
+        Gated on the text-fallback marker's presence (M2 fix): the leading
+        claim line is only ever stripped together with the marker, never on
+        its own. This preserves a permanent "Parent: #N" first line written
+        by Add-FollowUpIssue.ps1 on a successful attach (which never carries
+        the text-fallback marker) and, as a side effect, avoids a
+        functionless TrimEnd()-only body diff when there is nothing stale to
+        remove (M5 fix): when the marker is absent this function returns the
+        body unchanged instead of reaching the TrimEnd() call.
     #>
     param([string]$Body)
 
     if ([string]::IsNullOrEmpty($Body)) { return $Body }
+    if ($Body -notmatch [regex]::Escape($script:TextFallbackMarker)) { return $Body }
 
     $result = $Body -replace $script:LeadingClaimPattern, ''
     $result = $result -replace $script:TrailingMarkerPattern, ''
@@ -108,6 +119,29 @@ if ($ParentIssueNumber -eq $ChildIssueNumber) {
     exit 1
 }
 
+# --- 1b. Resolve the ambient gh repo once (M1) -------------------------
+# `gh issue view` (used for the parent read) and every `gh issue edit`
+# call already resolve against `gh`'s ambient cwd-repo. Resolving the same
+# repo here, once, and reusing it in the pre-check GraphQL query keeps the
+# read and write paths pinned to the same repo instead of a hardcoded
+# owner/name literal that can silently drift in a fork or renamed repo.
+$repoViewStderr = $null
+$repoNwo = $null
+try {
+    $repoNwo = gh repo view --json owner,name -q '.owner.login + "/" + .name' 2>$repoViewStderr
+} catch {
+    $repoNwo = $null
+}
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoNwo)) {
+    $stderrText = if ($repoViewStderr) { (($repoViewStderr | Out-String).Trim()) } else { '' }
+    $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
+    Write-Error "Could not resolve the current repository via 'gh repo view' (owner/name).$suffix"
+    exit 1
+}
+$repoParts = $repoNwo.Trim() -split '/', 2
+$repoOwner = $repoParts[0]
+$repoName = $repoParts[1]
+
 # --- 2 & 3. Verify the child exists and pre-check its current parent. ---
 # Combined into one GraphQL query: `gh issue view --json` has no `parent`
 # field (PF3), so the parent read must go through `gh api graphql`
@@ -115,7 +149,7 @@ if ($ParentIssueNumber -eq $ChildIssueNumber) {
 # same round trip avoids three separate `gh` calls.
 $childQuery = @"
 query {
-  repository(owner: "Grimblaz", name: "agent-orchestra") {
+  repository(owner: "$repoOwner", name: "$repoName") {
     issue(number: $ChildIssueNumber) {
       id
       body
@@ -128,27 +162,48 @@ query {
 $childId = $null
 $childBody = $null
 $currentParentNumber = $null
-try {
-    $childRawJson = gh api graphql -f "query=$childQuery" 2>$null
-    if ($LASTEXITCODE -eq 0 -and $childRawJson) {
-        $childResponse = $childRawJson | ConvertFrom-Json -ErrorAction SilentlyContinue
-        $childIssueData = $childResponse.data.repository.issue
-        if ($childIssueData) {
-            $childId = $childIssueData.id
-            $childBody = $childIssueData.body
-            if ($childIssueData.parent) {
-                $currentParentNumber = $childIssueData.parent.number
+$precheckSuccess = $false
+$precheckAttempts = 0
+$childPrecheckStderr = $null
+# M7: mirror the addSubIssue mutation's 2-attempt retry loop below instead
+# of a single unretried try/catch.
+while (-not $precheckSuccess -and $precheckAttempts -lt 2) {
+    $precheckAttempts++
+    $childPrecheckStderr = $null
+    try {
+        # M4: carry the same GraphQL-Features header as the mutation, since
+        # this query also reads the feature-gated `parent { number }` field.
+        $childRawJson = gh api graphql -H "GraphQL-Features: sub_issues" -f "query=$childQuery" 2>$childPrecheckStderr
+        if ($LASTEXITCODE -eq 0 -and $childRawJson) {
+            $childResponse = $childRawJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+            # M4: check for GraphQL-level errors returned with exit code 0,
+            # mirroring the mutation's existing error-check pattern. Treat
+            # this the same as an unresolved child (retry, then fail loud).
+            if ($childResponse -and $childResponse.errors) {
+                Write-Warning "GraphQL child pre-check returned errors: $($childResponse.errors | ConvertTo-Json -Compress)"
+            } else {
+                $childIssueData = $childResponse.data.repository.issue
+                if ($childIssueData) {
+                    $childId = $childIssueData.id
+                    $childBody = $childIssueData.body
+                    if ($childIssueData.parent) {
+                        $currentParentNumber = $childIssueData.parent.number
+                    }
+                    $precheckSuccess = $true
+                }
             }
         }
+    } catch {
+        # Try again
     }
-} catch {
-    $childId = $null
 }
 
 # PF9: verify the child issue resolves to a real issue before writing
 # anything to its body.
 if (-not $childId) {
-    Write-Error "Child issue #$ChildIssueNumber could not be resolved (missing or inaccessible)."
+    $stderrText = if ($childPrecheckStderr) { (($childPrecheckStderr | Out-String).Trim()) } else { '' }
+    $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
+    Write-Error "Child issue #$ChildIssueNumber could not be resolved (missing or inaccessible).$suffix"
     exit 1
 }
 
@@ -158,9 +213,12 @@ if ($null -ne $currentParentNumber) {
         # Marker hygiene: strip any stale claim/marker a prior failed run left.
         $strippedBody = Remove-StaleParentClaim -Body $childBody
         if ($strippedBody -ne $childBody) {
-            gh issue edit $ChildIssueNumber --body $strippedBody 2>$null | Out-Null
+            $editStderr = $null
+            gh issue edit $ChildIssueNumber --body $strippedBody 2>$editStderr | Out-Null
             if ($LASTEXITCODE -ne 0) {
-                Write-Warning "Failed to strip stale parent-link-mode marker from issue #$ChildIssueNumber body."
+                $stderrText = if ($editStderr) { (($editStderr | Out-String).Trim()) } else { '' }
+                $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
+                Write-Warning "Failed to strip stale parent-link-mode marker from issue #$ChildIssueNumber body.$suffix"
             }
         }
         exit 0
@@ -178,8 +236,9 @@ if ($null -ne $currentParentNumber) {
 # addSubIssue mutation + 2-attempt retry). Divergence: on failure this
 # script exits non-zero instead of only Write-Warning-ing.
 $parentId = $null
+$parentViewStderr = $null
 try {
-    $parentId = gh issue view $ParentIssueNumber --json id --jq .id 2>$null
+    $parentId = gh issue view $ParentIssueNumber --json id --jq .id 2>$parentViewStderr
 } catch {
     $parentId = $null
 }
@@ -198,10 +257,12 @@ mutation {
 }
 "@
     $attempts = 0
+    $mutationStderr = $null
     while (-not $graphqlSuccess -and $attempts -lt 2) {
         $attempts++
+        $mutationStderr = $null
         try {
-            $result = gh api graphql -H "GraphQL-Features: sub_issues" -f "query=$mutation" 2>$null
+            $result = gh api graphql -H "GraphQL-Features: sub_issues" -f "query=$mutation" 2>$mutationStderr
             if ($LASTEXITCODE -eq 0 -and $result) {
                 # Check for GraphQL-level errors returned with exit code 0.
                 $parsed = $result | ConvertFrom-Json -ErrorAction SilentlyContinue
@@ -217,29 +278,39 @@ mutation {
     }
 
     if (-not $graphqlSuccess) {
-        Write-Warning "Failed to link issue #$ChildIssueNumber to parent issue #$ParentIssueNumber via GitHub GraphQL sub-issues after 2 attempts."
+        $stderrText = if ($mutationStderr) { (($mutationStderr | Out-String).Trim()) } else { '' }
+        $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
+        Write-Warning "Failed to link issue #$ChildIssueNumber to parent issue #$ParentIssueNumber via GitHub GraphQL sub-issues after 2 attempts.$suffix"
     }
 } else {
+    $stderrText = if ($parentViewStderr) { (($parentViewStderr | Out-String).Trim()) } else { '' }
+    $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
     Write-Error "addSubIssue prerequisite failed: childId=$childId parentId=$parentId" -ErrorAction Continue
-    Write-Warning "Could not retrieve GraphQL Node IDs for parent #$ParentIssueNumber or child #$ChildIssueNumber."
+    Write-Warning "Could not retrieve GraphQL Node IDs for parent #$ParentIssueNumber or child #$ChildIssueNumber.$suffix"
 }
 
 # --- 5 / 6. Success: strip stale marker. Failure: splice fallback claim. -
 if ($graphqlSuccess) {
     $strippedBody = Remove-StaleParentClaim -Body $childBody
     if ($strippedBody -ne $childBody) {
-        gh issue edit $ChildIssueNumber --body $strippedBody 2>$null | Out-Null
+        $editStderr = $null
+        gh issue edit $ChildIssueNumber --body $strippedBody 2>$editStderr | Out-Null
         if ($LASTEXITCODE -ne 0) {
-            Write-Warning "Failed to strip stale parent-link-mode marker from issue #$ChildIssueNumber body."
+            $stderrText = if ($editStderr) { (($editStderr | Out-String).Trim()) } else { '' }
+            $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
+            Write-Warning "Failed to strip stale parent-link-mode marker from issue #$ChildIssueNumber body.$suffix"
         }
     }
     exit 0
 } else {
     Write-Error "Failed to attach issue #$ChildIssueNumber to parent issue #$ParentIssueNumber."
     $fallbackBody = Add-ParentClaimFallback -Body $childBody -ParentIssueNumber $ParentIssueNumber
-    gh issue edit $ChildIssueNumber --body $fallbackBody 2>$null | Out-Null
+    $editStderr = $null
+    gh issue edit $ChildIssueNumber --body $fallbackBody 2>$editStderr | Out-Null
     if ($LASTEXITCODE -ne 0) {
-        Write-Warning "Failed to write parent-link-mode text-fallback claim to issue #$ChildIssueNumber body."
+        $stderrText = if ($editStderr) { (($editStderr | Out-String).Trim()) } else { '' }
+        $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
+        Write-Warning "Failed to write parent-link-mode text-fallback claim to issue #$ChildIssueNumber body.$suffix"
     }
     exit 1
 }

--- a/skills/safe-operations/scripts/Set-IssueParent.ps1
+++ b/skills/safe-operations/scripts/Set-IssueParent.ps1
@@ -125,15 +125,17 @@ if ($ParentIssueNumber -eq $ChildIssueNumber) {
 # repo here, once, and reusing it in the pre-check GraphQL query keeps the
 # read and write paths pinned to the same repo instead of a hardcoded
 # owner/name literal that can silently drift in a fork or renamed repo.
-$repoViewStderr = $null
 $repoNwo = $null
+$stderrText = ''
 try {
-    $repoNwo = gh repo view --json owner,name -q '.owner.login + "/" + .name' 2>$repoViewStderr
+    $repoViewMerged = gh repo view --json owner,name -q '.owner.login + "/" + .name' 2>&1
+    $repoNwo = (($repoViewMerged | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } | Out-String)).Trim()
+    $stderrText = (($repoViewMerged | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } |
+        ForEach-Object { $_.ToString() }) -join "`n").Trim()
 } catch {
     $repoNwo = $null
 }
 if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoNwo)) {
-    $stderrText = if ($repoViewStderr) { (($repoViewStderr | Out-String).Trim()) } else { '' }
     $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
     Write-Error "Could not resolve the current repository via 'gh repo view' (owner/name).$suffix"
     exit 1
@@ -164,16 +166,18 @@ $childBody = $null
 $currentParentNumber = $null
 $precheckSuccess = $false
 $precheckAttempts = 0
-$childPrecheckStderr = $null
+$childPrecheckStderr = ''
 # M7: mirror the addSubIssue mutation's 2-attempt retry loop below instead
 # of a single unretried try/catch.
 while (-not $precheckSuccess -and $precheckAttempts -lt 2) {
     $precheckAttempts++
-    $childPrecheckStderr = $null
     try {
         # M4: carry the same GraphQL-Features header as the mutation, since
         # this query also reads the feature-gated `parent { number }` field.
-        $childRawJson = gh api graphql -H "GraphQL-Features: sub_issues" -f "query=$childQuery" 2>$childPrecheckStderr
+        $childPrecheckMerged = gh api graphql -H "GraphQL-Features: sub_issues" -f "query=$childQuery" 2>&1
+        $childRawJson = (($childPrecheckMerged | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } | Out-String)).Trim()
+        $childPrecheckStderr = (($childPrecheckMerged | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } |
+            ForEach-Object { $_.ToString() }) -join "`n").Trim()
         if ($LASTEXITCODE -eq 0 -and $childRawJson) {
             $childResponse = $childRawJson | ConvertFrom-Json -ErrorAction SilentlyContinue
             # M4: check for GraphQL-level errors returned with exit code 0,
@@ -201,8 +205,7 @@ while (-not $precheckSuccess -and $precheckAttempts -lt 2) {
 # PF9: verify the child issue resolves to a real issue before writing
 # anything to its body.
 if (-not $childId) {
-    $stderrText = if ($childPrecheckStderr) { (($childPrecheckStderr | Out-String).Trim()) } else { '' }
-    $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
+    $suffix = if ($childPrecheckStderr) { " stderr: $childPrecheckStderr" } else { '' }
     Write-Error "Child issue #$ChildIssueNumber could not be resolved (missing or inaccessible).$suffix"
     exit 1
 }
@@ -213,10 +216,9 @@ if ($null -ne $currentParentNumber) {
         # Marker hygiene: strip any stale claim/marker a prior failed run left.
         $strippedBody = Remove-StaleParentClaim -Body $childBody
         if ($strippedBody -ne $childBody) {
-            $editStderr = $null
-            gh issue edit $ChildIssueNumber --body $strippedBody 2>$editStderr | Out-Null
+            $editOutput = gh issue edit $ChildIssueNumber --body $strippedBody 2>&1
             if ($LASTEXITCODE -ne 0) {
-                $stderrText = if ($editStderr) { (($editStderr | Out-String).Trim()) } else { '' }
+                $stderrText = (($editOutput | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } | Out-String)).Trim()
                 $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
                 Write-Warning "Failed to strip stale parent-link-mode marker from issue #$ChildIssueNumber body.$suffix"
             }
@@ -236,9 +238,12 @@ if ($null -ne $currentParentNumber) {
 # addSubIssue mutation + 2-attempt retry). Divergence: on failure this
 # script exits non-zero instead of only Write-Warning-ing.
 $parentId = $null
-$parentViewStderr = $null
+$parentViewStderr = ''
 try {
-    $parentId = gh issue view $ParentIssueNumber --json id --jq .id 2>$parentViewStderr
+    $parentViewMerged = gh issue view $ParentIssueNumber --json id --jq .id 2>&1
+    $parentId = (($parentViewMerged | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } | Out-String)).Trim()
+    $parentViewStderr = (($parentViewMerged | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } |
+        ForEach-Object { $_.ToString() }) -join "`n").Trim()
 } catch {
     $parentId = $null
 }
@@ -257,12 +262,14 @@ mutation {
 }
 "@
     $attempts = 0
-    $mutationStderr = $null
+    $mutationStderr = ''
     while (-not $graphqlSuccess -and $attempts -lt 2) {
         $attempts++
-        $mutationStderr = $null
         try {
-            $result = gh api graphql -H "GraphQL-Features: sub_issues" -f "query=$mutation" 2>$mutationStderr
+            $mutationMerged = gh api graphql -H "GraphQL-Features: sub_issues" -f "query=$mutation" 2>&1
+            $result = (($mutationMerged | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } | Out-String)).Trim()
+            $mutationStderr = (($mutationMerged | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } |
+                ForEach-Object { $_.ToString() }) -join "`n").Trim()
             if ($LASTEXITCODE -eq 0 -and $result) {
                 # Check for GraphQL-level errors returned with exit code 0.
                 $parsed = $result | ConvertFrom-Json -ErrorAction SilentlyContinue
@@ -278,13 +285,11 @@ mutation {
     }
 
     if (-not $graphqlSuccess) {
-        $stderrText = if ($mutationStderr) { (($mutationStderr | Out-String).Trim()) } else { '' }
-        $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
+        $suffix = if ($mutationStderr) { " stderr: $mutationStderr" } else { '' }
         Write-Warning "Failed to link issue #$ChildIssueNumber to parent issue #$ParentIssueNumber via GitHub GraphQL sub-issues after 2 attempts.$suffix"
     }
 } else {
-    $stderrText = if ($parentViewStderr) { (($parentViewStderr | Out-String).Trim()) } else { '' }
-    $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
+    $suffix = if ($parentViewStderr) { " stderr: $parentViewStderr" } else { '' }
     Write-Error "addSubIssue prerequisite failed: childId=$childId parentId=$parentId" -ErrorAction Continue
     Write-Warning "Could not retrieve GraphQL Node IDs for parent #$ParentIssueNumber or child #$ChildIssueNumber.$suffix"
 }
@@ -293,10 +298,9 @@ mutation {
 if ($graphqlSuccess) {
     $strippedBody = Remove-StaleParentClaim -Body $childBody
     if ($strippedBody -ne $childBody) {
-        $editStderr = $null
-        gh issue edit $ChildIssueNumber --body $strippedBody 2>$editStderr | Out-Null
+        $editOutput = gh issue edit $ChildIssueNumber --body $strippedBody 2>&1
         if ($LASTEXITCODE -ne 0) {
-            $stderrText = if ($editStderr) { (($editStderr | Out-String).Trim()) } else { '' }
+            $stderrText = (($editOutput | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } | Out-String)).Trim()
             $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
             Write-Warning "Failed to strip stale parent-link-mode marker from issue #$ChildIssueNumber body.$suffix"
         }
@@ -305,10 +309,9 @@ if ($graphqlSuccess) {
 } else {
     Write-Error "Failed to attach issue #$ChildIssueNumber to parent issue #$ParentIssueNumber."
     $fallbackBody = Add-ParentClaimFallback -Body $childBody -ParentIssueNumber $ParentIssueNumber
-    $editStderr = $null
-    gh issue edit $ChildIssueNumber --body $fallbackBody 2>$editStderr | Out-Null
+    $editOutput = gh issue edit $ChildIssueNumber --body $fallbackBody 2>&1
     if ($LASTEXITCODE -ne 0) {
-        $stderrText = if ($editStderr) { (($editStderr | Out-String).Trim()) } else { '' }
+        $stderrText = (($editOutput | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } | Out-String)).Trim()
         $suffix = if ($stderrText) { " stderr: $stderrText" } else { '' }
         Write-Warning "Failed to write parent-link-mode text-fallback claim to issue #$ChildIssueNumber body.$suffix"
     }

--- a/skills/safe-operations/scripts/Set-IssueParent.ps1
+++ b/skills/safe-operations/scripts/Set-IssueParent.ps1
@@ -1,0 +1,245 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Attaches an already-existing child issue to an already-existing parent
+    issue via GitHub's GraphQL sub-issues API, failing loudly (non-zero
+    exit) instead of silently degrading when the attach cannot be completed.
+
+.DESCRIPTION
+    Standalone counterpart to Add-FollowUpIssue.ps1 for the "attach an
+    existing child" case (plan-issue-800 Fork 1: extracted into a separate
+    script rather than a new param on the shared file, so the four existing
+    dot-source consumers of Add-FollowUpIssue.ps1 are unaffected — AC5).
+
+    Ported from Add-FollowUpIssue.ps1:158-208: the GraphQL Node-ID
+    resolution, the addSubIssue mutation, and the 2-attempt retry loop
+    (including the `$parsed.errors` check for GraphQL errors returned with
+    HTTP/exit-code 0). Intentional divergence from the source: the source
+    function only Write-Warnings on a failed attach (issue creation itself
+    still "succeeds" either way); this script treats a failed attach as the
+    whole operation failing and exits non-zero, because attaching an
+    existing issue IS the entire operation here — there is no "created
+    issue" fallback value to return.
+
+    Adds, beyond the ported block:
+      - A self-reference guard (ParentIssueNumber == ChildIssueNumber).
+      - A pre-check (via `gh api graphql`, since `gh issue view --json`
+        has no `parent` field) that reads the child's current parent before
+        attempting anything: already-correct is idempotent success,
+        already-different is a loud failure (parent-mismatch *resolution*
+        is out of scope here — deferred to a future issue).
+      - On an unrecoverable failure, an idempotent splice of a
+        "Parent: #N" claim line plus a
+        <!-- parent-link-mode: text-fallback --> marker into the child
+        issue's body, so the render-portfolio OrphanClaimWarnings detector
+        can flag it. Re-running a failed attach replaces rather than
+        duplicates the claim/marker.
+      - On success (attach or already-correct pre-check), strips any stale
+        claim/marker a prior failed run left behind, since success clears
+        it (marker hygiene).
+
+.PARAMETER ParentIssueNumber
+    The issue number of the parent to attach the child to.
+
+.PARAMETER ChildIssueNumber
+    The issue number of the already-existing child issue to attach.
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [int]$ParentIssueNumber,
+
+    [Parameter(Mandatory = $true)]
+    [int]$ChildIssueNumber
+)
+
+# Literal marker/claim shared with the render-portfolio OrphanClaimWarnings
+# detector contract (skills/safe-operations/SKILL.md). Keep in sync.
+$script:TextFallbackMarker = '<!-- parent-link-mode: text-fallback -->'
+# Matches a leading "Parent: #N" claim line only when it is literally the
+# first line of the body (line-boundary lookahead), so a coincidental
+# "Parent: #N" mention elsewhere in the body is never touched.
+$script:LeadingClaimPattern = '^Parent: #\d+(?=\r?\n|$)\r?\n?(\r?\n)?'
+$script:TrailingMarkerPattern = '(\r?\n)?' + [regex]::Escape($script:TextFallbackMarker) + '\s*$'
+
+function Remove-StaleParentClaim {
+    <#
+    .SYNOPSIS
+        Marker hygiene: idempotently strip a leading "Parent: #N" claim line
+        and a trailing text-fallback marker left by a prior failed run.
+        Safe to call on a body with no stale claim/marker (no-op).
+    #>
+    param([string]$Body)
+
+    if ([string]::IsNullOrEmpty($Body)) { return $Body }
+
+    $result = $Body -replace $script:LeadingClaimPattern, ''
+    $result = $result -replace $script:TrailingMarkerPattern, ''
+    return $result.TrimEnd()
+}
+
+function Add-ParentClaimFallback {
+    <#
+    .SYNOPSIS
+        Idempotently splice a "Parent: #N" claim line + the text-fallback
+        marker into a body. Always strips any pre-existing claim/marker
+        first, so a repeated failed run replaces rather than duplicates it.
+    #>
+    param(
+        [string]$Body,
+        [int]$ParentIssueNumber
+    )
+
+    $cleanBody = Remove-StaleParentClaim -Body $Body
+    $claimLine = "Parent: #$ParentIssueNumber"
+
+    $newBody = if ([string]::IsNullOrEmpty($cleanBody)) {
+        $claimLine
+    } else {
+        "$claimLine`n`n$cleanBody"
+    }
+
+    return "$newBody`n$script:TextFallbackMarker"
+}
+
+# --- 1. Self-reference guard (PF17) — reject before any GitHub call. ----
+if ($ParentIssueNumber -eq $ChildIssueNumber) {
+    Write-Error "Cannot attach issue #$ChildIssueNumber to itself (ParentIssueNumber and ChildIssueNumber are the same)."
+    exit 1
+}
+
+# --- 2 & 3. Verify the child exists and pre-check its current parent. ---
+# Combined into one GraphQL query: `gh issue view --json` has no `parent`
+# field (PF3), so the parent read must go through `gh api graphql`
+# regardless; folding the existence check (id) and body fetch into the
+# same round trip avoids three separate `gh` calls.
+$childQuery = @"
+query {
+  repository(owner: "Grimblaz", name: "agent-orchestra") {
+    issue(number: $ChildIssueNumber) {
+      id
+      body
+      parent { number }
+    }
+  }
+}
+"@
+
+$childId = $null
+$childBody = $null
+$currentParentNumber = $null
+try {
+    $childRawJson = gh api graphql -f "query=$childQuery" 2>$null
+    if ($LASTEXITCODE -eq 0 -and $childRawJson) {
+        $childResponse = $childRawJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+        $childIssueData = $childResponse.data.repository.issue
+        if ($childIssueData) {
+            $childId = $childIssueData.id
+            $childBody = $childIssueData.body
+            if ($childIssueData.parent) {
+                $currentParentNumber = $childIssueData.parent.number
+            }
+        }
+    }
+} catch {
+    $childId = $null
+}
+
+# PF9: verify the child issue resolves to a real issue before writing
+# anything to its body.
+if (-not $childId) {
+    Write-Error "Child issue #$ChildIssueNumber could not be resolved (missing or inaccessible)."
+    exit 1
+}
+
+if ($null -ne $currentParentNumber) {
+    if ($currentParentNumber -eq $ParentIssueNumber) {
+        # Already attached to the requested parent — idempotent success.
+        # Marker hygiene: strip any stale claim/marker a prior failed run left.
+        $strippedBody = Remove-StaleParentClaim -Body $childBody
+        if ($strippedBody -ne $childBody) {
+            gh issue edit $ChildIssueNumber --body $strippedBody 2>$null | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "Failed to strip stale parent-link-mode marker from issue #$ChildIssueNumber body."
+            }
+        }
+        exit 0
+    } else {
+        # Attached to a DIFFERENT parent — fail loud rather than silently
+        # succeed (PF2). Resolving the mismatch is out of scope for this
+        # script (deferred to a future issue).
+        Write-Error "Child issue #$ChildIssueNumber is already attached to a different parent (#$currentParentNumber), not the requested parent (#$ParentIssueNumber)."
+        exit 1
+    }
+}
+
+# --- 4. Attempt the attach. ---------------------------------------------
+# Ported from Add-FollowUpIssue.ps1:158-208 (GraphQL Node-ID resolution +
+# addSubIssue mutation + 2-attempt retry). Divergence: on failure this
+# script exits non-zero instead of only Write-Warning-ing.
+$parentId = $null
+try {
+    $parentId = gh issue view $ParentIssueNumber --json id --jq .id 2>$null
+} catch {
+    $parentId = $null
+}
+
+$graphqlSuccess = $false
+
+if ($parentId -and $childId) {
+    $mutation = @"
+mutation {
+  addSubIssue(input: {
+    issueId: "$parentId",
+    subIssueId: "$childId"
+  }) {
+    issue { title }
+  }
+}
+"@
+    $attempts = 0
+    while (-not $graphqlSuccess -and $attempts -lt 2) {
+        $attempts++
+        try {
+            $result = gh api graphql -H "GraphQL-Features: sub_issues" -f "query=$mutation" 2>$null
+            if ($LASTEXITCODE -eq 0 -and $result) {
+                # Check for GraphQL-level errors returned with exit code 0.
+                $parsed = $result | ConvertFrom-Json -ErrorAction SilentlyContinue
+                if ($parsed -and $parsed.errors) {
+                    Write-Warning "GraphQL addSubIssue returned errors: $($parsed.errors | ConvertTo-Json -Compress)"
+                } else {
+                    $graphqlSuccess = $true
+                }
+            }
+        } catch {
+            # Try again
+        }
+    }
+
+    if (-not $graphqlSuccess) {
+        Write-Warning "Failed to link issue #$ChildIssueNumber to parent issue #$ParentIssueNumber via GitHub GraphQL sub-issues after 2 attempts."
+    }
+} else {
+    Write-Error "addSubIssue prerequisite failed: childId=$childId parentId=$parentId" -ErrorAction Continue
+    Write-Warning "Could not retrieve GraphQL Node IDs for parent #$ParentIssueNumber or child #$ChildIssueNumber."
+}
+
+# --- 5 / 6. Success: strip stale marker. Failure: splice fallback claim. -
+if ($graphqlSuccess) {
+    $strippedBody = Remove-StaleParentClaim -Body $childBody
+    if ($strippedBody -ne $childBody) {
+        gh issue edit $ChildIssueNumber --body $strippedBody 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to strip stale parent-link-mode marker from issue #$ChildIssueNumber body."
+        }
+    }
+    exit 0
+} else {
+    Write-Error "Failed to attach issue #$ChildIssueNumber to parent issue #$ParentIssueNumber."
+    $fallbackBody = Add-ParentClaimFallback -Body $childBody -ParentIssueNumber $ParentIssueNumber
+    gh issue edit $ChildIssueNumber --body $fallbackBody 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to write parent-link-mode text-fallback claim to issue #$ChildIssueNumber body."
+    }
+    exit 1
+}


### PR DESCRIPTION
<!-- plan-issue-800 -->

## Summary

Fixes the follow-up-issue orphan-drift bug: the documented "attach a follow-up to its umbrella" command was a silent no-op, so filed issues could land unattached with no signal anything went wrong. This PR implements both halves of the fix decided in design:

- **A2** — a new standalone `Set-IssueParent.ps1` script (attach-existing, extracted from `Add-FollowUpIssue.ps1`'s embedded GraphQL linking logic) that fails **loudly** (non-zero exit) instead of silently, and idempotently splices a detectable `Parent: #N` + `<!-- parent-link-mode: text-fallback -->` claim into the child body on failure so an unresolved attach is never invisible.
- **B1** — a warn-only `OrphanClaimWarnings` bucket in `render-portfolio.ps1`'s tracker renderer that flags any open issue claiming a parent but lacking the real sub-issue link, surfaced both in the tracker body and as a CI `::warning::` annotation — regardless of how the issue was originally filed.

Documentation drift fixed at all five sites in `skills/safe-operations/SKILL.md` that referenced the nonexistent `Add-FollowUpIssue` attach-existing capability, plus a `Documents/Design/control-tower-v2.md` update documenting the new warning tier.

This went through the full pipeline: `/experience` → `/design` (3-pass adversarial design challenge, 12 findings incorporated) → `/plan` (5-pass adversarial plan stress-test, 16 findings — one **critical**) → `/orchestrate` (implementation → 5-pass standard code review → fix cycle → CE Gate) → `/review-github` (proxy prosecution of external bot review).

**Two adversarial passes each caught a version of the same critical defect** — a naive regex anchor would have silently missed the exact real-world orphan format (`Board positioning: …; placement=parent #N; …`, written mid-line by §2b-ter) that motivated this issue in the first place. The design-phase stress-test caught it in the *design*; the plan-phase stress-test caught that even the corrected design's `(?m)` regex flag was itself wrong (matches every line, not just the first) when it reached the *implementation*. Both are fixed; see Adversarial Review below for the code-review-stage version of this same class of bug.

Closes #800

## Changed Files

- `skills/safe-operations/scripts/Set-IssueParent.ps1` (new) — attach-existing primitive
- `.github/scripts/Tests/Set-IssueParent.Tests.ps1` (new) — 9 tests
- `.github/scripts/Tests/set-issue-parent-doc-contract.Tests.ps1` (new) — 3 tests, AST-bound doc↔script contract
- `.github/scripts/render-portfolio.ps1` — `OrphanClaimWarnings` detector + body plumbing + CI `::warning::`
- `.github/scripts/Tests/render-portfolio.Tests.ps1` — +18 tests for the new detector
- `.github/scripts/Tests/safe-operations-2b-bis-contract.Tests.ps1` — tightened to bind the lever-table row specifically
- `skills/safe-operations/SKILL.md` — 5 doc drift sites fixed
- `Documents/Design/control-tower-v2.md` — new warning-tier documented
- `plugin.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.github/plugin/marketplace.json`, `README.md`, `CHANGELOG.md` — version bump 3.3.6 → 3.3.7 (release-gate, entry-point change)

## Validation Evidence

All test suites run and independently verified green at HEAD:

| Suite | Result |
|---|---|
| `Set-IssueParent.Tests.ps1` | 9/9 ✅ |
| `render-portfolio.Tests.ps1` | 92/92 ✅ |
| `set-issue-parent-doc-contract.Tests.ps1` | 3/3 ✅ |
| `safe-operations-2b-bis-contract.Tests.ps1` | 6/6 ✅ |
| `Add-FollowUpIssue.Tests.ps1` (regression — AC5, script untouched) | 5/5 ✅ |
| **Total** | **115/115 ✅** |

Both production scripts (`Set-IssueParent.ps1`, `render-portfolio.ps1`) parse cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`, zero errors). `markdownlint-cli2 --fix` clean (0 errors) on both changed `.md` files. Newcomer-audit (warn-only): one advisory doc-anchor citation, non-blocking.

CI: `release-gate`, `pester`, `frame-enforce`, cost-pattern, and Sourcery all green.

## Review Mode

`standard` — full 5-pass two-layer prosecution panel (2 generalist + 3 specialist) → merged ledger → defense → judge, per `skills/adversarial-review/platforms/claude.md`. Plus a `/review-github` proxy-prosecution pass over the external bot review (see below).

## Adversarial Review Score Table (in-pipeline standard review)

16 findings prosecuted, 13 sustained, 3 defense-sustained (M8 perf-premise unevidenced, M10 proposed change would've been harmful, M14 factually-not-silent).

| Finding | Severity | Ruling | Disposition |
|---|---|---|---|
| M1 — pre-check hardcoded repo, writes used ambient `gh` context (cross-repo clobbering risk) | high | Sustained | ✅ Fixed |
| M2 — unconditional `Parent: #N` strip deleted `Add-FollowUpIssue`'s legitimate claim line | high | Sustained | ✅ Fixed |
| M3 — detector regex `(?m)` flag matched every line, not just the first (reintroduced the false-positive class the design eliminated) | medium | Sustained | ✅ Fixed |
| M4 — pre-check missing `sub_issues` GraphQL header + `$parsed.errors` check | medium | Sustained | ✅ Fixed |
| M5 — spurious edit from whitespace-only `TrimEnd()` diff | low | Sustained | ✅ Fixed |
| M6 — dual conflicting parent-claim numbers silently resolved to one | low | Sustained | ✅ Fixed |
| M7 — pre-check had no retry (asymmetric vs. the mutation's 2-attempt retry) | low | Sustained | ✅ Fixed |
| M8 — body-fetch "near-free" premise unevidenced | low | Defense-sustained | Dismissed (no failure mode) |
| M9 — stale "EXPECTED RED" test comments | low | Sustained | ✅ Fixed |
| M10 — regex short-circuit "optimization" | nit | Defense-sustained | Dismissed (would've degraded output) |
| M11 — no test asserted the warning renders in tracker markdown | low | Sustained | ✅ Fixed |
| M12 — untested `#unknown` interpolation branch | low | Sustained | ✅ Fixed |
| M13 — untested missing/closed-parent edge case | low | Sustained | ✅ Fixed |
| M14 — `--body` cmdline-length limit on huge bodies | low | Defense-sustained | Dismissed (failure is loud, not silent; unrealistic body size) |
| M15 — `2>$null` suppressed all `gh` stderr | nit | Sustained | ✅ Fixed |
| M16 — two-producer `parent-link-mode` marker-lifecycle divergence | low | Sustained | 📋 Deferred → [#827](https://github.com/Grimblaz/agent-orchestra/issues/827) |

**Judge confidence: high** — every ruling independently verified against the live tree, not taken from either ledger's say-so.

## GitHub Review Intake (`/review-github`)

External bot review (`gemini-code-assist`) raised 7 inline findings, all one root cause: the M15 fix used `2>$variable`, which does **not** capture stderr in PowerShell (it is a file-redirect operator, so with the variable `$null` at redirect time it discards stderr just like the original `2>$null`). Proxy prosecution → defense → judge sustained all 7 (deduped to one root-cause fix), downgraded severity high → medium (diagnostic-only; control flow and loud-failure behavior intact), and caught that the bot's own suggested fix (merge `2>&1` into one variable, then parse it as JSON) would be **unsafe** at 4 of the 7 sites — `gh` emits stderr notices even on successful exit-0 calls, so merging streams before parsing would corrupt JSON/GraphQL payloads and cause false failures. Fixed with `ErrorRecord`-type stream separation instead (commit `5c65604`). All 7 review threads answered with disposition replies.

## Prosecution Depth Summary

- **Design-challenge** (3-pass, prosecution-only): 12 findings sustained, all incorporated into the design.
- **Plan-stress-test** (5-pass standard, prosecution → defense → judge): 16 findings, 16 sustained (1 critical — a plan-authoring regex bug that would have defeated Class-B detection for the exact motivating incident format).
- **Code-review** (5-pass standard, prosecution → defense → judge): 16 findings, 13 sustained (12 fixed inline, 1 deferred to #827).
- **GitHub review intake** (proxy prosecution → defense → judge): 7 findings, all sustained (one root cause, fixed inline).

Total: 51 findings raised across four adversarial stages of this pipeline; 48 incorporated/fixed, 1 deferred with a tracked follow-up, 2 correctly dismissed by defense/judge scrutiny.

## CE Gate Result

Surface: CLI / script + tracker renderer (no GUI) — pre-set as `code-audit` by the design's own CE Gate readiness assessment; no live browser/interactive session applicable or available (`preview_list` confirmed empty).

| Scenario | Type | Verdict | Evidence type |
|---|---|---|---|
| S1 — documented attach path creates the parent link | Functional | ✅ PASS | code-audit |
| S2 — mis-invocation / attach-failure fails loudly, not silently | Functional | ✅ PASS | code-audit |
| S3 — tracker never silently lies about parentage ("LOUDLY flagged") | Intent | ✅ PASS | code-audit |
| S4 — doc↔script drift cannot recur unnoticed | Functional `[auto]` | ✅ PASS | code-audit |

All 4/4 PASS, independently re-run (not cited from prior reports) and cross-checked against the live source, including a genuine falsifiability check on S4 (confirmed the contract test would actually go RED on a doc regression).

## Pipeline Metrics

- Phases run this session: Experience-Owner, Solution-Designer, Issue-Planner, Code-Conductor (hub mode, full tier — scope classification announced `full` on direct evidence of all three completed upstream markers).
- Scope tier: full (announced, not asked — deterministic rubric).
- D9: fired, "Continue implementation" (auto-mode default, all upstream phases ran this session).
- Phase-containment: design-challenge 12/12 blocks emitted; plan-stress-test 16/16 blocks emitted; code-review 13/13 blocks emitted (all three surfaces verified `clean` via `phase-containment-emission-check.ps1`).

## Process Gaps Found

- Missed the per-step commit gate (`skills/step-commit/SKILL.md`) during initial dispatch of steps s1–s5 — recovered by committing the completed work as one consolidated commit (`46e985a`) rather than five granular step commits. No functional impact; reduces resume-point granularity if this session had been interrupted mid-implementation.
- The `<!-- plan-issue-800 -->` marker was initially omitted when the plan was first persisted (frontmatter posted without the literal marker comment) — caught and corrected via a same-session `PATCH` before `/orchestrate` began, so smart-resume never actually operated on the broken state, but worth noting as a near-miss in the plan-persistence step.
- The version bump was initially missed (release-gate failed on the `bump` leg) — resolved via `bump-version.ps1` (3.3.6 → 3.3.7) + CHANGELOG entry.

Closes #800

<!-- pipeline-metrics
pr_number: 800
branch: feature/issue-800-followup-orphan-drift
metrics_version: 4
frame_version: 1
credits:
  - port: experience
    adapter: work-adapter
    status: passed
    evidence: 'issue #800; experience completion marker posted'
  - port: design
    adapter: work-adapter
    status: passed
    evidence: 'issue #800; design completion marker posted'
  - port: plan
    adapter: work-adapter
    status: passed
    evidence: 'issue #800; plan completion marker posted'
  - port: orchestration
    adapter: scope-classification
    status: passed
    evidence: 'issue #800; scope-classification announced (deterministic rubric)'
  - port: implement-code
    adapter: agents/Senior-Engineer.agent.md
    status: passed
    evidence: 'commits 46e985a (s1 Set-IssueParent.ps1, s3 OrphanClaimWarnings), af52d0e (12 review-fix findings), 5c65604 (7 review-github findings)'
  - port: implement-test
    adapter: agents/Test-Writer.agent.md
    status: passed
    evidence: 'commits 46e985a (s2, s4 test suites), af52d0e (M11-M13 coverage additions); 115/115 tests green'
  - port: implement-docs
    adapter: agents/Doc-Keeper.agent.md
    status: passed
    evidence: 'commit 46e985a (s5, skills/safe-operations/SKILL.md five drift sites + Documents/Design/control-tower-v2.md)'
  - port: review
    adapter: skills/adversarial-review/adapters/standard.md
    status: passed
    evidence: 'standard 5-pass prosecution -> defense -> judge on 46e985a; 16 findings, 13 sustained, 12 fixed inline (af52d0e), 1 deferred to #827; plus /review-github proxy prosecution of 7 bot findings, all sustained, fixed in 5c65604'
  - port: ce-gate-cli
    adapter: skills/customer-experience/adapters/ce-gate-cli.md
    status: passed
    evidence: 'issue #800; S1-S4 all PASS, code-audit evidence type per pre-set design readiness assessment'
-->
