### PR TITLE
chore: portfolio sequence — register #830 after #476

### DIFF
--- a/Documents/Planning/sequence.yaml
+++ b/Documents/Planning/sequence.yaml
@@ -4,4 +4,4 @@
 schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-umbrellas: [761, 571, 732, 343, 693, 674, 662, 476, 801]
+umbrellas: [761, 571, 732, 343, 693, 674, 662, 476, 830, 801]


### PR DESCRIPTION
## Why

#830 (Codex adoption umbrella, restructured 2026-07-09) was created standalone and is not in `Documents/Planning/sequence.yaml`'s ranked umbrella list. Today the Control Tower (#704) shows it only as a Triage standalone (`priority: medium`), and as soon as its Stage A sub-issues are created, every #704 render would emit `⚠️ open umbrella #830 not in ranked list` (render-portfolio.ps1 drift rule).

## Change

One line: insert `830` into the ranked list directly after `476`.

```
umbrellas: [761, 571, 732, 343, 693, 674, 662, 476, 830, 801]
```

**Placement rationale:** #830 Stage B (implement-from-plan pilot) is explicitly blocked on #476 Phase 1/2 (#824/#825/#487 → #489, the USD-per-PR instrument), so it ranks immediately behind #476. #801 (read-surfaces) stays last per the existing portfolio decision (PR #803).

Refs #830, #476, #704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Update portfolio sequencing configuration to include umbrella 830 in the ranked umbrellas list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the portfolio sequence to include umbrella 830 in the priority order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->