### PR TITLE
Attribution-gap repair: trust ladder, honest render, targeted re-walk (#825)

### DIFF
--- a/.github/scripts/Tests/cost-baseline-harvest.Tests.ps1
+++ b/.github/scripts/Tests/cost-baseline-harvest.Tests.ps1
@@ -1430,6 +1430,92 @@ Describe 'Invoke-CostSessionRender AdmitCorroboratedFallback wiring, composed th
         $script:UpsertedBody | Should -Not -Match 'session_completeness: unknown'
     }
 
+    It 'derives the corroboration window start from the earliest commit authoredDate, not createdAt, when the PR has commits (M8 primary-branch coverage)' {
+        # Gap: every other test's gh mock returns a commits-less JSON payload,
+        # so only the createdAt fallback branch (Invoke-CostAttributionRepair
+        # ln ~929) was ever exercised. This test supplies out-of-order commit
+        # authoredDate values that predate createdAt by a multi-day span, and
+        # proves the resolved window start is the EARLIEST authoredDate, not
+        # createdAt — the primary branch (ln ~922-928) that was previously
+        # uncovered.
+        $pr = 822
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -CostSection "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: unknown`npr: $pr`nbranch: HEAD`n-->"
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                # createdAt trails the branch's real first commit by several
+                # days (the #814 flagship gotcha this window bound exists
+                # for) and the commits array is deliberately out of order so
+                # a naive "first element" read would pick the wrong one.
+                return '{"state":"MERGED","headRefName":"feature/issue-822-commits","body":"Fixes #822","createdAt":"2026-06-04T00:00:00Z","mergedAt":"2026-06-08T00:00:00Z","commits":[{"authoredDate":"2026-05-30T08:00:00Z"},{"authoredDate":"2026-05-28T10:00:00Z"},{"authoredDate":"2026-05-31T14:00:00Z"}]}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+
+        $script:CapturedWalkParams = $null
+        function global:Invoke-CostTranscriptWalk {
+            param(
+                [string]$Slug, [string]$Branch, [string]$ParentCwd, [string]$ProjectsRoot = '',
+                [Nullable[int]]$IssueNumber = $null, [string]$RepoRoot = '',
+                [switch]$AdmitCorroboratedFallback,
+                [Nullable[datetime]]$CorroborationWindowStart = $null,
+                [Nullable[datetime]]$CorroborationWindowEnd = $null,
+                [ref]$RejectedDirCountVar,
+                [Nullable[int]]$Tier2IssueNumber = $null
+            )
+            $script:CapturedWalkParams = $PSBoundParameters
+            if ($null -ne $RejectedDirCountVar) { $RejectedDirCountVar.Value = 0 }
+            return @(@{ type = 'assistant'; gitBranch = $Branch; uuid = 'evt-1'; message = @{ content = @() } })
+        }
+        function global:Invoke-CostCopilotWalk {
+            param([string]$Branch, [string]$RepoRoot, [string]$OtelJsonlPath, [string]$WorkspaceFolderBasename = '')
+            return @()
+        }
+        function global:Get-CostAttribution {
+            param([object[]]$Events, [string]$RateTablePath = '')
+            return @{
+                ports                 = @{}
+                orchestrator_overhead = @{ tokens = @{ input = 10; output = 5; cache_creation = 0; cache_read = 0 }; cost_estimate_usd = 0.0; cache_read_hit_ratio = 0.0 }
+                dispatches            = @{ general_purpose_count = 0; unattributed_count = 0 }
+                totals                = @{ total_cost_usd = 0.0; tokens = @{ input = 10; output = 5; cache_creation = 0; cache_read = 0 } }
+            }
+        }
+        function global:Get-CostRollingHistory { param([int]$TimeoutSeconds = 10) return @{ timed_out = $false; entries = @() } }
+        function global:Get-MostRecentRegimeCheckpoint { param([string]$Path) return $null }
+        function global:Get-CostAnomalyFlags { param($ThisRun, [object[]]$RollingHistory, $RegimeCheckpoint) return @() }
+        function global:Get-CostWalkerCurrentSessionId { param([string]$Slug, [string]$Branch, [string]$ParentCwd, [string]$RepoRoot = '') return '' }
+        $script:UpsertedBody = $null
+        function global:Find-OrUpsertComment {
+            param($Type, $Number, $Marker, $Body)
+            $script:UpsertedBody = $Body
+            return $null
+        }
+
+        $previousInline = $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE
+        $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = '1'
+        try {
+            $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+        }
+        finally {
+            $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = $previousInline
+        }
+
+        $script:CapturedWalkParams | Should -Not -BeNullOrEmpty
+        # The earliest of the three out-of-order authoredDate values, NOT
+        # createdAt (2026-06-04) and NOT the first array element (05-30).
+        $script:CapturedWalkParams['CorroborationWindowStart'].ToUniversalTime() | Should -Be ([datetime]'2026-05-28T10:00:00Z').ToUniversalTime()
+        $script:CapturedWalkParams['CorroborationWindowEnd'].ToUniversalTime() | Should -Be ([datetime]'2026-06-08T00:00:00Z').ToUniversalTime()
+        $result.Attempted | Should -Be $true
+        $result.Upserted | Should -Be $true
+    }
+
     It 'excludes a fixture event timestamped outside the PR''s createdAt->mergedAt window, specifically through Invoke-CostAttributionRepair''s own call path (M8 post-review fix)' {
         # Distinct from cost-walker.Tests.ps1's own M8 unit test (which hand-supplies
         # a window directly to Invoke-CostTranscriptWalk): this proves

--- a/.github/scripts/Tests/cost-baseline-harvest.Tests.ps1
+++ b/.github/scripts/Tests/cost-baseline-harvest.Tests.ps1
@@ -1280,6 +1280,44 @@ Describe 'Invoke-CostAttributionRepair (issue #825 s3)' {
         $script:UpsertCalled | Should -Be $false
     }
 
+    It 'refuses to write (no empty-splice data loss) and signals budget-exhaustion when the re-walk finds events but composes an empty cost section (issue #825 CE Gate regression pin)' {
+        # Data-loss reproduction: Invoke-CostSessionRender's step-6g budget-exhaustion
+        # edge returns CostEventsCount > 0 but CostSection = '' when the render budget
+        # is spent before the section is composed. The pre-fix caller guard gated only
+        # on CostEventsCount, so the empty section was spliced over the persisted block
+        # by Merge-CostBaselineHarvestSection (a pure substring splice) — DELETING the
+        # Cost Pattern section from real merged PRs #814/#815. This pins the refusal.
+        $pr = 814
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -PortReportsMarker '### Port Reports (must survive)' -CostSection $script:PreV4DegradedCostSection
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"feature/issue-814-real-branch","body":"Fixes #814"}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+        function global:Invoke-CostSessionRender {
+            param($Pr, $Branch, $Slug, $ParentCwd, $RepoRoot, $PrBody, [switch]$AdmitCorroboratedFallback, $CorroborationWindowStart, $CorroborationWindowEnd)
+            return @{ CostSection = ''; CostEventsCount = 5 }
+        }
+        $script:UpsertCalled = $false
+        function global:Find-OrUpsertComment { $script:UpsertCalled = $true; return $null }
+
+        $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+
+        $script:UpsertCalled | Should -Be $false
+        $result.Upserted | Should -Be $false
+        $result.Signal | Should -Match 'exhausted its render budget'
+        $result.Signal | Should -Not -Match 'repaired'
+    }
+
     It 'skips the write and signals a concurrent-change race when the section changed since the earlier read' {
         $pr = 819
         $originalBody = New-HarvestCompositeCommentBody -Pr $pr -CostSection $script:PreV4DegradedCostSection

--- a/.github/scripts/Tests/cost-baseline-harvest.Tests.ps1
+++ b/.github/scripts/Tests/cost-baseline-harvest.Tests.ps1
@@ -1097,7 +1097,7 @@ Describe 'Invoke-CostAttributionRepair (issue #825 s3)' {
             $joined = $Args -join ' '
             $global:LASTEXITCODE = 0
             if ($joined -match "pr view $pr --json state,headRefName,body") {
-                return '{"state":"MERGED","headRefName":"feature/issue-814-real-branch","body":"Fixes #814"}'
+                return '{"state":"MERGED","headRefName":"feature/issue-814-real-branch","body":"Fixes #814","createdAt":"2026-06-01T00:00:00Z","mergedAt":"2026-06-05T00:00:00Z"}'
             }
             if ($joined -match "pr view $pr --json comments") {
                 return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
@@ -1148,6 +1148,42 @@ Describe 'Invoke-CostAttributionRepair (issue #825 s3)' {
         { Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo' } | Should -Not -Throw
         $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
         $result.Attempted | Should -Be $false
+    }
+
+    It 'skips repair (L9, issue #825 post-review fix) when the corroboration window cannot be resolved — unparseable/absent createdAt and empty commits — without ever calling Invoke-CostSessionRender or Find-OrUpsertComment' {
+        $pr = 825001
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -CostSection $script:PreV4DegradedCostSection
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                # createdAt absent entirely and commits an empty array — window start
+                # cannot resolve via either the earliest-commit or createdAt fallback.
+                return '{"state":"MERGED","headRefName":"feature/unresolvable-window","body":"","mergedAt":"2026-06-05T00:00:00Z","commits":[]}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                # A real session_completeness: unknown composite comment exists — this
+                # test isolates the window-resolution guard, not the earlier
+                # composite-comment/session_completeness gates.
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+        $script:RenderCallCount = 0
+        function global:Invoke-CostSessionRender { $script:RenderCallCount++; return @{ CostSection = '' } }
+        $script:UpsertCalled = $false
+        function global:Find-OrUpsertComment { $script:UpsertCalled = $true; return $null }
+
+        $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+
+        $result.Attempted | Should -Be $false
+        $result.Upserted | Should -Be $false
+        $result.Signal | Should -Be "repair skipped for #$pr — corroboration window could not be resolved"
+        $script:RenderCallCount | Should -Be 0
+        $script:UpsertCalled | Should -Be $false
     }
 
     It 'skips when no composite comment is found for the PR' {
@@ -1212,7 +1248,7 @@ Describe 'Invoke-CostAttributionRepair (issue #825 s3)' {
             $joined = $Args -join ' '
             $global:LASTEXITCODE = 0
             if ($joined -match "pr view $pr --json state,headRefName,body") {
-                return '{"state":"MERGED","headRefName":"feature/issue-814-real-branch","body":"Fixes #814"}'
+                return '{"state":"MERGED","headRefName":"feature/issue-814-real-branch","body":"Fixes #814","createdAt":"2026-06-01T00:00:00Z","mergedAt":"2026-06-05T00:00:00Z"}'
             }
             if ($joined -match "pr view $pr --json comments") {
                 return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
@@ -1258,7 +1294,7 @@ Describe 'Invoke-CostAttributionRepair (issue #825 s3)' {
             $joined = $Args -join ' '
             $global:LASTEXITCODE = 0
             if ($joined -match "pr view $pr --json state,headRefName,body") {
-                return '{"state":"MERGED","headRefName":"feature/issue-815-real-branch","body":"Fixes #815"}'
+                return '{"state":"MERGED","headRefName":"feature/issue-815-real-branch","body":"Fixes #815","createdAt":"2026-06-01T00:00:00Z","mergedAt":"2026-06-05T00:00:00Z"}'
             }
             if ($joined -match "pr view $pr --json comments") {
                 return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
@@ -1296,7 +1332,7 @@ Describe 'Invoke-CostAttributionRepair (issue #825 s3)' {
             $joined = $Args -join ' '
             $global:LASTEXITCODE = 0
             if ($joined -match "pr view $pr --json state,headRefName,body") {
-                return '{"state":"MERGED","headRefName":"feature/issue-814-real-branch","body":"Fixes #814"}'
+                return '{"state":"MERGED","headRefName":"feature/issue-814-real-branch","body":"Fixes #814","createdAt":"2026-06-01T00:00:00Z","mergedAt":"2026-06-05T00:00:00Z"}'
             }
             if ($joined -match "pr view $pr --json comments") {
                 return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
@@ -1330,7 +1366,7 @@ Describe 'Invoke-CostAttributionRepair (issue #825 s3)' {
             $joined = $Args -join ' '
             $global:LASTEXITCODE = 0
             if ($joined -match "pr view $pr --json state,headRefName,body") {
-                return '{"state":"MERGED","headRefName":"feature/race","body":""}'
+                return '{"state":"MERGED","headRefName":"feature/race","body":"","createdAt":"2026-06-01T00:00:00Z","mergedAt":"2026-06-05T00:00:00Z"}'
             }
             if ($joined -match "pr view $pr --json comments") {
                 $script:FetchCallCount++

--- a/.github/scripts/Tests/cost-baseline-harvest.Tests.ps1
+++ b/.github/scripts/Tests/cost-baseline-harvest.Tests.ps1
@@ -1224,7 +1224,8 @@ Describe 'Invoke-CostAttributionRepair (issue #825 s3)' {
             param($Pr, $Branch, $Slug, $ParentCwd, $RepoRoot, $PrBody, [switch]$AdmitCorroboratedFallback, $CorroborationWindowStart, $CorroborationWindowEnd)
             $script:CapturedAdmit = [bool]$AdmitCorroboratedFallback
             return @{
-                CostSection = "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: complete`npr: $Pr`nbranch: $Branch`n-->"
+                CostSection     = "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: complete`npr: $Pr`nbranch: $Branch`n-->"
+                CostEventsCount = 1
             }
         }
         $script:UpsertedBody = $null
@@ -1302,7 +1303,7 @@ Describe 'Invoke-CostAttributionRepair (issue #825 s3)' {
         }
         function global:Invoke-CostSessionRender {
             param($Pr, $Branch, $Slug, $ParentCwd, $RepoRoot, $PrBody, [switch]$AdmitCorroboratedFallback, $CorroborationWindowStart, $CorroborationWindowEnd)
-            return @{ CostSection = "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: complete`npr: $Pr`nbranch: $Branch`n-->" }
+            return @{ CostSection = "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: complete`npr: $Pr`nbranch: $Branch`n-->"; CostEventsCount = 1 }
         }
         $script:UpsertCalled = $false
         function global:Find-OrUpsertComment { $script:UpsertCalled = $true; return $null }
@@ -1366,7 +1367,8 @@ Describe 'Invoke-CostSessionRender AdmitCorroboratedFallback wiring, composed th
                 [switch]$AdmitCorroboratedFallback,
                 [Nullable[datetime]]$CorroborationWindowStart = $null,
                 [Nullable[datetime]]$CorroborationWindowEnd = $null,
-                [ref]$RejectedDirCountVar
+                [ref]$RejectedDirCountVar,
+                [Nullable[int]]$Tier2IssueNumber = $null
             )
             $script:CapturedWalkParams = $PSBoundParameters
             if ($null -ne $RejectedDirCountVar) { $RejectedDirCountVar.Value = 0 }
@@ -1459,7 +1461,8 @@ Describe 'Invoke-CostSessionRender AdmitCorroboratedFallback wiring, composed th
                 [switch]$AdmitCorroboratedFallback,
                 [Nullable[datetime]]$CorroborationWindowStart = $null,
                 [Nullable[datetime]]$CorroborationWindowEnd = $null,
-                [ref]$RejectedDirCountVar
+                [ref]$RejectedDirCountVar,
+                [Nullable[int]]$Tier2IssueNumber = $null
             )
             if ($null -ne $RejectedDirCountVar) { $RejectedDirCountVar.Value = 0 }
 
@@ -1530,5 +1533,321 @@ Describe 'Invoke-CostSessionRender AdmitCorroboratedFallback wiring, composed th
         # the M8 window bound actually took effect through this call path.
         $script:UpsertedBody | Should -Match 'input:\s*100'
         $script:UpsertedBody | Should -Not -Match 'input:\s*200'
+    }
+
+    It 'C10 regression pin: threads the branch-only Tier2IssueNumber (not the PR-body-derived IssueNumber) into the Tier-2 gate when the branch does not name an issue but the PR body does' {
+        # Resolve-FCLLinkedIssueNumber checks the branch prefix FIRST and only
+        # consults the PR body when the branch does not match — so the only
+        # fixture shape where the two resolutions can actually diverge is a
+        # non-issue-prefixed branch alongside a PR body that names an issue.
+        # IssueNumber (IssueNumber-windowing, body-inclusive) must still resolve
+        # via the body; Tier2IssueNumber (corroboration) must NOT — proving C2's
+        # fix rejects the PR-body-derived number specifically for Tier 2.
+        $pr = 823
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -CostSection "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: unknown`npr: $pr`nbranch: HEAD`n-->"
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"chore/unrelated-branch-name","body":"Fixes #999","createdAt":"2026-06-01T00:00:00Z","mergedAt":"2026-06-05T00:00:00Z"}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+
+        $script:CapturedWalkParams = $null
+        function global:Invoke-CostTranscriptWalk {
+            param(
+                [string]$Slug, [string]$Branch, [string]$ParentCwd, [string]$ProjectsRoot = '',
+                [Nullable[int]]$IssueNumber = $null, [string]$RepoRoot = '',
+                [switch]$AdmitCorroboratedFallback,
+                [Nullable[datetime]]$CorroborationWindowStart = $null,
+                [Nullable[datetime]]$CorroborationWindowEnd = $null,
+                [ref]$RejectedDirCountVar,
+                [Nullable[int]]$Tier2IssueNumber = $null
+            )
+            $script:CapturedWalkParams = $PSBoundParameters
+            if ($null -ne $RejectedDirCountVar) { $RejectedDirCountVar.Value = 0 }
+            return @(@{ type = 'assistant'; gitBranch = $Branch; uuid = 'evt-1'; message = @{ content = @() } })
+        }
+        function global:Invoke-CostCopilotWalk {
+            param([string]$Branch, [string]$RepoRoot, [string]$OtelJsonlPath, [string]$WorkspaceFolderBasename = '')
+            return @()
+        }
+        function global:Get-CostAttribution {
+            param([object[]]$Events, [string]$RateTablePath = '')
+            return @{
+                ports                 = @{}
+                orchestrator_overhead = @{ tokens = @{ input = 10; output = 5; cache_creation = 0; cache_read = 0 }; cost_estimate_usd = 0.0; cache_read_hit_ratio = 0.0 }
+                dispatches            = @{ general_purpose_count = 0; unattributed_count = 0 }
+                totals                = @{ total_cost_usd = 0.0; tokens = @{ input = 10; output = 5; cache_creation = 0; cache_read = 0 } }
+            }
+        }
+        function global:Get-CostRollingHistory { param([int]$TimeoutSeconds = 10) return @{ timed_out = $false; entries = @() } }
+        function global:Get-MostRecentRegimeCheckpoint { param([string]$Path) return $null }
+        function global:Get-CostAnomalyFlags { param($ThisRun, [object[]]$RollingHistory, $RegimeCheckpoint) return @() }
+        function global:Get-CostWalkerCurrentSessionId { param([string]$Slug, [string]$Branch, [string]$ParentCwd, [string]$RepoRoot = '') return '' }
+        function global:Find-OrUpsertComment { return $null }
+
+        $previousInline = $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE
+        $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = '1'
+        try {
+            $null = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+        }
+        finally {
+            $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = $previousInline
+        }
+
+        $script:CapturedWalkParams | Should -Not -BeNullOrEmpty
+        $script:CapturedWalkParams['IssueNumber'] | Should -Be 999
+        $script:CapturedWalkParams.ContainsKey('Tier2IssueNumber') | Should -Be $true
+        $script:CapturedWalkParams['Tier2IssueNumber'] | Should -BeNullOrEmpty
+    }
+}
+
+# ---------------------------------------------------------------------------
+# End-to-end regression pins (issue #825 post-review fix cycle, C1/C8/C9): the
+# ENTIRE real pipeline (real Invoke-CostSessionRender -> real
+# Invoke-CostTranscriptWalk -> real Get-CostAttribution) through
+# Invoke-CostAttributionRepair, not the mocked-Invoke-CostTranscriptWalk
+# composition tests above. Only Get-CostRollingHistory, Get-MostRecentRegimeCheckpoint,
+# Get-CostAnomalyFlags, Invoke-CostCopilotWalk, gh, and Find-OrUpsertComment are
+# mocked — everything that decides HOW MANY events get attributed runs for real.
+# This is what makes C8 (the real walker honoring the test-only projects-root
+# override) and C9 (the real walker's own M7 dedup guard, reached through this
+# exact composition path) provable at all.
+# ---------------------------------------------------------------------------
+Describe 'Invoke-CostAttributionRepair end-to-end regression pins (issue #825 post-review fix)' {
+
+    BeforeAll {
+        $script:E2EPathNormalizeLibPath = Join-Path $script:RepoRoot '.github/scripts/lib/path-normalize.ps1'
+        $script:E2EWalkerLibPath = Join-Path $script:RepoRoot '.github/scripts/lib/cost-walker.ps1'
+        $script:E2ECompletenessLibPath = Join-Path $script:RepoRoot '.github/scripts/lib/cost-completeness.ps1'
+        $script:E2ERendererLibPath = Join-Path $script:RepoRoot '.github/scripts/lib/cost-pattern-renderer.ps1'
+        $script:E2ESessionRenderLibPath = Join-Path $script:RepoRoot '.github/scripts/lib/cost-session-render.ps1'
+
+        # Deliberately NOT dot-sourcing cost-walker-copilot.ps1 or cost-attribution.ps1
+        # here: dot-sourcing runs their function definitions into this BeforeAll's own
+        # (Describe-container) scope, which sits BETWEEN each It's scope and true global
+        # scope in PowerShell's function-resolution walk. A same-named `function
+        # global:X` mock defined inside an It body is resolved AFTER that container
+        # scope, so it would be silently shadowed by the real dot-sourced version the
+        # moment production code (reached via the real, dot-sourced Invoke-CostTranscriptWalk
+        # / Invoke-CostSessionRender) calls Invoke-CostCopilotWalk or Get-CostAttribution —
+        # this was empirically confirmed: the REAL Invoke-CostCopilotWalk ran instead of
+        # the mock and scanned this machine's actual git reflog, which is what made these
+        # tests slow/resource-heavy before this fix. Every It below mocks both functions
+        # instead, and neither one needs to be real for what these two tests verify.
+        foreach ($libPath in @(
+                $script:E2EPathNormalizeLibPath, $script:E2EWalkerLibPath,
+                $script:E2ECompletenessLibPath, $script:E2ERendererLibPath,
+                $script:E2ESessionRenderLibPath
+            )) {
+            if (Test-Path $libPath) { . $libPath }
+        }
+
+        function script:Write-E2ETestJsonl {
+            param([string]$Path, [hashtable[]]$Events)
+            $dir = Split-Path -Parent $Path
+            if (-not (Test-Path $dir)) { $null = New-Item -ItemType Directory -Path $dir -Force }
+            $Events | ForEach-Object { $_ | ConvertTo-Json -Compress -Depth 10 } | Set-Content -Path $Path -Encoding utf8NoBOM
+        }
+    }
+
+    It 'C8 regression pin: writes nothing when the REAL re-walk (real Invoke-CostTranscriptWalk, pointed at a temp projects root with no matching transcripts via the test-only env override) finds no activity' {
+        $pr = 824
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -PortReportsMarker '### Port Reports (C8 real empty re-walk)' -CostSection "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: unknown`npr: $pr`nbranch: HEAD`n-->"
+
+        $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-c8-empty-$([System.Guid]::NewGuid())"
+        $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+
+        # Get-CostTranscriptSlug and Get-CostWalkerCurrentSessionId are deliberately left
+        # REAL here (not mocked — see the BeforeAll comment on why a same-named global
+        # mock would be silently shadowed by cost-walker.ps1's own dot-sourced version
+        # anyway). Both are safe unmocked for this scenario: whatever real slug they
+        # resolve for $script:RepoRoot, $tmpProjects is freshly empty so no directory
+        # will ever match it.
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"feature/issue-824-empty","body":"Fixes #824","createdAt":"2026-06-01T00:00:00Z","mergedAt":"2026-06-05T00:00:00Z"}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+        function global:Invoke-CostCopilotWalk {
+            param([string]$Branch, [string]$RepoRoot, [string]$OtelJsonlPath, [string]$WorkspaceFolderBasename = '')
+            return @()
+        }
+        function global:Get-CostRollingHistory { param([int]$TimeoutSeconds = 10) return @{ timed_out = $false; entries = @() } }
+        function global:Get-MostRecentRegimeCheckpoint { param([string]$Path) return $null }
+        function global:Get-CostAnomalyFlags { param($ThisRun, [object[]]$RollingHistory, $RegimeCheckpoint) return @() }
+        # Get-CostWalkerCurrentSessionId is left REAL too (same shadowing reason as
+        # Get-CostTranscriptSlug above — it's defined in cost-walker.ps1 alongside
+        # Invoke-CostTranscriptWalk, which this Describe needs real). It does not honor
+        # the test-only projects-root override (out of C8's scope — only
+        # Invoke-CostTranscriptWalk was fixed), so it scans this machine's real
+        # ~/.claude/projects; that is slower but bounded, and its return value is purely
+        # informational (persisted session_id metadata) — not read by any assertion below.
+        $script:E2EUpsertCalled = $false
+        function global:Find-OrUpsertComment { $script:E2EUpsertCalled = $true; return $null }
+
+        $previousInline = $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE
+        $previousProjectsRoot = $env:FRAME_CREDIT_LEDGER_TEST_CLAUDE_PROJECTS_ROOT
+        $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = '1'
+        $env:FRAME_CREDIT_LEDGER_TEST_CLAUDE_PROJECTS_ROOT = $tmpProjects
+        try {
+            $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd $script:RepoRoot -RepoRoot $script:RepoRoot
+        }
+        finally {
+            $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = $previousInline
+            $env:FRAME_CREDIT_LEDGER_TEST_CLAUDE_PROJECTS_ROOT = $previousProjectsRoot
+            Remove-Item -Recurse -Force $tmpProjects -ErrorAction SilentlyContinue
+        }
+
+        # Proves the C8 wiring: without the projects-root override reaching the REAL
+        # Invoke-CostTranscriptWalk, the walk would fall back to the real user profile
+        # and this assertion would be unreliable (machine-dependent). With it wired,
+        # the temp root is authoritative and guaranteed empty.
+        $result.Attempted | Should -Be $true
+        $result.Upserted | Should -Be $false
+        $result.Signal | Should -Match 'no matching transcripts'
+        $script:E2EUpsertCalled | Should -Be $false
+    }
+
+    It 'C9 regression pin: single-counts (not double-counts) a spanning session admitted via both the primary Tier-1 dir and a Tier-2-corroborated worktree dir sharing the same session id' {
+        $remoteProbe = @(& git -C $script:RepoRoot remote get-url origin 2>&1) | Select-Object -First 1
+        if ($global:LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($remoteProbe)) {
+            Set-ItResult -Skipped -Because 'cannot resolve test repo remote for Tier-2 identity resolution'
+            return
+        }
+
+        $pr = 825
+        $branch = 'feature/issue-825-spanning-session'
+        $sessionId = 'spanning-session-825'
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -PortReportsMarker '### Port Reports (C9 spanning session)' -CostSection "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: unknown`npr: $pr`nbranch: HEAD`n-->"
+
+        $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-c9-spanning-$([System.Guid]::NewGuid())"
+        $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+        $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-c9-missing-worktree-$([System.Guid]::NewGuid())"
+
+        # Real (non-mocked) slug derivation — resolved BEFORE Get-CostTranscriptSlug is
+        # mocked below, so the primary dir's name matches exactly what the real walk's
+        # primary-slug fallback (script:Resolve-CostWalkerPrimarySlugDir) looks for.
+        $primarySlug = Get-CostTranscriptSlug -CwdPath $script:RepoRoot
+        $primaryDir = Join-Path $tmpProjects $primarySlug
+        $null = New-Item -ItemType Directory -Path $primaryDir -Force
+
+        $candidateDir = Join-Path $tmpProjects 'corroborated-worktree-candidate'
+        $null = New-Item -ItemType Directory -Path $candidateDir -Force
+
+        # Primary dir's session file: a phase marker naming issue 825 (M14 cross-file
+        # corroboration signal, consumed by the Tier-2 candidate below) plus the
+        # session's own admitted assistant event (strict cwd+branch match).
+        $phaseMarkerEvent = @{
+            type      = 'user'
+            message   = @{ content = '<command-name>/plan</command-name><command-args>825</command-args>' }
+            gitBranch = 'main'
+            timestamp = '2026-06-01T00:00:00Z'
+        }
+        $primaryAssistantEvent = @{
+            type      = 'assistant'
+            uuid      = 'evt-spanning-1'
+            timestamp = '2026-06-02T00:00:00Z'
+            cwd       = $script:RepoRoot
+            gitBranch = $branch
+            message   = @{ usage = @{ input_tokens = 10; output_tokens = 5 }; content = @() }
+        }
+        # Tier-2 candidate: SAME session id (file BaseName) and SAME event uuid as the
+        # primary dir's event — simulating a deleted-worktree checkout of the identical
+        # session. cwd points at a path that does not exist on disk (M9 cwd-absent
+        # trigger); branch matches (Tier-2 branch-matched-file signal).
+        $candidateAssistantEvent = @{
+            type      = 'assistant'
+            uuid      = 'evt-spanning-1'
+            timestamp = '2026-06-02T00:05:00Z'
+            cwd       = $missingCwd
+            gitBranch = $branch
+            message   = @{ usage = @{ input_tokens = 10; output_tokens = 5 }; content = @() }
+        }
+
+        script:Write-E2ETestJsonl -Path (Join-Path $primaryDir "$sessionId.jsonl") -Events @($phaseMarkerEvent, $primaryAssistantEvent)
+        script:Write-E2ETestJsonl -Path (Join-Path $candidateDir "$sessionId.jsonl") -Events @($candidateAssistantEvent)
+
+        # Get-CostTranscriptSlug and Get-CostWalkerCurrentSessionId are deliberately left
+        # REAL (see the BeforeAll comment — a same-named global mock would be silently
+        # shadowed by cost-walker.ps1's own dot-sourced version anyway). This is exactly
+        # what we want here: $primaryDir was named using this same real function against
+        # this same $script:RepoRoot, so the real re-resolution inside
+        # Invoke-CostAttributionRepair lands on the identical slug/dir.
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return (@{ state = 'MERGED'; headRefName = $branch; body = 'Fixes #825'; createdAt = '2026-06-01T00:00:00Z'; mergedAt = '2026-06-05T00:00:00Z' } | ConvertTo-Json -Compress)
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+        function global:Invoke-CostCopilotWalk {
+            param([string]$Branch, [string]$RepoRoot, [string]$OtelJsonlPath, [string]$WorkspaceFolderBasename = '')
+            return @()
+        }
+        # Deterministic token accounting keyed on the REAL walk's own event count: 100
+        # input tokens per DISTINCT admitted event, so single-counting (100) reads
+        # differently from double-counting (200) in the final rendered/upserted body.
+        function global:Get-CostAttribution {
+            param([object[]]$Events, [string]$RateTablePath = '')
+            $inputTokens = @($Events).Count * 100
+            return @{
+                ports                 = @{}
+                orchestrator_overhead = @{ tokens = @{ input = $inputTokens; output = 0; cache_creation = 0; cache_read = 0 }; cost_estimate_usd = 0.0; cache_read_hit_ratio = 0.0 }
+                dispatches            = @{ general_purpose_count = 0; unattributed_count = 0 }
+                totals                = @{ total_cost_usd = 0.0; tokens = @{ input = $inputTokens; output = 0; cache_creation = 0; cache_read = 0 } }
+            }
+        }
+        function global:Get-CostRollingHistory { param([int]$TimeoutSeconds = 10) return @{ timed_out = $false; entries = @() } }
+        function global:Get-MostRecentRegimeCheckpoint { param([string]$Path) return $null }
+        function global:Get-CostAnomalyFlags { param($ThisRun, [object[]]$RollingHistory, $RegimeCheckpoint) return @() }
+        # Get-CostWalkerCurrentSessionId is left REAL too — see the C8 test's comment
+        # above; its return value here is purely informational and unread by any assertion.
+        $script:E2EUpsertedBody = $null
+        function global:Find-OrUpsertComment {
+            param($Type, $Number, $Marker, $Body)
+            $script:E2EUpsertedBody = $Body
+            return $null
+        }
+
+        $previousInline = $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE
+        $previousProjectsRoot = $env:FRAME_CREDIT_LEDGER_TEST_CLAUDE_PROJECTS_ROOT
+        $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = '1'
+        $env:FRAME_CREDIT_LEDGER_TEST_CLAUDE_PROJECTS_ROOT = $tmpProjects
+        try {
+            $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd $script:RepoRoot -RepoRoot $script:RepoRoot
+        }
+        finally {
+            $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = $previousInline
+            $env:FRAME_CREDIT_LEDGER_TEST_CLAUDE_PROJECTS_ROOT = $previousProjectsRoot
+            Remove-Item -Recurse -Force $tmpProjects -ErrorAction SilentlyContinue
+            Remove-Item -Recurse -Force $missingCwd -ErrorAction SilentlyContinue
+        }
+
+        $result.Attempted | Should -Be $true
+        $result.Upserted | Should -Be $true
+        $script:E2EUpsertedBody | Should -Not -BeNullOrEmpty
+        $script:E2EUpsertedBody | Should -Match 'input:\s*100'
+        $script:E2EUpsertedBody | Should -Not -Match 'input:\s*200'
     }
 }

--- a/.github/scripts/Tests/cost-baseline-harvest.Tests.ps1
+++ b/.github/scripts/Tests/cost-baseline-harvest.Tests.ps1
@@ -1067,3 +1067,468 @@ _end of comment_
         }
     }
 }
+
+# ---------------------------------------------------------------------------
+# Invoke-CostAttributionRepair (issue #825, Step 3) — targeted, maintainer-
+# invoked single-PR re-attribution repair. Deliberately a SEPARATE Describe
+# from Invoke-CostBaselineHarvest above: this function is not part of, and
+# never calls into, script:Select-CostBaselineHarvestCandidates' automatic
+# candidate loop or Invoke-CostBaselineHarvest's own promote/stamp machinery.
+#
+# The #814/#815 degraded fixture (M13): the real pre-#824 CI-written blocks
+# for those PRs carry ONLY session_completeness/pr/branch (branch reads the
+# literal string "HEAD", never a real ref) — no head_ref/session_id/
+# capture_point. $script:PreV4DegradedCostSection reproduces that exact
+# shape so the AC3 regression proves something real rather than a strawman.
+# ---------------------------------------------------------------------------
+Describe 'Invoke-CostAttributionRepair (issue #825 s3)' {
+
+    BeforeAll {
+        $script:PreV4DegradedCostSection = "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: unknown`npr: 814`nbranch: HEAD`n-->"
+    }
+
+    It 'resolves the PR''s REAL head ref via gh pr view and passes it (never the persisted branch: HEAD field) to Invoke-CostSessionRender (M2/M15)' {
+        $pr = 814
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -CostSection $script:PreV4DegradedCostSection
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"feature/issue-814-real-branch","body":"Fixes #814"}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+        $script:CapturedBranch = $null
+        function global:Invoke-CostSessionRender {
+            param($Pr, $Branch, $Slug, $ParentCwd, $RepoRoot, $PrBody, [switch]$AdmitCorroboratedFallback, $CorroborationWindowStart, $CorroborationWindowEnd)
+            $script:CapturedBranch = $Branch
+            return @{ CostSection = "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: complete`npr: $Pr`nbranch: $Branch`n-->" }
+        }
+        function global:Find-OrUpsertComment { return $null }
+
+        $null = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+
+        $script:CapturedBranch | Should -Be 'feature/issue-814-real-branch'
+        $script:CapturedBranch | Should -Not -Be 'HEAD'
+    }
+
+    It 'skips a PR that is not MERGED, without ever calling Invoke-CostSessionRender' {
+        $pr = 815
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $global:LASTEXITCODE = 0
+            return '{"state":"OPEN","headRefName":"feature/still-open","body":""}'
+        }
+        $script:RenderCallCount = 0
+        function global:Invoke-CostSessionRender { $script:RenderCallCount++; return @{ CostSection = '' } }
+
+        $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+
+        $result.Attempted | Should -Be $false
+        $result.Upserted | Should -Be $false
+        $script:RenderCallCount | Should -Be 0
+    }
+
+    It 'skips when the gh pr view call itself fails' {
+        $pr = 816
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $global:LASTEXITCODE = 1
+            return ''
+        }
+
+        { Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo' } | Should -Not -Throw
+        $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+        $result.Attempted | Should -Be $false
+    }
+
+    It 'skips when no composite comment is found for the PR' {
+        $pr = 817
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"feature/no-comment","body":""}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @() } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+        $script:RenderCallCount = 0
+        function global:Invoke-CostSessionRender { $script:RenderCallCount++; return @{ CostSection = '' } }
+
+        $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+
+        $result.Attempted | Should -Be $false
+        $script:RenderCallCount | Should -Be 0
+    }
+
+    It 'leaves an already-populated (non-unknown) persisted block untouched' {
+        $pr = 818
+        $populatedSection = "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: complete`npr: $pr`nbranch: feature/already-good`n-->"
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -CostSection $populatedSection
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"feature/already-good","body":""}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+        $script:RenderCallCount = 0
+        function global:Invoke-CostSessionRender { $script:RenderCallCount++; return @{ CostSection = '' } }
+
+        $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+
+        $result.Attempted | Should -Be $false
+        $result.Signal | Should -Match 'not session_completeness: unknown'
+        $script:RenderCallCount | Should -Be 0
+    }
+
+    It 'reproduces the pre-#824 #814/#815 degraded fixture shape and upserts a populated re-walk (populated-beats-empty-unknown, M13)' {
+        $pr = 814
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -PortReportsMarker '### Port Reports (must survive repair)' -CostSection $script:PreV4DegradedCostSection
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"feature/issue-814-real-branch","body":"Fixes #814"}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+        $script:CapturedAdmit = $false
+        function global:Invoke-CostSessionRender {
+            param($Pr, $Branch, $Slug, $ParentCwd, $RepoRoot, $PrBody, [switch]$AdmitCorroboratedFallback, $CorroborationWindowStart, $CorroborationWindowEnd)
+            $script:CapturedAdmit = [bool]$AdmitCorroboratedFallback
+            return @{
+                CostSection = "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: complete`npr: $Pr`nbranch: $Branch`n-->"
+            }
+        }
+        $script:UpsertedBody = $null
+        function global:Find-OrUpsertComment {
+            param($Type, $Number, $Marker, $Body)
+            $script:UpsertedBody = $Body
+            return $null
+        }
+
+        $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+
+        $result.Attempted | Should -Be $true
+        $result.Upserted | Should -Be $true
+        $result.Signal | Should -Be "repaired #$pr — attribution re-walked and upserted"
+        $script:CapturedAdmit | Should -Be $true
+        $script:UpsertedBody | Should -Not -BeNullOrEmpty
+        $script:UpsertedBody | Should -Match '### Port Reports \(must survive repair\)'
+        $script:UpsertedBody | Should -Match 'session_completeness: complete'
+        $script:UpsertedBody | Should -Not -Match 'session_completeness: unknown'
+        (@([regex]::Matches($script:UpsertedBody, '<!--\s*cost-pattern-data')).Count) | Should -Be 1
+    }
+
+    It 'reports honestly and writes nothing when the re-walk finds no matching transcripts on this machine' {
+        $pr = 815
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -PortReportsMarker '### Port Reports (must survive no-op)' -CostSection $script:PreV4DegradedCostSection
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"feature/issue-815-real-branch","body":"Fixes #815"}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+        function global:Invoke-CostSessionRender {
+            param($Pr, $Branch, $Slug, $ParentCwd, $RepoRoot, $PrBody, [switch]$AdmitCorroboratedFallback, $CorroborationWindowStart, $CorroborationWindowEnd)
+            return @{ CostSection = '' }
+        }
+        $script:UpsertCalled = $false
+        function global:Find-OrUpsertComment { $script:UpsertCalled = $true; return $null }
+
+        $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+
+        $result.Attempted | Should -Be $true
+        $result.Upserted | Should -Be $false
+        $result.Signal | Should -Match 'no matching transcripts'
+        $script:UpsertCalled | Should -Be $false
+    }
+
+    It 'skips the write and signals a concurrent-change race when the section changed since the earlier read' {
+        $pr = 819
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -CostSection $script:PreV4DegradedCostSection
+        $changedBody = New-HarvestCompositeCommentBody -Pr $pr -CostSection "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: complete`npr: $pr`nbranch: someone-else-raced-us`n-->"
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        $script:FetchCallCount = 0
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"feature/race","body":""}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                $script:FetchCallCount++
+                $body = if ($script:FetchCallCount -eq 1) { $originalBody } else { $changedBody }
+                return (@{ comments = @(@{ body = $body; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+        function global:Invoke-CostSessionRender {
+            param($Pr, $Branch, $Slug, $ParentCwd, $RepoRoot, $PrBody, [switch]$AdmitCorroboratedFallback, $CorroborationWindowStart, $CorroborationWindowEnd)
+            return @{ CostSection = "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: complete`npr: $Pr`nbranch: $Branch`n-->" }
+        }
+        $script:UpsertCalled = $false
+        function global:Find-OrUpsertComment { $script:UpsertCalled = $true; return $null }
+
+        $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+
+        $result.Upserted | Should -Be $false
+        $result.Signal | Should -Match 'concurrent change'
+        $script:UpsertCalled | Should -Be $false
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Composition/wiring regression (issue #825 s3): proves -AdmitCorroboratedFallback
+# actually reaches Invoke-CostTranscriptWalk when Invoke-CostAttributionRepair
+# calls the REAL (dot-sourced, not mocked) Invoke-CostSessionRender. This is the
+# specific regression this slice's grounding surfaced: cost-session-render.ps1
+# (as landed by s2) accepted no -AdmitCorroboratedFallback parameter at all and
+# never threaded one into its own walkParameters hashtable, so s3's own plan
+# text ("call Invoke-CostSessionRender with -AdmitCorroboratedFallback on") was
+# not actually possible before this slice's own edit to that file. Only
+# Invoke-CostTranscriptWalk is mocked (to capture what it actually receives,
+# without touching the real filesystem); Resolve-BaselineEligibility and the
+# Format-CostPattern* renderers run for REAL (dot-sourced from
+# cost-completeness.ps1 / cost-pattern-renderer.ps1), matching the established
+# "does NOT stub" convention already used by cost-integration.Tests.ps1's own
+# issue #824 s3 caller-wiring invoker.
+# ---------------------------------------------------------------------------
+Describe 'Invoke-CostSessionRender AdmitCorroboratedFallback wiring, composed through Invoke-CostAttributionRepair (issue #825 s3)' {
+
+    BeforeAll {
+        $script:SessionRenderLibPath = Join-Path $script:RepoRoot '.github/scripts/lib/cost-session-render.ps1'
+        $script:CompletenessLibPath = Join-Path $script:RepoRoot '.github/scripts/lib/cost-completeness.ps1'
+        if (Test-Path $script:CompletenessLibPath) { . $script:CompletenessLibPath }
+        if (Test-Path $script:SessionRenderLibPath) { . $script:SessionRenderLibPath }
+    }
+
+    It 'threads -AdmitCorroboratedFallback through to the real Invoke-CostTranscriptWalk call' {
+        $pr = 820
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -CostSection "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: unknown`npr: $pr`nbranch: HEAD`n-->"
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"feature/issue-820-wiring","body":"Fixes #820","createdAt":"2026-06-01T00:00:00Z","mergedAt":"2026-06-05T00:00:00Z"}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+
+        $script:CapturedWalkParams = $null
+        function global:Invoke-CostTranscriptWalk {
+            param(
+                [string]$Slug, [string]$Branch, [string]$ParentCwd, [string]$ProjectsRoot = '',
+                [Nullable[int]]$IssueNumber = $null, [string]$RepoRoot = '',
+                [switch]$AdmitCorroboratedFallback,
+                [Nullable[datetime]]$CorroborationWindowStart = $null,
+                [Nullable[datetime]]$CorroborationWindowEnd = $null,
+                [ref]$RejectedDirCountVar
+            )
+            $script:CapturedWalkParams = $PSBoundParameters
+            if ($null -ne $RejectedDirCountVar) { $RejectedDirCountVar.Value = 0 }
+            return @(@{ type = 'assistant'; gitBranch = $Branch; uuid = 'evt-1'; message = @{ content = @() } })
+        }
+        function global:Invoke-CostCopilotWalk {
+            param([string]$Branch, [string]$RepoRoot, [string]$OtelJsonlPath, [string]$WorkspaceFolderBasename = '')
+            return @()
+        }
+        function global:Get-CostAttribution {
+            param([object[]]$Events, [string]$RateTablePath = '')
+            return @{
+                ports                 = @{}
+                orchestrator_overhead = @{ tokens = @{ input = 10; output = 5; cache_creation = 0; cache_read = 0 }; cost_estimate_usd = 0.0; cache_read_hit_ratio = 0.0 }
+                dispatches            = @{ general_purpose_count = 0; unattributed_count = 0 }
+                totals                = @{ total_cost_usd = 0.0; tokens = @{ input = 10; output = 5; cache_creation = 0; cache_read = 0 } }
+            }
+        }
+        function global:Get-CostRollingHistory { param([int]$TimeoutSeconds = 10) return @{ timed_out = $false; entries = @() } }
+        function global:Get-MostRecentRegimeCheckpoint { param([string]$Path) return $null }
+        function global:Get-CostAnomalyFlags { param($ThisRun, [object[]]$RollingHistory, $RegimeCheckpoint) return @() }
+        function global:Get-CostWalkerCurrentSessionId { param([string]$Slug, [string]$Branch, [string]$ParentCwd, [string]$RepoRoot = '') return '' }
+        $script:UpsertedBody = $null
+        function global:Find-OrUpsertComment {
+            param($Type, $Number, $Marker, $Body)
+            $script:UpsertedBody = $Body
+            return $null
+        }
+
+        # Inline-execute the walker call (no isolated runspace) so the mocked
+        # Invoke-CostTranscriptWalk's $script:CapturedWalkParams assignment
+        # lands in THIS scope rather than a cloned runspace's own copy —
+        # matches the established FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE
+        # convention used throughout cost-integration.Tests.ps1.
+        $previousInline = $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE
+        $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = '1'
+        try {
+            $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+        }
+        finally {
+            $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = $previousInline
+        }
+
+        $script:CapturedWalkParams | Should -Not -BeNullOrEmpty
+        $script:CapturedWalkParams['AdmitCorroboratedFallback'] | Should -Be $true
+        $script:CapturedWalkParams['Branch'] | Should -Be 'feature/issue-820-wiring'
+        # M8 wiring gap fix: the PR's own createdAt/mergedAt (fetched on the same
+        # gh pr view call as headRefName, no extra API round-trip) must reach the
+        # walker call as the corroboration window — not stay $null/unbounded.
+        # .ToUniversalTime() normalizes Kind (ConvertFrom-Json's date coercion
+        # preserves Utc Kind; a bare string-literal [datetime] cast in this test
+        # converts to Local Kind) so the comparison is instant-equality, not a
+        # Kind/offset-display mismatch.
+        $script:CapturedWalkParams['CorroborationWindowStart'].ToUniversalTime() | Should -Be ([datetime]'2026-06-01T00:00:00Z').ToUniversalTime()
+        $script:CapturedWalkParams['CorroborationWindowEnd'].ToUniversalTime() | Should -Be ([datetime]'2026-06-05T00:00:00Z').ToUniversalTime()
+        $result.Attempted | Should -Be $true
+        $result.Upserted | Should -Be $true
+        $script:UpsertedBody | Should -Match 'session_completeness'
+        $script:UpsertedBody | Should -Not -Match 'session_completeness: unknown'
+    }
+
+    It 'excludes a fixture event timestamped outside the PR''s createdAt->mergedAt window, specifically through Invoke-CostAttributionRepair''s own call path (M8 post-review fix)' {
+        # Distinct from cost-walker.Tests.ps1's own M8 unit test (which hand-supplies
+        # a window directly to Invoke-CostTranscriptWalk): this proves
+        # Invoke-CostAttributionRepair itself DERIVES the window from the target
+        # PR's real createdAt/mergedAt and that a real walker honoring that window
+        # would exclude an out-of-window event reached through this exact call
+        # path — not merely that the switch/window values are captured in transit.
+        $pr = 821
+        $originalBody = New-HarvestCompositeCommentBody -Pr $pr -CostSection "## Cost Pattern`n<!-- cost-pattern-data`nsession_completeness: unknown`npr: $pr`nbranch: HEAD`n-->"
+
+        function global:Get-CostTranscriptSlug { param($CwdPath) return 'test-slug' }
+        function global:gh {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+            $joined = $Args -join ' '
+            $global:LASTEXITCODE = 0
+            if ($joined -match "pr view $pr --json state,headRefName,body") {
+                return '{"state":"MERGED","headRefName":"feature/issue-821-window","body":"Fixes #821","createdAt":"2026-06-01T00:00:00Z","mergedAt":"2026-06-05T00:00:00Z"}'
+            }
+            if ($joined -match "pr view $pr --json comments") {
+                return (@{ comments = @(@{ body = $originalBody; authorAssociation = 'OWNER' }) } | ConvertTo-Json -Depth 6 -Compress)
+            }
+            return ''
+        }
+
+        function global:Invoke-CostTranscriptWalk {
+            param(
+                [string]$Slug, [string]$Branch, [string]$ParentCwd, [string]$ProjectsRoot = '',
+                [Nullable[int]]$IssueNumber = $null, [string]$RepoRoot = '',
+                [switch]$AdmitCorroboratedFallback,
+                [Nullable[datetime]]$CorroborationWindowStart = $null,
+                [Nullable[datetime]]$CorroborationWindowEnd = $null,
+                [ref]$RejectedDirCountVar
+            )
+            if ($null -ne $RejectedDirCountVar) { $RejectedDirCountVar.Value = 0 }
+
+            # Two Tier-2 candidate events from a same-repo reused-branch-name
+            # collision scenario (M8's own threat model): one inside the PR's
+            # real lifetime, one from 3 days BEFORE it was even created (the
+            # kind of stale, same-branch-name event M8 exists to exclude).
+            # This mock applies the IDENTICAL window predicate cost-walker.ps1's
+            # own Tier-2 loop applies (see Invoke-CostTranscriptWalk's
+            # CorroborationWindowStart/End handling) so a non-null window
+            # reaching this call actually changes what gets admitted — proving
+            # the wiring, not just capturing it in transit.
+            $inWindowEvent = @{ type = 'assistant'; gitBranch = $Branch; uuid = 'evt-in-window'; timestamp = '2026-06-02T00:00:00Z'; message = @{ content = @() } }
+            $outOfWindowEvent = @{ type = 'assistant'; gitBranch = $Branch; uuid = 'evt-out-of-window'; timestamp = '2026-05-29T00:00:00Z'; message = @{ content = @() } }
+
+            $admitted = [System.Collections.Generic.List[object]]::new()
+            foreach ($ev in @($inWindowEvent, $outOfWindowEvent)) {
+                $ts = [datetime]$ev['timestamp']
+                if ($null -ne $CorroborationWindowStart -and $ts -lt $CorroborationWindowStart) { continue }
+                if ($null -ne $CorroborationWindowEnd -and $ts -gt $CorroborationWindowEnd) { continue }
+                $admitted.Add($ev)
+            }
+            return $admitted
+        }
+        function global:Invoke-CostCopilotWalk {
+            param([string]$Branch, [string]$RepoRoot, [string]$OtelJsonlPath, [string]$WorkspaceFolderBasename = '')
+            return @()
+        }
+        # Encodes admitted-event count into input tokens (100 per event) so the
+        # final rendered/upserted body distinguishes "both events admitted"
+        # (200) from "only the in-window event admitted" (100) without needing
+        # the real cost-attribution.ps1 pipeline dot-sourced.
+        function global:Get-CostAttribution {
+            param([object[]]$Events, [string]$RateTablePath = '')
+            $inputTokens = @($Events).Count * 100
+            return @{
+                ports                 = @{}
+                orchestrator_overhead = @{ tokens = @{ input = $inputTokens; output = 0; cache_creation = 0; cache_read = 0 }; cost_estimate_usd = 0.0; cache_read_hit_ratio = 0.0 }
+                dispatches            = @{ general_purpose_count = 0; unattributed_count = 0 }
+                totals                = @{ total_cost_usd = 0.0; tokens = @{ input = $inputTokens; output = 0; cache_creation = 0; cache_read = 0 } }
+            }
+        }
+        function global:Get-CostRollingHistory { param([int]$TimeoutSeconds = 10) return @{ timed_out = $false; entries = @() } }
+        function global:Get-MostRecentRegimeCheckpoint { param([string]$Path) return $null }
+        function global:Get-CostAnomalyFlags { param($ThisRun, [object[]]$RollingHistory, $RegimeCheckpoint) return @() }
+        function global:Get-CostWalkerCurrentSessionId { param([string]$Slug, [string]$Branch, [string]$ParentCwd, [string]$RepoRoot = '') return '' }
+        $script:UpsertedBody = $null
+        function global:Find-OrUpsertComment {
+            param($Type, $Number, $Marker, $Body)
+            $script:UpsertedBody = $Body
+            return $null
+        }
+
+        $previousInline = $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE
+        $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = '1'
+        try {
+            $result = Invoke-CostAttributionRepair -Pr $pr -ParentCwd 'C:\fake\cwd' -RepoRoot 'C:\fake\repo'
+        }
+        finally {
+            $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = $previousInline
+        }
+
+        $result.Attempted | Should -Be $true
+        $result.Upserted | Should -Be $true
+        $script:UpsertedBody | Should -Not -BeNullOrEmpty
+        # Only the in-window event (100 input tokens) reached attribution — the
+        # pre-createdAt event (which would make it 200) was excluded, proving
+        # the M8 window bound actually took effect through this call path.
+        $script:UpsertedBody | Should -Match 'input:\s*100'
+        $script:UpsertedBody | Should -Not -Match 'input:\s*200'
+    }
+}

--- a/.github/scripts/Tests/cost-fcl-helpers-relocation.Tests.ps1
+++ b/.github/scripts/Tests/cost-fcl-helpers-relocation.Tests.ps1
@@ -177,4 +177,101 @@ Describe 'cost-session-render harvest dependency chain (issue #824 post-review f
         $captured.CostSection | Should -Not -BeNullOrEmpty -Because 'a real cost section must have been rendered from the fixture event'
         $captured.TokenSum | Should -Be 160 -Because 'input(120) + output(40) from the fixture event, summed via the relocated script:Get-FCLTokenSumFromBucket — proves the relocated function is both reachable AND executing correctly, not just silently absent'
     }
+
+    It 'M17 regression pin (L10, issue #825 post-review fix): $costEvents is guarded in the return block, so a StrictMode read never throws when an FCL helper call fails before $costEvents'' own first assignment' {
+        # Reproduces the exact M17 gap: script:Get-FCLCostWalkerTimeoutSeconds (the
+        # very first FCL call inside the try block, well before "$costEvents = @()"
+        # is reached) throws — caught by Invoke-CostSessionRender's own outer
+        # fail-open catch, which never assigns $costEvents. Without the costEvents
+        # guard line in the pre-return block, "CostEventsCount = @($costEvents).Count"
+        # in the final return statement throws under Set-StrictMode -Version Latest
+        # (a genuinely unassigned variable read), defeating the fail-open contract
+        # this whole guard block exists to preserve.
+        #
+        # Deliberately dot-sources the FULL, CORRECT (post-fix) dependency set —
+        # exactly like the GREEN test above — and forces the failure with an
+        # explicit override of script:Get-FCLCostWalkerTimeoutSeconds, rather than
+        # reproducing it via an incomplete dot-source list. Unlike the RED test
+        # above, a real cost-fcl-helpers.ps1 dot-source at "function script:X {}"
+        # scope is sticky across Its within the same Pester file run, so an
+        # omission-based repro run AFTER the GREEN test would silently inherit the
+        # GREEN test's already-defined script-scope function and never reproduce
+        # the throw at all — this explicit-override approach is immune to that
+        # ordering hazard and targets the exact call site directly.
+        $repoRoot = $script:RepoRoot
+        $fixtureEventsScript = $script:FixtureEventsScript
+
+        $captured = & {
+            param($repoRoot, $fixtureEventsScript)
+            $events = & $fixtureEventsScript
+
+            # The CORRECTED Step 7d set (matches the GREEN test above).
+            . (Join-Path $repoRoot '.github/scripts/lib/path-normalize.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-walker.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-walker-copilot.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-attribution.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-anomaly.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-rolling-history.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-checkpoint-core.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-completeness.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-pattern-renderer.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-fcl-helpers.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-session-render.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/find-or-upsert-comment.ps1')
+            . (Join-Path $repoRoot '.github/scripts/lib/cost-baseline-harvest.ps1')
+
+            function Invoke-CostTranscriptWalk {
+                param([string]$Slug, [string]$Branch, [string]$ParentCwd, [Nullable[int]]$IssueNumber = $null)
+                return $events
+            }
+            function Invoke-CostCopilotWalk {
+                param([string]$Branch, [string]$RepoRoot, [string]$OtelJsonlPath, [string]$WorkspaceFolderBasename = '')
+                return @()
+            }
+            # Forces the exact M17 reproduction: the FIRST FCL call inside
+            # Invoke-CostSessionRender's try block throws, well before
+            # "$costEvents = @()" is ever reached.
+            function script:Get-FCLCostWalkerTimeoutSeconds {
+                param([string]$EnvironmentVariableName, [int]$DefaultSeconds)
+                throw 'M17 regression pin: forced failure before $costEvents is assigned'
+            }
+
+            $previousInline = $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE
+            $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = '1'
+
+            # The load-bearing part of this test: force StrictMode Latest in THIS
+            # scope so an unassigned $costEvents read in the return block would
+            # actually throw if the guard were missing.
+            Set-StrictMode -Version Latest
+
+            $stderrWriter = [System.IO.StringWriter]::new()
+            $originalError = [Console]::Error
+            [Console]::SetError($stderrWriter)
+            $renderResult = $null
+            $threw = $false
+            $thrownMessage = ''
+            try {
+                $renderResult = Invoke-CostSessionRender -Pr 824003 -Branch 'feature/issue-824-fixture' -Slug 'fixture-slug' -ParentCwd $repoRoot -RepoRoot $repoRoot
+            }
+            catch {
+                $threw = $true
+                $thrownMessage = $_.Exception.Message
+            }
+            finally {
+                [Console]::SetError($originalError)
+                $env:FRAME_CREDIT_LEDGER_TEST_WALKER_INLINE = $previousInline
+            }
+
+            return @{
+                Threw           = $threw
+                ThrownMessage   = $thrownMessage
+                Stderr          = $stderrWriter.ToString()
+                CostEventsCount = $renderResult.CostEventsCount
+            }
+        } $repoRoot $fixtureEventsScript
+
+        $captured.Stderr | Should -Match 'M17 regression pin: forced failure' -Because 'confirms the forced failure actually fired inside the try block, proving this is a real reproduction and not a no-op'
+        $captured.Threw | Should -Be $false -Because "Invoke-CostSessionRender's own fail-open contract must hold under StrictMode even when an FCL helper fails before `$costEvents is first assigned; got: $($captured.ThrownMessage)"
+        $captured.CostEventsCount | Should -Be 0 -Because 'the costEvents guard defaults it to an empty array before the return block reads @($costEvents).Count'
+    }
 }

--- a/.github/scripts/Tests/cost-pattern-renderer.Tests.ps1
+++ b/.github/scripts/Tests/cost-pattern-renderer.Tests.ps1
@@ -246,17 +246,18 @@ Describe 'Format-CostPatternMarkdown' {
             $result | Should -Match 'max_tokens'
         }
 
-        It 'unknown: header renders cross-tool diagnostic and unavailable cost fields' {
+        It 'unknown: header renders honest environment-state diagnostic and unavailable cost fields, no #488 pointer' {
             $attribution = script:Add-CoverageMetadata `
                 -Attribution (script:New-MinimalAttribution) `
                 -Coverage 'claude-only-with-copilot-fallback-warning' `
                 -InstallStatus 'missing-or-fallback' `
                 -ProviderSupport @('claude')
             $completeness = script:New-Completeness -Completeness 'unknown' -StopReason $null -Excluded $true -ExcludeReason 'session completeness: unknown'
-            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness
+            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $false }
             $result | Should -Not -Match ([regex]::Escape((script:Get-LegacyUnknownSessionWarningText)))
             $result | Should -Match 'cost-fields unavailable'
-            $result | Should -Match 'no Claude or Copilot session activity recorded for this PR''s branch; cross-tool collection is enabled — see `Initialize-CopilotCostCollection` if Copilot is installed but data is missing, or #488 for diagnostics\.'
+            $result | Should -Match 'no local session data on this machine'
+            $result | Should -Not -Match '488'
         }
 
         It 'timeout: header contains "rolling-history fetch timed out"' {
@@ -281,8 +282,77 @@ Describe 'Format-CostPatternMarkdown' {
             $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness
             $result | Should -Match 'phase-marker-only attribution; rolling-history excluded'
             $result | Should -Match 'Claude-side phase-marker attribution'
-            $result | Should -Match 'Copilot-side collection remains tracked by \[#488\]\(https://github\.com/Grimblaz/agent-orchestra/issues/488\)'
+            $result | Should -Match 'Copilot-side collection was not captured for this run'
+            $result | Should -Not -Match '488'
             $result | Should -Not -Match 'session not found'
+        }
+    }
+
+    Context 'unknown-completeness three render states (issue #825 s2, M12)' {
+        It 'CI state: RenderContext IsCi true renders the CI-cannot-see-local-transcripts message' {
+            $attribution = script:New-MinimalAttribution
+            $completeness = script:New-Completeness -Completeness 'unknown' -StopReason $null -Excluded $true -ExcludeReason 'session completeness: unknown'
+            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $true; ProjectsRootPresent = $false }
+            $result | Should -Match 'CI cannot see local transcripts'
+            $result | Should -Not -Match '488'
+            $result | Should -Not -Match 'no session activity'
+        }
+
+        It 'non-CI, no local projects root: renders the no-local-session-data message' {
+            $attribution = script:New-MinimalAttribution
+            $completeness = script:New-Completeness -Completeness 'unknown' -StopReason $null -Excluded $true -ExcludeReason 'session completeness: unknown'
+            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $false }
+            $result | Should -Match 'no local session data on this machine'
+            $result | Should -Not -Match '488'
+            $result | Should -Not -Match 'no session activity'
+        }
+
+        It 'non-CI, projects root present, genuinely empty walk: renders the honest-zero message naming the pinned loss modes' {
+            $attribution = script:New-MinimalAttribution
+            $completeness = script:New-Completeness -Completeness 'unknown' -StopReason $null -Excluded $true -ExcludeReason 'session completeness: unknown'
+            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $true }
+            $result | Should -Match 'transcripts were searched on this machine and none matched'
+            $result | Should -Match 'walk ran where transcripts are unavailable'
+            $result | Should -Match 'local walk never ran or exited before the cost step'
+            $result | Should -Match 'since-deleted sibling worktree'
+            $result | Should -Match 'mid-session'
+            $result | Should -Match 'linked issue could not be resolved'
+            $result | Should -Not -Match '488'
+            $result | Should -Not -Match 'no session activity'
+        }
+
+        It 'all three unknown-completeness states are textually distinct' {
+            $attribution = script:New-MinimalAttribution
+            $completeness = script:New-Completeness -Completeness 'unknown' -StopReason $null -Excluded $true -ExcludeReason 'session completeness: unknown'
+            $ci = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $true; ProjectsRootPresent = $false }
+            $noRoot = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $false }
+            $emptyWalk = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $true }
+            $ci | Should -Not -BeExactly $noRoot
+            $ci | Should -Not -BeExactly $emptyWalk
+            $noRoot | Should -Not -BeExactly $emptyWalk
+        }
+    }
+
+    Context 'coverage annotation on populated blocks (issue #825 s2, M6)' {
+        It 'appends the coverage annotation when RejectedDirCount is greater than zero' {
+            $attribution = script:New-MinimalAttribution
+            $completeness = script:New-Completeness
+            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RejectedDirCount 3
+            $result | Should -Match 'activity from 3 unverifiable location\(s\) may be excluded'
+        }
+
+        It 'omits the coverage annotation when RejectedDirCount is zero' {
+            $attribution = script:New-MinimalAttribution
+            $completeness = script:New-Completeness
+            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RejectedDirCount 0
+            $result | Should -Not -Match 'unverifiable location'
+        }
+
+        It 'never appends the coverage annotation on an unknown-completeness (unpopulated) block, even with RejectedDirCount set' {
+            $attribution = script:New-MinimalAttribution
+            $completeness = script:New-Completeness -Completeness 'unknown' -StopReason $null -Excluded $true -ExcludeReason 'session completeness: unknown'
+            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $true } -RejectedDirCount 5
+            $result | Should -Not -Match 'unverifiable location'
         }
     }
 
@@ -432,7 +502,7 @@ Describe 'Format-CostPatternMarkdown' {
             $result | Should -Match '⚠ building cross-tool baseline — matching-coverage history < 5 entries'
         }
 
-        It 'replaces the legacy unknown-session warning with the cross-tool diagnostic text' {
+        It 'replaces the legacy unknown-session warning with an honest environment-state message, never #488' {
             $attribution = script:Add-CoverageMetadata `
                 -Attribution (script:New-MinimalAttribution) `
                 -Coverage 'claude-only-with-copilot-fallback-warning' `
@@ -440,10 +510,11 @@ Describe 'Format-CostPatternMarkdown' {
                 -ProviderSupport @('claude')
             $completeness = script:New-Completeness -Completeness 'unknown' -StopReason $null -Excluded $true -ExcludeReason 'session completeness: unknown'
 
-            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness
+            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $false }
 
             $result | Should -Not -Match ([regex]::Escape((script:Get-LegacyUnknownSessionWarningText)))
-            $result | Should -Match 'no Claude or Copilot session activity recorded for this PR''s branch; cross-tool collection is enabled — see `Initialize-CopilotCostCollection` if Copilot is installed but data is missing, or #488 for diagnostics\.'
+            $result | Should -Match 'no local session data on this machine'
+            $result | Should -Not -Match '488'
         }
 
         It 'renders the inline coverage-tag legend once when fallback-warning coverage appears' {

--- a/.github/scripts/Tests/cost-pattern-renderer.Tests.ps1
+++ b/.github/scripts/Tests/cost-pattern-renderer.Tests.ps1
@@ -331,6 +331,32 @@ Describe 'Format-CostPatternMarkdown' {
             $ci | Should -Not -BeExactly $emptyWalk
             $noRoot | Should -Not -BeExactly $emptyWalk
         }
+
+        It 'non-CI, projects root present, walker budget-exceeded (L11, issue #825 post-review fix): renders a distinct message naming the timeout/budget cause, not the genuine-empty-walk message' {
+            $attribution = script:New-MinimalAttribution
+            $completeness = script:New-Completeness -Completeness 'unknown' -StopReason $null -Excluded $true -ExcludeReason 'session completeness: unknown'
+            $result = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $true; DegradedReason = 'budget-exceeded' }
+            $result | Should -Match 'exceeded its time budget'
+            $result | Should -Match 'FRAME_CREDIT_LEDGER_TEST_COST_BUDGET_SECONDS'
+            $result | Should -Not -Match 'transcripts were searched on this machine and none matched'
+            $result | Should -Not -Match '488'
+            $result | Should -Not -Match 'no session activity'
+        }
+
+        It 'all four unknown-completeness states (including budget-exceeded, L11) are textually distinct from each other' {
+            $attribution = script:New-MinimalAttribution
+            $completeness = script:New-Completeness -Completeness 'unknown' -StopReason $null -Excluded $true -ExcludeReason 'session completeness: unknown'
+            $ci = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $true; ProjectsRootPresent = $false }
+            $noRoot = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $false }
+            $emptyWalk = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $true }
+            $budgetExceeded = Format-CostPatternMarkdown -Attribution $attribution -Completeness $completeness -RenderContext @{ IsCi = $false; ProjectsRootPresent = $true; DegradedReason = 'budget-exceeded' }
+            $states = @($ci, $noRoot, $emptyWalk, $budgetExceeded)
+            for ($i = 0; $i -lt $states.Count; $i++) {
+                for ($j = $i + 1; $j -lt $states.Count; $j++) {
+                    $states[$i] | Should -Not -BeExactly $states[$j] -Because "state $i and state $j must render distinct text"
+                }
+            }
+        }
     }
 
     Context 'coverage annotation on populated blocks (issue #825 s2, M6)' {

--- a/.github/scripts/Tests/cost-walker.Tests.ps1
+++ b/.github/scripts/Tests/cost-walker.Tests.ps1
@@ -1043,6 +1043,322 @@ Describe 'Invoke-CostTranscriptWalk' {
             Remove-Item -Recurse -Force $tmp
         }
     }
+
+    Context 'Tier-2 corroborated-fallback trust ladder (issue #825 s1, opt-in via -AdmitCorroboratedFallback)' {
+        BeforeAll {
+            $script:CorrRepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+            $script:CorrRemoteAvailable = $true
+            $probe = @(& git -C $script:CorrRepoRoot remote get-url origin 2>&1) | Select-Object -First 1
+            if ($global:LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($probe)) {
+                $script:CorrRemoteAvailable = $false
+            }
+
+            # Phase-marker event for a Tier-2 candidate dir. Deliberately carries NO cwd by
+            # default: script:Get-CostWalkerFirstEventCwd scans ALL events (not just
+            # assistant ones) for the first non-empty cwd, so a marker with a real,
+            # on-disk cwd would falsely satisfy the M9 cwd-absent trigger before the
+            # walker ever reaches the branch-matched assistant event. Pass -Cwd only for a
+            # Tier-1 identity-matched dir's own marker-only file (ladder case 7).
+            function script:New-CorrPhaseMarkerEvent {
+                param(
+                    [Parameter(Mandatory)][string]$IssueArg,
+                    [string]$Command = '/plan',
+                    [AllowNull()][string]$Cwd = $null,
+                    [string]$Timestamp = '2026-01-01T00:00:00Z'
+                )
+                $ev = @{
+                    type      = 'user'
+                    message   = @{ content = "<command-name>$Command</command-name><command-args>$IssueArg</command-args>" }
+                    gitBranch = 'main'
+                    timestamp = $Timestamp
+                }
+                if ($Cwd) { $ev['cwd'] = $Cwd }
+                return $ev
+            }
+
+            function script:New-CorrAssistantEvent {
+                param(
+                    [string]$Uuid = [System.Guid]::NewGuid().ToString(),
+                    [Parameter(Mandatory)][string]$Cwd,
+                    [Parameter(Mandatory)][string]$Branch,
+                    [string]$Timestamp = '2026-01-01T00:05:00Z'
+                )
+                return @{
+                    type      = 'assistant'
+                    uuid      = $Uuid
+                    timestamp = $Timestamp
+                    cwd       = $Cwd
+                    gitBranch = $Branch
+                    message   = @{ usage = @{ input_tokens = 10; output_tokens = 5 }; content = @() }
+                }
+            }
+        }
+
+        It 'ladder case 1: Tier 1 identity-matched dir stays admitted unchanged when -AdmitCorroboratedFallback is set' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t1-$([System.Guid]::NewGuid())"
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/corr-ladder-1'
+
+            $primarySlug = Get-CostTranscriptSlug -CwdPath $script:CorrRepoRoot
+            $primaryDir = Join-Path $tmpProjects $primarySlug
+            $null = New-Item -ItemType Directory -Path $primaryDir -Force
+
+            $ev = script:New-CorrAssistantEvent -Cwd $script:CorrRepoRoot -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $primaryDir 'session.jsonl') -Events @($ev)
+
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -AdmitCorroboratedFallback)
+            $result.Count | Should -Be 1
+            $result[0]['uuid'] | Should -Be $ev['uuid']
+            Remove-Item -Recurse -Force $tmpProjects
+        }
+
+        It 'ladder case 2: admits a cwd-absent dir corroborated by branch + issue phase marker' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t2-$([System.Guid]::NewGuid())"
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-2'
+            $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-missing-$([System.Guid]::NewGuid())"
+
+            $candidateDir = Join-Path $tmpProjects 'corroborated-candidate'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+
+            $marker = script:New-CorrPhaseMarkerEvent -IssueArg '825'
+            $asst = script:New-CorrAssistantEvent -Cwd $missingCwd -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $candidateDir 'session.jsonl') -Events @($marker, $asst)
+
+            $rejectedRef = [ref]0
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback -RejectedDirCountVar $rejectedRef)
+
+            $result.Count | Should -Be 1
+            $result[0]['uuid'] | Should -Be $asst['uuid']
+            $rejectedRef.Value | Should -Be 0
+            Remove-Item -Recurse -Force $tmpProjects
+        }
+
+        It 'ladder case 3: rejects a cwd-absent branch-matched dir with no issue marker at all' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t3-$([System.Guid]::NewGuid())"
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-3'
+            $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-missing-$([System.Guid]::NewGuid())"
+
+            $candidateDir = Join-Path $tmpProjects 'branch-only-candidate'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+
+            $asst = script:New-CorrAssistantEvent -Cwd $missingCwd -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $candidateDir 'session.jsonl') -Events @($asst)
+
+            $rejectedRef = [ref]0
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback -RejectedDirCountVar $rejectedRef)
+
+            $result.Count | Should -Be 0
+            $rejectedRef.Value | Should -Be 1
+            Remove-Item -Recurse -Force $tmpProjects
+        }
+
+        It 'ladder case 4: rejects a cwd-absent branch-matched dir whose phase marker names a different issue' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t4-$([System.Guid]::NewGuid())"
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-4'
+            $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-missing-$([System.Guid]::NewGuid())"
+
+            $candidateDir = Join-Path $tmpProjects 'wrong-issue-candidate'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+
+            $marker = script:New-CorrPhaseMarkerEvent -IssueArg '999'
+            $asst = script:New-CorrAssistantEvent -Cwd $missingCwd -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $candidateDir 'session.jsonl') -Events @($marker, $asst)
+
+            $rejectedRef = [ref]0
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback -RejectedDirCountVar $rejectedRef)
+
+            $result.Count | Should -Be 0
+            $rejectedRef.Value | Should -Be 1
+            Remove-Item -Recurse -Force $tmpProjects
+        }
+
+        It 'ladder case 5: never re-admits a cwd-present, identity-mismatched dir via corroboration' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProj = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t5-$([System.Guid]::NewGuid())"
+            $tmpProjects = Join-Path $tmpProj 'projects'
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-5'
+
+            $otherRepoPath = Join-Path $tmpProj 'mismatched-repo'
+            $null = New-Item -ItemType Directory -Path $otherRepoPath -Force
+            $null = & git init $otherRepoPath 2>&1
+            $null = & git -C $otherRepoPath remote add origin 'https://github.com/fake-org/mismatched-corr-test'
+
+            $candidateDir = Join-Path $tmpProjects 'mismatched-candidate'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+
+            $marker = script:New-CorrPhaseMarkerEvent -IssueArg '825'
+            $asst = script:New-CorrAssistantEvent -Cwd $otherRepoPath -Branch $branch  # cwd EXISTS, wrong identity
+            script:Write-TestJsonl -Path (Join-Path $candidateDir 'session.jsonl') -Events @($marker, $asst)
+
+            $rejectedRef = [ref]0
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback -RejectedDirCountVar $rejectedRef)
+
+            $result.Count | Should -Be 0
+            $rejectedRef.Value | Should -Be 0 -Because 'a cwd-present dir never reaches the Tier-2 branch-matched/rejected accounting'
+            Remove-Item -Recurse -Force $tmpProj
+        }
+
+        It 'ladder case 6: admits a corroborated dir whose slug name is outside both the primary and worktree slug families' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t6-$([System.Guid]::NewGuid())"
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-6'
+            $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-missing-$([System.Guid]::NewGuid())"
+
+            # Deliberately unrelated to both "$Slug" and "$Slug--claude-worktrees-*".
+            $candidateDir = Join-Path $tmpProjects 'totally-unrelated-sibling-clone-slug'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+
+            $marker = script:New-CorrPhaseMarkerEvent -IssueArg '825'
+            $asst = script:New-CorrAssistantEvent -Cwd $missingCwd -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $candidateDir 'session.jsonl') -Events @($marker, $asst)
+
+            $result = @(Invoke-CostTranscriptWalk -Slug 'primary-slug-not-present' -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback)
+
+            $result.Count | Should -Be 1
+            $result[0]['uuid'] | Should -Be $asst['uuid']
+            Remove-Item -Recurse -Force $tmpProjects
+        }
+
+        It 'ladder case 7 (M14): admits via cross-file signal-ii corroboration from a same-session sibling in a Tier-1 identity-matched dir' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t7-$([System.Guid]::NewGuid())"
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-7'
+            $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-missing-$([System.Guid]::NewGuid())"
+            $sharedSessionId = [System.Guid]::NewGuid().ToString()
+
+            # Tier-1 identity-matched dir: holds the phase marker for the SAME session id.
+            $primarySlug = Get-CostTranscriptSlug -CwdPath $script:CorrRepoRoot
+            $primaryDir = Join-Path $tmpProjects $primarySlug
+            $null = New-Item -ItemType Directory -Path $primaryDir -Force
+            $markerOnly = script:New-CorrPhaseMarkerEvent -IssueArg '825' -Cwd $script:CorrRepoRoot
+            script:Write-TestJsonl -Path (Join-Path $primaryDir "$sharedSessionId.jsonl") -Events @($markerOnly)
+
+            # Tier-2 candidate dir (cwd absent): holds cost events for the SAME session id, no local marker.
+            $candidateDir = Join-Path $tmpProjects 'deleted-worktree-candidate'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+            $asst = script:New-CorrAssistantEvent -Cwd $missingCwd -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $candidateDir "$sharedSessionId.jsonl") -Events @($asst)
+
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback)
+
+            @($result | Where-Object { $_['uuid'] -eq $asst['uuid'] }).Count | Should -Be 1
+            Remove-Item -Recurse -Force $tmpProjects
+        }
+
+        It 'ladder case 8 (M11): excludes a branch-matched file when the only corroborating marker sits in a co-located, unrelated main-branch session' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t8-$([System.Guid]::NewGuid())"
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-8'
+            $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-missing-$([System.Guid]::NewGuid())"
+
+            $candidateDir = Join-Path $tmpProjects 'co-located-candidate'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+
+            # File A: branch-matched, no local marker.
+            $asstA = script:New-CorrAssistantEvent -Cwd $missingCwd -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $candidateDir 'session-a.jsonl') -Events @($asstA)
+
+            # File B: an unrelated, DIFFERENT session in the same dir with a main-branch marker
+            # for the SAME issue — must never corroborate File A (same-file/session scoping).
+            $markerB = script:New-CorrPhaseMarkerEvent -IssueArg '825'
+            script:Write-TestJsonl -Path (Join-Path $candidateDir 'session-b.jsonl') -Events @($markerB)
+
+            $rejectedRef = [ref]0
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback -RejectedDirCountVar $rejectedRef)
+
+            $result.Count | Should -Be 0
+            $rejectedRef.Value | Should -Be 1
+            Remove-Item -Recurse -Force $tmpProjects
+        }
+
+        It 'ladder case 9 (M8): excludes an admitted Tier-2 event whose timestamp falls outside the merge window' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t9-$([System.Guid]::NewGuid())"
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-9'
+            $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-missing-$([System.Guid]::NewGuid())"
+
+            $candidateDir = Join-Path $tmpProjects 'windowed-candidate'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+
+            $marker = script:New-CorrPhaseMarkerEvent -IssueArg '825'
+            $inWindow = script:New-CorrAssistantEvent -Cwd $missingCwd -Branch $branch -Timestamp '2026-02-10T12:00:00Z'
+            $outOfWindow = script:New-CorrAssistantEvent -Cwd $missingCwd -Branch $branch -Timestamp '2026-03-01T12:00:00Z'
+            script:Write-TestJsonl -Path (Join-Path $candidateDir 'session.jsonl') -Events @($marker, $inWindow, $outOfWindow)
+
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback -CorroborationWindowStart ([datetime]'2026-02-01T00:00:00Z') -CorroborationWindowEnd ([datetime]'2026-02-20T00:00:00Z'))
+
+            $result.Count | Should -Be 1
+            $result[0]['uuid'] | Should -Be $inWindow['uuid']
+            Remove-Item -Recurse -Force $tmpProjects
+        }
+
+        It 'ladder case 10a (M7 union): sums a legitimately split spanning session across a Tier-1 dir and a corroborated Tier-2 dir without collapsing distinct events' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t10a-$([System.Guid]::NewGuid())"
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-10a'
+            $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-missing-$([System.Guid]::NewGuid())"
+
+            $primarySlug = Get-CostTranscriptSlug -CwdPath $script:CorrRepoRoot
+            $primaryDir = Join-Path $tmpProjects $primarySlug
+            $null = New-Item -ItemType Directory -Path $primaryDir -Force
+            $primaryEvent = script:New-CorrAssistantEvent -Cwd $script:CorrRepoRoot -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $primaryDir 'session-primary.jsonl') -Events @($primaryEvent)
+
+            $candidateDir = Join-Path $tmpProjects 'spanning-candidate'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+            $marker = script:New-CorrPhaseMarkerEvent -IssueArg '825'
+            $fallbackEvent = script:New-CorrAssistantEvent -Cwd $missingCwd -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $candidateDir 'session-fallback.jsonl') -Events @($marker, $fallbackEvent)
+
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback)
+
+            $result.Count | Should -Be 2
+            @($result | Where-Object { $_['uuid'] -eq $primaryEvent['uuid'] }).Count | Should -Be 1
+            @($result | Where-Object { $_['uuid'] -eq $fallbackEvent['uuid'] }).Count | Should -Be 1
+            Remove-Item -Recurse -Force $tmpProjects
+        }
+
+        It 'ladder case 10b (M7 identical-copy-collapse): collapses an identical duplicate copy of the same session file appearing in both the Tier-1 dir and a corroborated Tier-2 dir' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProjects = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t10b-$([System.Guid]::NewGuid())"
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-10b'
+            $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-missing-$([System.Guid]::NewGuid())"
+            $sharedSessionId = [System.Guid]::NewGuid().ToString()
+            $sharedUuid = [System.Guid]::NewGuid().ToString()
+
+            $primarySlug = Get-CostTranscriptSlug -CwdPath $script:CorrRepoRoot
+            $primaryDir = Join-Path $tmpProjects $primarySlug
+            $null = New-Item -ItemType Directory -Path $primaryDir -Force
+            $primaryCopy = script:New-CorrAssistantEvent -Uuid $sharedUuid -Cwd $script:CorrRepoRoot -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $primaryDir "$sharedSessionId.jsonl") -Events @($primaryCopy)
+
+            $candidateDir = Join-Path $tmpProjects 'identical-copy-candidate'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+            $marker = script:New-CorrPhaseMarkerEvent -IssueArg '825'
+            $duplicateCopy = script:New-CorrAssistantEvent -Uuid $sharedUuid -Cwd $missingCwd -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $candidateDir "$sharedSessionId.jsonl") -Events @($marker, $duplicateCopy)
+
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback)
+
+            $result.Count | Should -Be 1 -Because 'same session_id + uuid must be attributed exactly once (M7)'
+            $result[0]['uuid'] | Should -Be $sharedUuid
+            Remove-Item -Recurse -Force $tmpProjects
+        }
+    }
 }
 
 Describe 'Resolve-CostWalkerRepoIdentity' {

--- a/.github/scripts/Tests/cost-walker.Tests.ps1
+++ b/.github/scripts/Tests/cost-walker.Tests.ps1
@@ -337,6 +337,50 @@ Describe 'Invoke-CostTranscriptWalk' {
             @(Invoke-CostTranscriptWalk -Slug $slug -Branch $script:TestBranch -ParentCwd $script:TestCwd -ProjectsRoot $tmp).Count | Should -Be 1
             Remove-Item -Recurse -Force $tmp
         }
+
+        It 'L12 (issue #825 post-review fix): captures a duplicate parent''s own subagent event when the subagent file exists only in the second-processed (duplicate) copy' {
+            $tmp = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-test-$([System.Guid]::NewGuid())"
+            $slug = 'test--l12-dedup'
+            $primaryDir = Join-Path $tmp $slug
+            $null = New-Item -ItemType Directory -Path $primaryDir -Force
+            # Discovered via the name-based worktree glob, and — per
+            # script:Get-CostWalkerCandidateSlugDirs's own resolution order (worktree
+            # glob before the primary-slug backward-compat fallback) — walked BEFORE
+            # $primaryDir, making $primaryDir the second-processed (duplicate) copy.
+            $worktreeDir = Join-Path $tmp "$slug--claude-worktrees-abc123"
+            $null = New-Item -ItemType Directory -Path $worktreeDir -Force
+
+            $sharedUuid = [System.Guid]::NewGuid().ToString()
+            $toolUseId = [System.Guid]::NewGuid().ToString()
+            $sharedSessionId = 'shared-session'
+
+            # The identical parent event (same session_id file BaseName + same event
+            # uuid) exists in BOTH copies.
+            $parentEvent = script:New-AssistantEvent -Uuid $sharedUuid -Content @(script:New-AgentToolUseContent -ToolUseId $toolUseId)
+            script:Write-TestJsonl -Path (Join-Path $worktreeDir "$sharedSessionId.jsonl") -Events @($parentEvent)
+            script:Write-TestJsonl -Path (Join-Path $primaryDir "$sharedSessionId.jsonl") -Events @($parentEvent)
+
+            # The subagent transcript exists ONLY in $primaryDir (the second-processed
+            # / duplicate copy) — $worktreeDir's own subagents/ dir is absent.
+            $subagDir = Join-Path $primaryDir 'subagents'
+            $null = New-Item -ItemType Directory -Path $subagDir -Force
+            $subEvent = @{
+                type      = 'assistant'
+                uuid      = 'subagent-only-in-duplicate'
+                timestamp = '2026-01-01T00:01:00Z'
+                message   = @{ usage = @{ input_tokens = 1; output_tokens = 1 }; content = @() }
+            }
+            script:Write-TestJsonl -Path (Join-Path $subagDir "agent-$toolUseId.jsonl") -Events @($subEvent)
+
+            $result = @(Invoke-CostTranscriptWalk -Slug $slug -Branch $script:TestBranch -ParentCwd $script:TestCwd -ProjectsRoot $tmp)
+
+            # Parent counted exactly once — dedup is not weakened by this fix.
+            @($result | Where-Object { $_.uuid -eq $sharedUuid }).Count | Should -Be 1
+            # The duplicate copy's own subagent traversal must still run and capture
+            # its subagent event, even though its parent event was a dedup no-op.
+            @($result | Where-Object { $_.uuid -eq 'subagent-only-in-duplicate' }).Count | Should -Be 1
+            Remove-Item -Recurse -Force $tmp
+        }
     }
 
     Context 'resilience' {
@@ -1357,6 +1401,40 @@ Describe 'Invoke-CostTranscriptWalk' {
             $result.Count | Should -Be 1 -Because 'same session_id + uuid must be attributed exactly once (M7)'
             $result[0]['uuid'] | Should -Be $sharedUuid
             Remove-Item -Recurse -Force $tmpProjects
+        }
+
+        It 'ladder case 11 (L14, issue #825 post-review fix): rejects a branch+marker corroborated candidate whose own file evidence resolves to a different repository identity via a non-first, still-extant cwd' {
+            if (-not $script:CorrRemoteAvailable) { Set-ItResult -Skipped -Because 'cannot resolve test repo remote'; return }
+            $tmpProj = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-t11-$([System.Guid]::NewGuid())"
+            $tmpProjects = Join-Path $tmpProj 'projects'
+            $null = New-Item -ItemType Directory -Path $tmpProjects -Force
+            $branch = 'feature/issue-825-corr-11'
+            $missingCwd = Join-Path ([IO.Path]::GetTempPath()) "cost-walker-corr-missing-$([System.Guid]::NewGuid())"
+
+            $otherRepoPath = Join-Path $tmpProj 'other-identity-repo'
+            $null = New-Item -ItemType Directory -Path $otherRepoPath -Force
+            $null = & git init $otherRepoPath 2>&1
+            $null = & git -C $otherRepoPath remote add origin 'https://github.com/fake-org/l14-mismatch-test'
+
+            $candidateDir = Join-Path $tmpProjects 'different-repo-candidate'
+            $null = New-Item -ItemType Directory -Path $candidateDir -Force
+
+            $marker = script:New-CorrPhaseMarkerEvent -IssueArg '825'
+            # The M9 trigger cwd (first non-empty cwd found in the file) — absent, so
+            # this directory still becomes a Tier-2 candidate.
+            $asst = script:New-CorrAssistantEvent -Cwd $missingCwd -Branch $branch
+            # A SECOND, non-first event in the SAME file whose cwd currently exists on
+            # disk and resolves to a DIFFERENT repo identity than the target. L14 must
+            # catch this even though it is not the cwd that triggered the M9 fallback.
+            $identityProbe = script:New-CorrAssistantEvent -Cwd $otherRepoPath -Branch $branch
+            script:Write-TestJsonl -Path (Join-Path $candidateDir 'session.jsonl') -Events @($marker, $asst, $identityProbe)
+
+            $rejectedRef = [ref]0
+            $result = @(Invoke-CostTranscriptWalk -Branch $branch -ParentCwd $script:CorrRepoRoot -RepoRoot $script:CorrRepoRoot -ProjectsRoot $tmpProjects -IssueNumber 825 -AdmitCorroboratedFallback -RejectedDirCountVar $rejectedRef)
+
+            $result.Count | Should -Be 0 -Because 'own-marker corroboration must not admit a file whose own evidence proves a different repository identity'
+            $rejectedRef.Value | Should -Be 1
+            Remove-Item -Recurse -Force $tmpProj
         }
     }
 }

--- a/.github/scripts/Tests/frame-credit-ledger-degraded-telemetry.Tests.ps1
+++ b/.github/scripts/Tests/frame-credit-ledger-degraded-telemetry.Tests.ps1
@@ -353,6 +353,28 @@ Describe 'frame-credit-ledger degraded telemetry (issue #794 s4)' {
 
             $attribution['degraded_reason'] | Should -Be 'env-absent' -Because 'env-absent is the routine CI shape and takes priority over a timeout that could not have meaningfully occurred without a projects root'
         }
+
+        It 'accepts an empty -CopilotOtelJsonlPath (Copilot OTEL absent) without throwing and treats it as the missing-path case' {
+            # Regression (#825 CE-Gate render-robustness): Resolve-FCLCostCopilotOtelJsonlPath
+            # returns '' when Copilot OTEL collection is not installed (the common case).
+            # Before the [AllowEmptyString()] fix, that empty value was rejected at bind
+            # time by the [Parameter(Mandatory)][string] attribute BEFORE the body's own
+            # IsNullOrWhiteSpace handling ran, throwing "Cannot bind argument ... empty
+            # string" and silently degrading the whole cost section to ''.
+            $presentRoot = Join-Path $TestDrive ('fcl-s4-unit-emptyotel-' + [System.Guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path $presentRoot -Force | Out-Null
+            $env:FRAME_CREDIT_LEDGER_TEST_CLAUDE_PROJECTS_ROOT = $presentRoot
+
+            $attribution = @{}
+            $claudeWalk = [pscustomobject]@{ Events = @(); TimedOut = $false; Failed = $false; Warnings = @() }
+            {
+                script:Set-FCLCostCoverageMetadata -Attribution $attribution -Events @() -ClaudeWalk $claudeWalk -CopilotWalk $null -CopilotOtelJsonlPath ''
+            } | Should -Not -Throw
+
+            # Behaves as the empty/missing-path case: install status is the fallback value,
+            # not 'ok' — Copilot coverage is NOT marked present from a bogus path.
+            $attribution['install_status'] | Should -Be 'missing-or-fallback'
+        }
     }
 
     Context 'Part 1 (orchestrator-level): degraded standalone comment carries the typed reason' {

--- a/.github/scripts/lib/cost-baseline-harvest.ps1
+++ b/.github/scripts/lib/cost-baseline-harvest.ps1
@@ -875,10 +875,10 @@ function Invoke-CostAttributionRepair {
         }
 
         # 1. Live merge-state + REAL head ref — never the persisted `branch:` field (M2/M15).
-        # createdAt/mergedAt ride along on this same call (no extra API round-trip) for
-        # step 3's M8 corroboration-window bound.
+        # createdAt/mergedAt/commits ride along on this same call (no extra API
+        # round-trip) for step 3's M8 corroboration-window bound.
         $liveJson = $null
-        try { $liveJson = & gh pr view $Pr --json 'state,headRefName,body,createdAt,mergedAt' 2>$null } catch { $liveJson = $null }
+        try { $liveJson = & gh pr view $Pr --json 'state,headRefName,body,createdAt,mergedAt,commits' 2>$null } catch { $liveJson = $null }
         if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($liveJson)) {
             $result.Signal = "repair skipped for #$Pr — gh pr view failed"
             return $result
@@ -898,13 +898,39 @@ function Invoke-CostAttributionRepair {
         }
         $prBody = [string]$liveInfo.body
 
-        # M8 corroboration-window bound (issue #825 s3 post-review fix): the PR's own
-        # first-branch-appearance -> merge lifetime. An unparseable/absent timestamp
-        # degrades that one bound to $null (unenforced), matching the walker's own
-        # "a $null bound is not enforced" contract — never blocks the repair.
+        # M8 corroboration-window bound (issue #825 s3/s4 post-review fix, C4): the PR's
+        # own first-branch-appearance -> merge lifetime. "First branch appearance" is the
+        # earliest commit's authoredDate, NOT the PR's createdAt — createdAt only reflects
+        # when the PR object itself was opened on GitHub, which can trail the branch's real
+        # start by the bulk of a multi-day session (the #814 flagship case: session ran
+        # 2026-07-04T16:20Z, PR wasn't opened until 2026-07-06T05:12Z near the very end).
+        # Using createdAt as the window start would silently exclude nearly all real
+        # activity from corroboration. Falls back to createdAt only when the commits list
+        # is empty or unparseable. An unparseable/absent timestamp still degrades that one
+        # bound to $null (unenforced), matching the walker's own "a $null bound is not
+        # enforced" contract — never blocks the repair.
         [Nullable[datetime]]$corroborationWindowStart = $null
         [Nullable[datetime]]$corroborationWindowEnd = $null
-        try { if (-not [string]::IsNullOrWhiteSpace([string]$liveInfo.createdAt)) { $corroborationWindowStart = [datetime]$liveInfo.createdAt } } catch { $corroborationWindowStart = $null }
+        try {
+            $earliestCommitDate = $null
+            if ($null -ne $liveInfo.commits -and @($liveInfo.commits).Count -gt 0) {
+                $authoredDates = @(
+                    $liveInfo.commits | ForEach-Object {
+                        try { [datetime]$_.authoredDate } catch { $null }
+                    } | Where-Object { $null -ne $_ }
+                )
+                if ($authoredDates.Count -gt 0) {
+                    $earliestCommitDate = ($authoredDates | Sort-Object)[0]
+                }
+            }
+            if ($null -ne $earliestCommitDate) {
+                $corroborationWindowStart = $earliestCommitDate
+            }
+            elseif (-not [string]::IsNullOrWhiteSpace([string]$liveInfo.createdAt)) {
+                $corroborationWindowStart = [datetime]$liveInfo.createdAt
+            }
+        }
+        catch { $corroborationWindowStart = $null }
         try { if (-not [string]::IsNullOrWhiteSpace([string]$liveInfo.mergedAt)) { $corroborationWindowEnd = [datetime]$liveInfo.mergedAt } } catch { $corroborationWindowEnd = $null }
 
         # 2. Locate the composite comment's Cost Pattern section; only act on a
@@ -947,7 +973,13 @@ function Invoke-CostAttributionRepair {
         catch { $renderResult = $null }
 
         $reWalkCostSection = if ($null -ne $renderResult) { [string]$renderResult['CostSection'] } else { '' }
-        if ([string]::IsNullOrWhiteSpace($reWalkCostSection)) {
+        # C1 fix (issue #825 post-review): the honest-unknown renderer always returns a
+        # non-empty, populated-looking section even on a zero-event walk, so gating on
+        # IsNullOrWhiteSpace($reWalkCostSection) never fires on the real "no matching
+        # transcripts" path. Gate on actual walk activity instead — CostEventsCount is the
+        # ground truth the render result already carries.
+        $reWalkEventsCount = if ($null -ne $renderResult) { [int]$renderResult['CostEventsCount'] } else { 0 }
+        if ($null -eq $renderResult -or $reWalkEventsCount -le 0) {
             $result.Signal = "repair found no activity for #$Pr — machine holds no matching transcripts; nothing written"
             return $result
         }

--- a/.github/scripts/lib/cost-baseline-harvest.ps1
+++ b/.github/scripts/lib/cost-baseline-harvest.ps1
@@ -953,6 +953,21 @@ function Invoke-CostAttributionRepair {
             return $result
         }
 
+        # L9 (issue #825 post-review fix): a null/unparseable bound previously
+        # degraded silently to an UNENFORCED window (the walker's own "a $null bound
+        # is not enforced" contract) — this repair path must never proceed with an
+        # unenforced corroboration window, since an unenforced window is exactly what
+        # lets a same-repo reused-branch collision outside this PR's real lifetime
+        # slip through the Tier-2 corroborated-fallback ladder this repair turns on.
+        # Checked here — after the cheaper composite-comment/session_completeness
+        # gates above, which take priority when they alone already explain a skip —
+        # and before $result.Attempted is set, so an unresolvable window is reported
+        # honestly instead of proceeding with an unenforced repair.
+        if ($null -eq $corroborationWindowStart -or $null -eq $corroborationWindowEnd) {
+            $result.Signal = "repair skipped for #$Pr — corroboration window could not be resolved"
+            return $result
+        }
+
         $result.Attempted = $true
 
         # 3. Re-walk with the Tier-2 corroborated-fallback ladder ON — this call only (M10) —

--- a/.github/scripts/lib/cost-baseline-harvest.ps1
+++ b/.github/scripts/lib/cost-baseline-harvest.ps1
@@ -984,6 +984,21 @@ function Invoke-CostAttributionRepair {
             return $result
         }
 
+        # Data-loss guard (issue #825 CE Gate): Invoke-CostSessionRender's step-6g
+        # budget-exhaustion edge (cost-session-render.ps1 line ~479) can return
+        # CostEventsCount > 0 but an empty CostSection when the render budget runs out
+        # before the section is composed. Splicing that empty replacement over the
+        # matched block below would DELETE the persisted Cost Pattern section, because
+        # Merge-CostBaselineHarvestSection is a pure substring splice. Kept DISTINCT
+        # from the events<=0 "no matching transcripts" signal above: here the machine
+        # DID hold activity, so the honest, actionable signal is to enlarge the budget
+        # (FRAME_CREDIT_LEDGER_TEST_COST_BUDGET_SECONDS) and retry — never a silent
+        # write, never a false "repaired".
+        if ([string]::IsNullOrWhiteSpace($reWalkCostSection)) {
+            $result.Signal = "repair found activity for #$Pr but the re-walk exhausted its render budget before composing the cost section; existing block left intact — retry with a larger cost budget"
+            return $result
+        }
+
         # 4. Populated-beats-empty-unknown: upsert only when the re-walk found activity.
         $newBody = script:Merge-CostBaselineHarvestSection -Body $compositeBody -SectionMatch $sectionMatch -Replacement $reWalkCostSection.TrimEnd()
 

--- a/.github/scripts/lib/cost-baseline-harvest.ps1
+++ b/.github/scripts/lib/cost-baseline-harvest.ps1
@@ -14,6 +14,15 @@
     session-startup step in a later, separate slice (issue #824 s5) — that step
     owns the fail-open wiring/prose; this function owns the mechanics.
 
+    This file also supplies Invoke-CostAttributionRepair (issue #825, Step 3),
+    a second, independent public function: a maintainer-invoked, single-PR
+    targeted re-attribution repair for a merged PR whose block reads
+    `session_completeness: unknown`. It is NOT an extension of
+    script:Select-CostBaselineHarvestCandidates' automatic candidate loop —
+    that loop and Invoke-CostBaselineHarvest's own promote/stamp machinery are
+    untouched. See Invoke-CostAttributionRepair's own doc comment for the full
+    contract.
+
     Every failure path is silent no-op (fail-open): a failed `gh` call, no
     candidates, a verify-then-select miss, or a re-walk error all leave the
     harvest a no-op rather than throwing or blocking whatever invoked it.
@@ -768,5 +777,211 @@ function Invoke-CostBaselineHarvest {
     catch {
         [Console]::Error.WriteLine("cost-baseline-harvest: harvest failed (fail-open, no-op): $($_.Exception.Message)")
         return @{ Attempted = $false; Promoted = $false; Pr = $null; Signal = $null }
+    }
+}
+
+function Invoke-CostAttributionRepair {
+    <#
+    .SYNOPSIS
+        Targeted, maintainer-invoked re-attribution repair for ONE merged PR
+        whose persisted cost-pattern-data block reads
+        `session_completeness: unknown` (issue #825, Step 3).
+    .DESCRIPTION
+        NOT an extension of script:Select-CostBaselineHarvestCandidates' automatic
+        candidate loop — that function, and the rest of Invoke-CostBaselineHarvest's
+        own promote/stamp machinery, are untouched by this function. This is a
+        standalone entry point for a single, maintainer-named PR:
+
+          1. Resolves the PR's REAL head ref via a fresh `gh pr view
+             --json state,headRefName,body,createdAt,mergedAt` — never the
+             persisted block's own `branch:` field, which the CI-written
+             targets carry as the literal string `HEAD` (M2/M15, empirically
+             confirmed on #814/#815) — and confirms the PR is genuinely
+             MERGED before acting. The same call also fetches `createdAt`/
+             `mergedAt` (no extra API call) for step 3's corroboration
+             window.
+          2. Fetches the composite `<!-- frame-credit-ledger-$Pr -->` comment
+             (script:Get-CostBaselineHarvestCompositeComment — same
+             fail-closed authorship gate Invoke-CostBaselineHarvest uses) and
+             locates its Cost Pattern section. Only proceeds when the
+             persisted section reads `session_completeness: unknown` — this
+             function repairs exactly that degraded shape; a populated block
+             is left untouched (it is not this function's job to re-render an
+             already-populated session).
+          3. Re-walks via Invoke-CostSessionRender with
+             -AdmitCorroboratedFallback ON for this call only — turns on the
+             s1 Tier-2 corroborated-fallback trust ladder (cost-walker.ps1)
+             for this one targeted repair; the live PR-creation path never
+             sets this (M10). -CorroborationWindowStart/-End are passed as
+             this PR's own `createdAt`/`mergedAt` (issue #825 s3 post-review
+             fix, M8 wiring gap) — without this, Tier-2 admission ran
+             unbounded on the one path that actually ships in this issue
+             (the automatic-drain path where this would also matter is
+             deferred to #841), leaving the M8 same-repo reused-branch-name
+             collision guard inert. An unparseable timestamp degrades that
+             one bound to $null (unenforced) rather than blocking the repair
+             — matching the walker's own "a $null bound is not enforced"
+             contract.
+          4. Acceptance = populated-beats-empty-unknown: the composite
+             comment's Cost Pattern section is section-spliced (never a
+             full-body replace, never a new sibling comment) with the
+             re-walk's own rendered section — which already carries its own
+             honest completeness label and the M6 coverage annotation when
+             the walker rejected any corroborated directory — ONLY when the
+             re-walk actually produced a non-empty section. When the machine
+             holds no matching transcripts, this reports honestly and writes
+             nothing: no `upgrade_attempted_at` stamp, no budget bookkeeping —
+             that machinery belongs to the deferred automatic startup-drain
+             follow-up (issue #841), out of scope here.
+
+        Every failure path (gh failure, not-MERGED, no composite comment, no
+        matching section, non-unknown persisted block, empty re-walk, a
+        concurrent-change race on the pre-write re-check) returns
+        Upserted=$false with a Signal describing why, and never throws to its
+        caller.
+    .PARAMETER Pr
+        The merged PR number to re-attribute. Maintainer-supplied.
+    .PARAMETER ParentCwd
+        This (repairing) session's own parent cwd — the machine performing
+        the repair must hold the target PR's transcripts. Passed through to
+        Invoke-CostSessionRender.
+    .PARAMETER RepoRoot
+        This session's own repo root — used for slug/identity resolution and
+        passed through to Invoke-CostSessionRender.
+    .PARAMETER Slug
+        This session's own cost-transcript slug. Resolved from RepoRoot via
+        Get-CostTranscriptSlug when omitted.
+    .OUTPUTS
+        [hashtable] @{ Attempted = [bool]; Upserted = [bool]; Pr = [int]; Signal = [string] }
+        Attempted is $true only once the persisted block has been confirmed
+        `session_completeness: unknown` and the re-walk has actually been
+        invoked. Upserted is $true only when the composite comment was
+        successfully rewritten with populated data.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][int]$Pr,
+        [Parameter(Mandatory)][string]$ParentCwd,
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [string]$Slug = ''
+    )
+
+    $result = @{ Attempted = $false; Upserted = $false; Pr = $Pr; Signal = $null }
+
+    try {
+        if ([string]::IsNullOrWhiteSpace($Slug)) {
+            try { $Slug = Get-CostTranscriptSlug -CwdPath $RepoRoot } catch { $Slug = '' }
+        }
+
+        # 1. Live merge-state + REAL head ref — never the persisted `branch:` field (M2/M15).
+        # createdAt/mergedAt ride along on this same call (no extra API round-trip) for
+        # step 3's M8 corroboration-window bound.
+        $liveJson = $null
+        try { $liveJson = & gh pr view $Pr --json 'state,headRefName,body,createdAt,mergedAt' 2>$null } catch { $liveJson = $null }
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($liveJson)) {
+            $result.Signal = "repair skipped for #$Pr — gh pr view failed"
+            return $result
+        }
+
+        $liveInfo = $null
+        try { $liveInfo = ($liveJson | Out-String) | ConvertFrom-Json -ErrorAction Stop } catch { $liveInfo = $null }
+        if ($null -eq $liveInfo -or [string]$liveInfo.state -ne 'MERGED') {
+            $result.Signal = "repair skipped for #$Pr — not MERGED"
+            return $result
+        }
+
+        $liveHeadRef = [string]$liveInfo.headRefName
+        if ([string]::IsNullOrWhiteSpace($liveHeadRef)) {
+            $result.Signal = "repair skipped for #$Pr — live headRefName unresolvable"
+            return $result
+        }
+        $prBody = [string]$liveInfo.body
+
+        # M8 corroboration-window bound (issue #825 s3 post-review fix): the PR's own
+        # first-branch-appearance -> merge lifetime. An unparseable/absent timestamp
+        # degrades that one bound to $null (unenforced), matching the walker's own
+        # "a $null bound is not enforced" contract — never blocks the repair.
+        [Nullable[datetime]]$corroborationWindowStart = $null
+        [Nullable[datetime]]$corroborationWindowEnd = $null
+        try { if (-not [string]::IsNullOrWhiteSpace([string]$liveInfo.createdAt)) { $corroborationWindowStart = [datetime]$liveInfo.createdAt } } catch { $corroborationWindowStart = $null }
+        try { if (-not [string]::IsNullOrWhiteSpace([string]$liveInfo.mergedAt)) { $corroborationWindowEnd = [datetime]$liveInfo.mergedAt } } catch { $corroborationWindowEnd = $null }
+
+        # 2. Locate the composite comment's Cost Pattern section; only act on a
+        # persisted session_completeness: unknown block.
+        $fetchResult = script:Get-CostBaselineHarvestCompositeComment -Pr $Pr
+        if ($null -eq $fetchResult -or -not $fetchResult['Found']) {
+            $result.Signal = "repair skipped for #$Pr — composite comment not found"
+            return $result
+        }
+
+        $compositeBody = $fetchResult['Body']
+        $sectionMatch = [regex]::Match($compositeBody, $script:FCLCostPatternSectionRegex)
+        if (-not $sectionMatch.Success) {
+            $result.Signal = "repair skipped for #$Pr — cost section format mismatch"
+            return $result
+        }
+
+        if ($sectionMatch.Groups['section'].Value -notmatch '(?m)^session_completeness\s*:\s*unknown\s*$') {
+            $result.Signal = "repair skipped for #$Pr — persisted block is not session_completeness: unknown"
+            return $result
+        }
+
+        $result.Attempted = $true
+
+        # 3. Re-walk with the Tier-2 corroborated-fallback ladder ON — this call only (M10) —
+        # bounded to this PR's own createdAt->mergedAt window (M8 wiring gap fix).
+        $renderResult = $null
+        try {
+            $renderResult = Invoke-CostSessionRender `
+                -Pr $Pr `
+                -Branch $liveHeadRef `
+                -Slug $Slug `
+                -ParentCwd $ParentCwd `
+                -RepoRoot $RepoRoot `
+                -PrBody $prBody `
+                -AdmitCorroboratedFallback `
+                -CorroborationWindowStart $corroborationWindowStart `
+                -CorroborationWindowEnd $corroborationWindowEnd
+        }
+        catch { $renderResult = $null }
+
+        $reWalkCostSection = if ($null -ne $renderResult) { [string]$renderResult['CostSection'] } else { '' }
+        if ([string]::IsNullOrWhiteSpace($reWalkCostSection)) {
+            $result.Signal = "repair found no activity for #$Pr — machine holds no matching transcripts; nothing written"
+            return $result
+        }
+
+        # 4. Populated-beats-empty-unknown: upsert only when the re-walk found activity.
+        $newBody = script:Merge-CostBaselineHarvestSection -Body $compositeBody -SectionMatch $sectionMatch -Replacement $reWalkCostSection.TrimEnd()
+
+        # M15-style cheap concurrency mitigation, reused from the harvest's own
+        # pre-write re-check: skip the write (rather than risk a last-write-wins
+        # clobber) if the section changed since it was matched above.
+        if (-not (script:Test-CostBaselineHarvestSectionStillCurrent -Pr $Pr -ExpectedSectionText $sectionMatch.Value)) {
+            $result.Signal = "repair for #$Pr — composite comment write failed (concurrent change)"
+            return $result
+        }
+
+        $upserted = $false
+        try {
+            $null = Find-OrUpsertComment -Type 'pr' -Number $Pr -Marker $fetchResult['Marker'] -Body $newBody
+            $upserted = $true
+        }
+        catch { $upserted = $false }
+
+        if ($upserted) {
+            $result.Upserted = $true
+            $result.Signal = "repaired #$Pr — attribution re-walked and upserted"
+        }
+        else {
+            $result.Signal = "repair for #$Pr — composite comment write failed"
+        }
+
+        return $result
+    }
+    catch {
+        [Console]::Error.WriteLine("cost-baseline-harvest: attribution repair failed (fail-open, no write): $($_.Exception.Message)")
+        return @{ Attempted = $false; Upserted = $false; Pr = $Pr; Signal = $null }
     }
 }

--- a/.github/scripts/lib/cost-fcl-helpers.ps1
+++ b/.github/scripts/lib/cost-fcl-helpers.ps1
@@ -106,7 +106,14 @@ function script:Get-FCLCostScriptState {
             'CostAttributionPortMap',
             'CostCompletenessPartialReasons',
             'CostRendererPortOrder',
-            'CostRendererSkillDrivenPorts'
+            'CostRendererSkillDrivenPorts',
+            # C3 (issue #825 post-review fix): missing from this marshal list meant an
+            # isolated runspace (New-FCLInitialSessionStateClone) never received this
+            # constant — PowerShell coerces the unmarshaled $null to '', and
+            # ''.StartsWith(anything) returns $true, misclassifying every real cwd as the
+            # Copilot-OTEL sentinel and silently killing both Tier-1 identity discovery
+            # and Tier-2 admission.
+            'CostWalkerCopilotOtelCwdPrefix'
         )) {
         try {
             $state[$costStateName] = Get-Variable -Scope Script -Name $costStateName -ValueOnly -ErrorAction Stop

--- a/.github/scripts/lib/cost-fcl-helpers.ps1
+++ b/.github/scripts/lib/cost-fcl-helpers.ps1
@@ -403,7 +403,7 @@ function script:Set-FCLCostCoverageMetadata {
         [AllowEmptyCollection()][object[]]$Events,
         [AllowNull()]$ClaudeWalk,
         [AllowNull()]$CopilotWalk,
-        [Parameter(Mandatory)][string]$CopilotOtelJsonlPath
+        [Parameter(Mandatory)][AllowEmptyString()][string]$CopilotOtelJsonlPath
     )
 
     [string[]]$providers = @(script:Get-FCLCostEventProviderSet -Events $Events)
@@ -470,7 +470,7 @@ function script:Compose-FCLDegradedCostComment {
     param(
         [Parameter(Mandatory)][string]$DegradedReason,
         [Parameter(Mandatory)][int]$Pr,
-        [Parameter(Mandatory)][string]$Branch
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Branch
     )
 
     $inv = [System.Globalization.CultureInfo]::InvariantCulture

--- a/.github/scripts/lib/cost-pattern-renderer.ps1
+++ b/.github/scripts/lib/cost-pattern-renderer.ps1
@@ -276,22 +276,93 @@ function script:Format-CostRendererFallbackRemediationNote {
 
 #region ---- Header builder -----------------------------------------------------
 
+function script:Format-CostPatternCoverageAnnotation {
+    <#
+    .SYNOPSIS
+        Renders the coverage-annotation suffix appended to a populated header
+        when the walker's Tier-2 corroboration rejected one or more candidate
+        directories (issue #825 s2, M6). Returns '' when RejectedDirCount is
+        not positive, so callers can unconditionally append the result.
+    #>
+    [OutputType([string])]
+    param([int]$RejectedDirCount = 0)
+
+    if ($RejectedDirCount -le 0) { return '' }
+    return " (activity from $RejectedDirCount unverifiable location(s) may be excluded)"
+}
+
+function script:Format-CostPatternUnknownHeader {
+    <#
+    .SYNOPSIS
+        Renders the unknown-completeness header across the three honest render
+        states (issue #825 s2, M12). Pure — reads only the caller-computed
+        -RenderContext, never $env: itself, so the sharded Pester runner stays
+        deterministic. None of the three states asserts "no session activity"
+        as settled fact: each names the real reason the walk found nothing, or
+        that the walk could not run at all.
+    .PARAMETER RenderContext
+        Optional hashtable with IsCi / ProjectsRootPresent booleans. Missing
+        keys default to false (non-CI, projects root absent) — the more
+        conservative "no local data" framing rather than a false honest-zero
+        claim when the caller did not supply enough context.
+    #>
+    [OutputType([string])]
+    param([hashtable]$RenderContext = $null)
+
+    $isCi = $false
+    $projectsRootPresent = $false
+    if ($null -ne $RenderContext) {
+        if ($RenderContext.ContainsKey('IsCi')) { $isCi = [bool]$RenderContext['IsCi'] }
+        if ($RenderContext.ContainsKey('ProjectsRootPresent')) { $projectsRootPresent = [bool]$RenderContext['ProjectsRootPresent'] }
+    }
+
+    if ($isCi) {
+        return "## Cost Pattern `u{26A0} CI cannot see local transcripts; a local re-walk will upgrade this block. cost-fields unavailable; this run is excluded from rolling-history aggregation"
+    }
+
+    if (-not $projectsRootPresent) {
+        return "## Cost Pattern `u{26A0} no local session data on this machine; a re-walk from the machine holding the transcripts will upgrade this block. cost-fields unavailable; this run is excluded from rolling-history aggregation"
+    }
+
+    return "## Cost Pattern `u{26A0} transcripts were searched on this machine and none matched this PR's branch/session; possible causes: the walk ran where transcripts are unavailable, the local walk never ran or exited before the cost step, a since-deleted sibling worktree held the events, the branch was created mid-session outside the phase-marker windows, or the linked issue could not be resolved from the branch name. cost-fields unavailable; this run is excluded from rolling-history aggregation"
+}
+
 function script:Build-CostPatternHeader {
     <#
     .SYNOPSIS
         Returns the header line for the ## Cost Pattern section.
+    .PARAMETER RenderContext
+        Issue #825 s2. Optional hashtable with IsCi / ProjectsRootPresent
+        booleans, used only for the unknown-completeness branch. See
+        Format-CostPatternUnknownHeader.
+    .PARAMETER RejectedDirCount
+        Issue #825 s2, M6. Count of Tier-2 branch-matched candidate
+        directories the walker rejected for failing corroboration. When
+        greater than zero, a populated (non-unknown) header carries a
+        coverage-annotation suffix naming the excluded location count.
     #>
     [OutputType([string])]
     param(
         [Parameter(Mandatory)][hashtable]$Completeness,
         [AllowEmptyCollection()][hashtable[]]$AnomalyFlags = @(),
-        [hashtable]$RollingMeta = $null
+        [hashtable]$RollingMeta = $null,
+        [hashtable]$RenderContext = $null,
+        [int]$RejectedDirCount = 0
     )
 
     $completenessValue = $Completeness['completeness']
     $excluded = $Completeness['excluded_from_rolling_baseline']
     $excludeReason = $Completeness['exclude_reason']
     $stopReason = $Completeness['stop_reason']
+
+    # unknown session (issue #825 s2, M12): no populated data exists, so this
+    # branch returns directly — it is never decorated with the coverage
+    # annotation below, which is scoped to populated blocks only.
+    if ($completenessValue -eq 'unknown') {
+        return script:Format-CostPatternUnknownHeader -RenderContext $RenderContext
+    }
+
+    $header = $null
 
     # eligible-partial session (issue #824 M6): a mid-session capture that
     # Resolve-BaselineEligibility promoted to baseline-eligible. Self-contained —
@@ -301,44 +372,40 @@ function script:Build-CostPatternHeader {
     if ($completenessValue -eq 'partial' -and $excluded -eq $false) {
         $disclosure = 'mid-session capture — baseline-eligible; totals may understate the final turn'
         if ($null -ne $RollingMeta -and $RollingMeta['timed_out'] -eq $true) {
-            return "## Cost Pattern `u{26A0} $disclosure; rolling-history fetch timed out — anomaly review unavailable for this run; per-port table shown below"
+            $header = "## Cost Pattern `u{26A0} $disclosure; rolling-history fetch timed out — anomaly review unavailable for this run; per-port table shown below"
         }
-        if ($null -ne $AnomalyFlags -and $AnomalyFlags.Count -gt 0) {
+        elseif ($null -ne $AnomalyFlags -and $AnomalyFlags.Count -gt 0) {
             $n = $AnomalyFlags.Count
-            return "## Cost Pattern `u{26A0} $disclosure ($n anomalies vs rolling baseline)"
+            $header = "## Cost Pattern `u{26A0} $disclosure ($n anomalies vs rolling baseline)"
         }
-        return "## Cost Pattern `u{26A0} $disclosure"
+        else {
+            $header = "## Cost Pattern `u{26A0} $disclosure"
+        }
     }
-
     # partial session (excluded from rolling-baseline aggregation)
-    if ($completenessValue -eq 'partial') {
+    elseif ($completenessValue -eq 'partial') {
         $reason = if ($stopReason) { $stopReason } else { 'unknown stop reason' }
-        return "## Cost Pattern `u{26A0} session incomplete ($reason); cost-fields show partial data; this run is excluded from rolling-history aggregation"
+        $header = "## Cost Pattern `u{26A0} session incomplete ($reason); cost-fields show partial data; this run is excluded from rolling-history aggregation"
     }
-
-    # unknown session
-    if ($completenessValue -eq 'unknown') {
-        return "## Cost Pattern `u{26A0} no Claude or Copilot session activity recorded for this PR's branch; cross-tool collection is enabled — see ``Initialize-CopilotCostCollection`` if Copilot is installed but data is missing, or #488 for diagnostics. cost-fields unavailable; this run is excluded from rolling-history aggregation"
-    }
-
     # rolling-history timed out
-    if ($null -ne $RollingMeta -and $RollingMeta['timed_out'] -eq $true) {
-        return "## Cost Pattern `u{26A0} rolling-history fetch timed out — anomaly review unavailable for this run; per-port table shown below"
+    elseif ($null -ne $RollingMeta -and $RollingMeta['timed_out'] -eq $true) {
+        $header = "## Cost Pattern `u{26A0} rolling-history fetch timed out — anomaly review unavailable for this run; per-port table shown below"
     }
-
     # complete session, excluded (outlier-PR annotation)
-    if ($excluded -and $null -ne $excludeReason -and $excludeReason -ne '' -and $completenessValue -eq 'complete') {
-        return "## Cost Pattern `u{26A0} this PR is annotated $excludeReason; excluded from rolling-history aggregation by future PRs"
+    elseif ($excluded -and $null -ne $excludeReason -and $excludeReason -ne '' -and $completenessValue -eq 'complete') {
+        $header = "## Cost Pattern `u{26A0} this PR is annotated $excludeReason; excluded from rolling-history aggregation by future PRs"
     }
-
     # complete, anomaly flags present
-    if ($null -ne $AnomalyFlags -and $AnomalyFlags.Count -gt 0) {
+    elseif ($null -ne $AnomalyFlags -and $AnomalyFlags.Count -gt 0) {
         $n = $AnomalyFlags.Count
-        return "## Cost Pattern ($n anomalies vs rolling baseline)"
+        $header = "## Cost Pattern ($n anomalies vs rolling baseline)"
+    }
+    # complete, clean
+    else {
+        $header = "## Cost Pattern — within rolling baseline"
     }
 
-    # complete, clean
-    return "## Cost Pattern — within rolling baseline"
+    return $header + (script:Format-CostPatternCoverageAnnotation -RejectedDirCount $RejectedDirCount)
 }
 
 #endregion
@@ -623,6 +690,14 @@ function Format-CostPatternMarkdown {
         PR number (informational; not rendered in markdown body but available for callers).
     .PARAMETER Branch
         Branch name (informational).
+    .PARAMETER RenderContext
+        Issue #825 s2. Optional hashtable with IsCi / ProjectsRootPresent
+        booleans, threaded to the unknown-completeness header. Pure — this
+        function never reads $env: itself; the caller computes both flags.
+    .PARAMETER RejectedDirCount
+        Issue #825 s2, M6. Count of Tier-2 branch-matched candidate
+        directories the walker rejected for failing corroboration; drives the
+        coverage-annotation suffix on populated (non-unknown) headers.
     .OUTPUTS
         [string] Full ## Cost Pattern markdown section.
     #>
@@ -634,10 +709,12 @@ function Format-CostPatternMarkdown {
         [AllowEmptyCollection()][hashtable[]]$AnomalyFlags = @(),
         [hashtable]$RollingMeta = $null,
         [int]$Pr = 0,
-        [string]$Branch = ''
+        [string]$Branch = '',
+        [hashtable]$RenderContext = $null,
+        [int]$RejectedDirCount = 0
     )
 
-    $header = script:Build-CostPatternHeader -Completeness $Completeness -AnomalyFlags $AnomalyFlags -RollingMeta $RollingMeta
+    $header = script:Build-CostPatternHeader -Completeness $Completeness -AnomalyFlags $AnomalyFlags -RollingMeta $RollingMeta -RenderContext $RenderContext -RejectedDirCount $RejectedDirCount
     $table = script:Build-CostPatternTable  -Attribution $Attribution -AnomalyFlags $AnomalyFlags
     $coverage = script:Get-CostRendererCoverage -Attribution $Attribution
 
@@ -669,7 +746,7 @@ function Format-CostPatternMarkdown {
         $body += "`n`n> **Note**: $nullEventTotal cost event(s) had unknown models not present in ``cost-rate-table.json`` and contributed null to the cost estimate. Update the rate table to include the missing model(s) for accurate attribution."
     }
     if ($Completeness['exclude_reason'] -eq 'phase-marker-only attribution; rolling-history excluded') {
-        $body += "`n`n> **Note**: This Cost Pattern shows Claude-side phase-marker attribution. Copilot-side collection remains tracked by [#488](https://github.com/Grimblaz/agent-orchestra/issues/488)."
+        $body += "`n`n> **Note**: This Cost Pattern shows Claude-side phase-marker attribution. Copilot-side collection was not captured for this run."
     }
     if (script:Test-CostRendererFallbackWarning -Attribution $Attribution -Coverage $coverage) {
         $body += "`n`n" + (script:Format-CostRendererFallbackRemediationNote)

--- a/.github/scripts/lib/cost-pattern-renderer.ps1
+++ b/.github/scripts/lib/cost-pattern-renderer.ps1
@@ -294,26 +294,36 @@ function script:Format-CostPatternCoverageAnnotation {
 function script:Format-CostPatternUnknownHeader {
     <#
     .SYNOPSIS
-        Renders the unknown-completeness header across the three honest render
-        states (issue #825 s2, M12). Pure — reads only the caller-computed
+        Renders the unknown-completeness header across the four honest render
+        states (issue #825 s2, M12; L11 issue #825 post-review fix added the
+        4th, budget-exceeded, state). Pure — reads only the caller-computed
         -RenderContext, never $env: itself, so the sharded Pester runner stays
-        deterministic. None of the three states asserts "no session activity"
+        deterministic. None of the four states asserts "no session activity"
         as settled fact: each names the real reason the walk found nothing, or
         that the walk could not run at all.
     .PARAMETER RenderContext
-        Optional hashtable with IsCi / ProjectsRootPresent booleans. Missing
-        keys default to false (non-CI, projects root absent) — the more
-        conservative "no local data" framing rather than a false honest-zero
-        claim when the caller did not supply enough context.
+        Optional hashtable with IsCi / ProjectsRootPresent / DegradedReason.
+        Missing IsCi/ProjectsRootPresent keys default to false (non-CI,
+        projects root absent) — the more conservative "no local data" framing
+        rather than a false honest-zero claim when the caller did not supply
+        enough context. DegradedReason (L11) is read only when IsCi is false
+        and ProjectsRootPresent is true — a local walker TIMEOUT
+        (degraded_reason = 'budget-exceeded', set in cost-fcl-helpers.ps1)
+        must not render the identical "searched and none matched" message a
+        genuine empty walk (degraded_reason = 'no-transcript-found') gets —
+        that collision loses the actionable "retry with a larger walker
+        budget" signal.
     #>
     [OutputType([string])]
     param([hashtable]$RenderContext = $null)
 
     $isCi = $false
     $projectsRootPresent = $false
+    $degradedReason = $null
     if ($null -ne $RenderContext) {
         if ($RenderContext.ContainsKey('IsCi')) { $isCi = [bool]$RenderContext['IsCi'] }
         if ($RenderContext.ContainsKey('ProjectsRootPresent')) { $projectsRootPresent = [bool]$RenderContext['ProjectsRootPresent'] }
+        if ($RenderContext.ContainsKey('DegradedReason')) { $degradedReason = [string]$RenderContext['DegradedReason'] }
     }
 
     if ($isCi) {
@@ -322,6 +332,10 @@ function script:Format-CostPatternUnknownHeader {
 
     if (-not $projectsRootPresent) {
         return "## Cost Pattern `u{26A0} no local session data on this machine; a re-walk from the machine holding the transcripts will upgrade this block. cost-fields unavailable; this run is excluded from rolling-history aggregation"
+    }
+
+    if ($degradedReason -eq 'budget-exceeded') {
+        return "## Cost Pattern `u{26A0} the local walk exceeded its time budget or stopped before finishing searching this PR's branch/session; if it was a timeout, retry the walk on this machine with a larger FRAME_CREDIT_LEDGER_TEST_COST_BUDGET_SECONDS override. cost-fields unavailable; this run is excluded from rolling-history aggregation"
     }
 
     return "## Cost Pattern `u{26A0} transcripts were searched on this machine and none matched this PR's branch/session; possible causes: the walk ran where transcripts are unavailable, the local walk never ran or exited before the cost step, a since-deleted sibling worktree held the events, the branch was created mid-session outside the phase-marker windows, or the linked issue could not be resolved from the branch name. cost-fields unavailable; this run is excluded from rolling-history aggregation"

--- a/.github/scripts/lib/cost-session-render.ps1
+++ b/.github/scripts/lib/cost-session-render.ps1
@@ -164,6 +164,16 @@ function Invoke-CostSessionRender {
     $degradedMarker = "<!-- cost-pattern-data-degraded-$Pr -->"
 
     try {
+        # Env override for the cost render budget (issue #825 CE Gate): on a
+        # large-profile machine (large ~/.claude/projects) the walk can legitimately
+        # exceed the 19s default before step-6g composes the section, so the section
+        # can never be rendered without a bigger budget. Resolved INSIDE this try so an
+        # unreachable FCL helper degrades to the 19s default via the outer fail-open
+        # catch (preserving the #824 dependency-chain contract) instead of throwing.
+        # Reuses Get-FCLCostWalkerTimeoutSeconds' exact shape, matching the walker-timeout
+        # overrides below: env present + valid positive int -> use it; else the default.
+        $costBudgetSeconds = script:Get-FCLCostWalkerTimeoutSeconds -EnvironmentVariableName 'FRAME_CREDIT_LEDGER_TEST_COST_BUDGET_SECONDS' -DefaultSeconds $costBudgetSeconds
+
         # 6a. Walkers
         $costEvents = @()
         $claudeWalk = $null

--- a/.github/scripts/lib/cost-session-render.ps1
+++ b/.github/scripts/lib/cost-session-render.ps1
@@ -192,6 +192,25 @@ function Invoke-CostSessionRender {
                 # Issue #825 s3: opt-in Tier-2 corroborated-fallback trust ladder,
                 # this caller only (M10 — never set by the live PR-create path).
                 $walkParameters['AdmitCorroboratedFallback'] = $true
+
+                # C2 (issue #825 post-review fix): a SECOND, branch-prefix-ONLY
+                # resolution (PrBody forced empty) feeds specifically the Tier-2
+                # corroboration gate. $resolvedIssueNumber (body-inclusive, below)
+                # stays reserved for phase-marker windowing, where trusting the PR
+                # body is legitimate — the Tier-2 trust ladder must not accept an
+                # author-controllable PR-body issue reference as its corroboration
+                # signal. Scoped to the AdmitCorroboratedFallback branch only —
+                # Tier2IssueNumber is meaningless (and unconsumed) on the live
+                # PR-create path, which never turns Tier 2 on. Set UNCONDITIONALLY
+                # (even when $null) — cost-walker.ps1's Tier2 gate distinguishes an
+                # explicitly-supplied $null (fail closed) from an omitted parameter
+                # (legacy fallback to -IssueNumber) via ContainsKey; omitting this key
+                # here whenever resolution comes back empty would silently re-admit
+                # the PR-body-derived -IssueNumber as the Tier-2 fallback, defeating
+                # this fix for the exact case it targets (branch doesn't match the
+                # issue-prefix pattern, so only the PR body names an issue).
+                $tier2ResolvedIssueNumber = script:Resolve-FCLLinkedIssueNumber -PrBody '' -Branch ([string]$Branch)
+                $walkParameters['Tier2IssueNumber'] = if ($null -ne $tier2ResolvedIssueNumber) { [int]$tier2ResolvedIssueNumber } else { $null }
             }
             if ($null -ne $CorroborationWindowStart) {
                 # Issue #825 s3 (post-review fix, M8 wiring gap): bounds Tier-2

--- a/.github/scripts/lib/cost-session-render.ps1
+++ b/.github/scripts/lib/cost-session-render.ps1
@@ -146,13 +146,23 @@ function Invoke-CostSessionRender {
         $claudeWalk = $null
         $copilotWalk = $null
         $copilotOtelJsonlPath = ''
+        # Issue #825 s2, M6: out-parameter ref for the walker's Tier-2
+        # rejected-dir count (see cost-walker.ps1's -RejectedDirCountVar,
+        # added by s1). AdmitCorroboratedFallback is not set by this caller
+        # (M10 — the live PR-create path stays fail-closed), so this stays 0
+        # today; the s3 targeted-repair entry point is the caller that turns
+        # the switch on and produces a nonzero count. Threaded through
+        # regardless so the annotation wiring below is already correct once
+        # s3 lands.
+        $rejectedDirCountRef = [ref]0
         if (-not [string]::IsNullOrWhiteSpace($Slug) -and -not [string]::IsNullOrWhiteSpace($Branch)) {
             $resolvedIssueNumber = script:Resolve-FCLLinkedIssueNumber -PrBody $PrBody -Branch ([string]$Branch)
             $walkParameters = @{
-                Slug      = $Slug
-                Branch    = $Branch
-                ParentCwd = $ParentCwd
-                RepoRoot  = $RepoRoot  # D2: used by identity-based slug discovery
+                Slug                = $Slug
+                Branch              = $Branch
+                ParentCwd           = $ParentCwd
+                RepoRoot            = $RepoRoot  # D2: used by identity-based slug discovery
+                RejectedDirCountVar = $rejectedDirCountRef
             }
             if ($null -ne $resolvedIssueNumber) {
                 $walkParameters['IssueNumber'] = [int]$resolvedIssueNumber
@@ -407,7 +417,19 @@ function Invoke-CostSessionRender {
 
             # 6g. Render fresh cost section
             if ((script:Get-FCLRemainingCostBudgetSeconds -Stopwatch $costStopwatch -BudgetSeconds $costBudgetSeconds) -gt 0) {
-                $costMarkdown = Format-CostPatternMarkdown -Attribution $costAttribution -Completeness $completeness -AnomalyFlags $anomalyFlags -RollingMeta $rollingResult -Pr $Pr -Branch ([string]$Branch)
+                # Issue #825 s2, M12: the renderer stays pure (no $env: reads inside
+                # cost-pattern-renderer.ps1, so the sharded Pester runner stays
+                # deterministic) — this caller computes both environment-state flags
+                # and threads them in. GITHUB_ACTIONS='true' mirrors the existing
+                # repo-wide CI-detection convention (see render-portfolio.ps1);
+                # ProjectsRootPresent reuses the same root-absence check the
+                # degraded_reason='env-absent' classification already relies on
+                # (script:Test-FCLClaudeProjectsRootAbsent, cost-fcl-helpers.ps1).
+                $renderContext = @{
+                    IsCi                = ($env:GITHUB_ACTIONS -eq 'true')
+                    ProjectsRootPresent = -not (script:Test-FCLClaudeProjectsRootAbsent)
+                }
+                $costMarkdown = Format-CostPatternMarkdown -Attribution $costAttribution -Completeness $completeness -AnomalyFlags $anomalyFlags -RollingMeta $rollingResult -Pr $Pr -Branch ([string]$Branch) -RenderContext $renderContext -RejectedDirCount ([int]$rejectedDirCountRef.Value)
                 $costYaml = Format-CostPatternYaml -Attribution $costAttribution -Completeness $completeness -AnomalyFlags $anomalyFlags -Pr $Pr -Branch ([string]$Branch) -SessionId $currentSessionId -HeadRef ([string]$Branch)
                 $costSection = $costMarkdown + "`n" + $costYaml
             }

--- a/.github/scripts/lib/cost-session-render.ps1
+++ b/.github/scripts/lib/cost-session-render.ps1
@@ -91,6 +91,26 @@ function Invoke-CostSessionRender {
     .PARAMETER IsOrchestrated
         Whether this PR is orchestrated-origin (gates both degraded-comment
         decisions, matching the pre-extraction inline behavior).
+    .PARAMETER AdmitCorroboratedFallback
+        Issue #825 s3. Opt-in switch, off by default — threaded straight through
+        to Invoke-CostTranscriptWalk's own -AdmitCorroboratedFallback (added by
+        s1). The live PR-creation caller never sets this (M10: that path stays
+        fail-closed). The s3 targeted-repair entry point
+        (Invoke-CostAttributionRepair, cost-baseline-harvest.ps1) is the one
+        caller that turns it on, for one maintainer-named PR at a time.
+    .PARAMETER CorroborationWindowStart
+    .PARAMETER CorroborationWindowEnd
+        Issue #825 s3 (post-review fix, M8 wiring gap). Threaded straight
+        through to Invoke-CostTranscriptWalk's own -CorroborationWindowStart/
+        -End (added by s1, bounds Tier-2-admitted events only). $null by
+        default and never set by the live PR-creation caller. Invoke-
+        CostAttributionRepair is the one caller that supplies these — the
+        target PR's own createdAt/mergedAt — so the M8 same-repo reused-
+        branch-name collision guard is actually enforced on the one path that
+        ships in issue #825 (the automatic-drain path where this would also
+        matter is deferred to #841). Without this, Tier-2 admission on the
+        shipped path runs unbounded despite the walker itself supporting the
+        bound.
     .OUTPUTS
         [hashtable] with keys: CostSection, Completeness, TokenSum, Attribution,
         SessionId, CostEventsCount, UsePriorCostSection, DegradedMarker,
@@ -107,7 +127,10 @@ function Invoke-CostSessionRender {
         [Parameter(Mandatory)][string]$RepoRoot,
         [AllowEmptyString()][string]$PrBody = '',
         [AllowNull()]$PriorComments = $null,
-        [bool]$IsOrchestrated = $false
+        [bool]$IsOrchestrated = $false,
+        [switch]$AdmitCorroboratedFallback,
+        [Nullable[datetime]]$CorroborationWindowStart = $null,
+        [Nullable[datetime]]$CorroborationWindowEnd = $null
     )
 
     $costBudgetSeconds = 19
@@ -148,12 +171,13 @@ function Invoke-CostSessionRender {
         $copilotOtelJsonlPath = ''
         # Issue #825 s2, M6: out-parameter ref for the walker's Tier-2
         # rejected-dir count (see cost-walker.ps1's -RejectedDirCountVar,
-        # added by s1). AdmitCorroboratedFallback is not set by this caller
-        # (M10 — the live PR-create path stays fail-closed), so this stays 0
-        # today; the s3 targeted-repair entry point is the caller that turns
-        # the switch on and produces a nonzero count. Threaded through
-        # regardless so the annotation wiring below is already correct once
-        # s3 lands.
+        # added by s1). AdmitCorroboratedFallback defaults off (this
+        # function's own switch, threaded straight through below) so this
+        # stays 0 for the live PR-create caller (M10 — that path stays
+        # fail-closed); the s3 targeted-repair entry point
+        # (Invoke-CostAttributionRepair) is the one caller that turns the
+        # switch on and produces a nonzero count. Threaded through
+        # regardless so the annotation wiring below is correct either way.
         $rejectedDirCountRef = [ref]0
         if (-not [string]::IsNullOrWhiteSpace($Slug) -and -not [string]::IsNullOrWhiteSpace($Branch)) {
             $resolvedIssueNumber = script:Resolve-FCLLinkedIssueNumber -PrBody $PrBody -Branch ([string]$Branch)
@@ -163,6 +187,23 @@ function Invoke-CostSessionRender {
                 ParentCwd           = $ParentCwd
                 RepoRoot            = $RepoRoot  # D2: used by identity-based slug discovery
                 RejectedDirCountVar = $rejectedDirCountRef
+            }
+            if ($AdmitCorroboratedFallback) {
+                # Issue #825 s3: opt-in Tier-2 corroborated-fallback trust ladder,
+                # this caller only (M10 — never set by the live PR-create path).
+                $walkParameters['AdmitCorroboratedFallback'] = $true
+            }
+            if ($null -ne $CorroborationWindowStart) {
+                # Issue #825 s3 (post-review fix, M8 wiring gap): bounds Tier-2
+                # admission to the caller-supplied window (Invoke-
+                # CostAttributionRepair passes the target PR's own
+                # createdAt/mergedAt). A $null bound is not enforced by the
+                # walker (see cost-walker.ps1), matching that function's own
+                # contract.
+                $walkParameters['CorroborationWindowStart'] = $CorroborationWindowStart
+            }
+            if ($null -ne $CorroborationWindowEnd) {
+                $walkParameters['CorroborationWindowEnd'] = $CorroborationWindowEnd
             }
             if ($null -ne $resolvedIssueNumber) {
                 $walkParameters['IssueNumber'] = [int]$resolvedIssueNumber

--- a/.github/scripts/lib/cost-session-render.ps1
+++ b/.github/scripts/lib/cost-session-render.ps1
@@ -495,9 +495,14 @@ function Invoke-CostSessionRender {
                 # ProjectsRootPresent reuses the same root-absence check the
                 # degraded_reason='env-absent' classification already relies on
                 # (script:Test-FCLClaudeProjectsRootAbsent, cost-fcl-helpers.ps1).
+                # DegradedReason (L11, issue #825 post-review fix): threaded from the
+                # already-computed $costAttribution so a local walker TIMEOUT renders
+                # a distinct message from a genuine empty walk instead of colliding on
+                # the same generic "searched and none matched" text.
                 $renderContext = @{
                     IsCi                = ($env:GITHUB_ACTIONS -eq 'true')
                     ProjectsRootPresent = -not (script:Test-FCLClaudeProjectsRootAbsent)
+                    DegradedReason      = [string]$costAttribution['degraded_reason']
                 }
                 $costMarkdown = Format-CostPatternMarkdown -Attribution $costAttribution -Completeness $completeness -AnomalyFlags $anomalyFlags -RollingMeta $rollingResult -Pr $Pr -Branch ([string]$Branch) -RenderContext $renderContext -RejectedDirCount ([int]$rejectedDirCountRef.Value)
                 $costYaml = Format-CostPatternYaml -Attribution $costAttribution -Completeness $completeness -AnomalyFlags $anomalyFlags -Pr $Pr -Branch ([string]$Branch) -SessionId $currentSessionId -HeadRef ([string]$Branch)
@@ -554,6 +559,7 @@ function Invoke-CostSessionRender {
     # ancestor walk) rather than `Test-Path variable:...` — the latter has
     # the identical ancestor-walk behavior as a bare variable read and would
     # reintroduce the same shadowing hazard this guard exists to avoid.
+    if ($null -eq (Get-Variable -Name 'costEvents' -Scope 0 -ErrorAction SilentlyContinue)) { $costEvents = @() }
     if ($null -eq (Get-Variable -Name 'completeness' -Scope 0 -ErrorAction SilentlyContinue)) { $completeness = $null }
     if ($null -eq (Get-Variable -Name 'costAttribution' -Scope 0 -ErrorAction SilentlyContinue)) { $costAttribution = $null }
     if ($null -eq (Get-Variable -Name 'currentTokenSum' -Scope 0 -ErrorAction SilentlyContinue)) { [long]$currentTokenSum = 0 }

--- a/.github/scripts/lib/cost-walker.ps1
+++ b/.github/scripts/lib/cost-walker.ps1
@@ -316,6 +316,32 @@ function script:Get-CostWalkerTargetIdentity {
     return $null
 }
 
+function script:ConvertFrom-CostWalkerJsonLine {
+    <#
+    .SYNOPSIS
+        Trims a raw JSONL line and parses it to a hashtable, or returns $null for
+        a blank line or a parse failure (issue #825 s1 extraction — shared by the
+        three Tier-2 corroborated-fallback probe helpers below, which previously
+        each duplicated this same trim/skip-blank/parse-or-skip shape inline).
+    .DESCRIPTION
+        Deliberately silent on parse failure (no Write-Warning) — these probe
+        helpers scan candidate transcripts speculatively and a malformed line is
+        just not-a-match, unlike Invoke-CostTranscriptWalk's own main walk loop
+        (and its Tier-2 file walk), which warns because it is the authoritative
+        pass over admitted events.
+    .OUTPUTS
+        [hashtable] the parsed event, or $null.
+    #>
+    param([AllowNull()][string]$Line)
+
+    if ([string]::IsNullOrEmpty($Line)) { return $null }
+    $trimmed = $Line.Trim()
+    if ([string]::IsNullOrEmpty($trimmed)) { return $null }
+
+    try { return $trimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop }
+    catch { return $null }
+}
+
 function script:Get-CostWalkerFirstEventCwd {
     <#
     .SYNOPSIS
@@ -334,18 +360,15 @@ function script:Get-CostWalkerFirstEventCwd {
         if ($null -ne $firstCwd) { break }
         $lines = @(Get-Content -Path $jf.FullName -Encoding utf8 -ErrorAction SilentlyContinue | Select-Object -First 20)
         foreach ($ln in $lines) {
-            $trimmed = $ln.Trim()
-            if ([string]::IsNullOrEmpty($trimmed)) { continue }
-            try {
-                $ev = $trimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop
-                if (-not [string]::IsNullOrEmpty([string]$ev['cwd'])) {
-                    $cwd = [string]$ev['cwd']
-                    if (-not $cwd.StartsWith($script:CostWalkerCopilotOtelCwdPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
-                        $firstCwd = $cwd
-                        break
-                    }
+            $ev = script:ConvertFrom-CostWalkerJsonLine -Line $ln
+            if ($null -eq $ev) { continue }
+            if (-not [string]::IsNullOrEmpty([string]$ev['cwd'])) {
+                $cwd = [string]$ev['cwd']
+                if (-not $cwd.StartsWith($script:CostWalkerCopilotOtelCwdPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $firstCwd = $cwd
+                    break
                 }
-            } catch { }
+            }
         }
     }
     return $firstCwd
@@ -413,10 +436,8 @@ function script:Test-CostWalkerDirHasBranchMatchFile {
     foreach ($file in $jsonlFiles) {
         $lines = @(Get-Content -Path $file.FullName -Encoding utf8 -ErrorAction SilentlyContinue)
         foreach ($line in $lines) {
-            $trimmed = $line.Trim()
-            if ([string]::IsNullOrEmpty($trimmed)) { continue }
-            $ev = $null
-            try { $ev = $trimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop } catch { continue }
+            $ev = script:ConvertFrom-CostWalkerJsonLine -Line $line
+            if ($null -eq $ev) { continue }
             if ($ev['type'] -eq 'assistant' -and $null -ne $ev['gitBranch'] -and [string]$ev['gitBranch'] -eq $Branch) {
                 $matchedFiles.Add($file.FullName)
                 break
@@ -440,11 +461,8 @@ function script:Test-CostWalkerFileHasIssueMarker {
 
     $lines = @(Get-Content -Path $FilePath -Encoding utf8 -ErrorAction SilentlyContinue)
     foreach ($line in $lines) {
-        $trimmed = $line.Trim()
-        if ([string]::IsNullOrEmpty($trimmed)) { continue }
-        $ev = $null
-        try { $ev = $trimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop } catch { continue }
-        if ($ev['type'] -ne 'user') { continue }
+        $ev = script:ConvertFrom-CostWalkerJsonLine -Line $line
+        if ($null -eq $ev -or $ev['type'] -ne 'user') { continue }
         $marker = script:Get-CostWalkerPhaseMarker -TranscriptEvent $ev
         if ($null -ne $marker -and $marker.IssueId -eq $IssueNumber) { return $true }
     }
@@ -802,10 +820,52 @@ function Invoke-CostTranscriptWalk {
     }
 
     # Issue #825 s1: walk the Tier-2 corroborated-fallback admitted files (opt-in, empty unless
-    # -AdmitCorroboratedFallback was set). Uses the same branch-only per-event predicate as Tier
-    # 1 (script:Test-CostWalkerAssistantMatchesStrictFilter) plus the M8 merge-window bound,
-    # which never applies to Tier 1.
-    foreach ($filePath in $tier2AdmittedFiles) {
+    # -AdmitCorroboratedFallback was set). Extracted to script:Invoke-CostWalkerTier2Walk (issue
+    # #825 refactor pass) to keep this function's own per-PR growth from the trust ladder
+    # proportionate — see that helper's docstring for the predicate/bound details.
+    script:Invoke-CostWalkerTier2Walk -Included $included -Tier2AdmittedFiles $tier2AdmittedFiles `
+        -NormalizedParentCwd $normalizedParentCwd -Branch $Branch -SeenDedupKeys $seenDedupKeys `
+        -CorroborationWindowStart $CorroborationWindowStart -CorroborationWindowEnd $CorroborationWindowEnd
+
+    return $included
+}
+
+function script:Invoke-CostWalkerTier2Walk {
+    <#
+    .SYNOPSIS
+        Walks the Tier-2 corroborated-fallback admitted files and appends
+        admitted events to $Included (issue #825 s1; extracted from
+        Invoke-CostTranscriptWalk by the issue #825 refactor pass — this loop
+        is self-contained with its own predicate and merge-window bound, so it
+        does not need to share Invoke-CostTranscriptWalk's local scope).
+    .DESCRIPTION
+        Uses the same branch-only per-event predicate as Tier 1
+        (script:Test-CostWalkerAssistantMatchesStrictFilter) plus the M8
+        merge-window bound, which never applies to Tier 1. Reuses the same
+        composite-dedup-key event admission (script:Add-CostWalkerAssistantEventAndSubagents)
+        Tier 1 uses, via the caller-supplied $Included list and $SeenDedupKeys set,
+        so an event admitted by both tiers is still only counted once.
+    .PARAMETER Tier2AdmittedFiles
+        The file list returned by script:Get-CostWalkerCorroboratedFallbackAdmission
+        (empty when -AdmitCorroboratedFallback was not set on the caller).
+    .PARAMETER CorroborationWindowStart
+    .PARAMETER CorroborationWindowEnd
+        Issue #825 s1, M8. Bounds Tier-2-admitted events only. A $null bound is
+        not enforced, matching Invoke-CostTranscriptWalk's own contract.
+    .OUTPUTS
+        None — admitted events are appended directly to $Included.
+    #>
+    param(
+        [Parameter(Mandatory)]$Included,
+        [Parameter(Mandatory)]$Tier2AdmittedFiles,
+        [Parameter(Mandatory)][string]$NormalizedParentCwd,
+        [Parameter(Mandatory)][string]$Branch,
+        [Parameter(Mandatory)]$SeenDedupKeys,
+        [Nullable[datetime]]$CorroborationWindowStart = $null,
+        [Nullable[datetime]]$CorroborationWindowEnd = $null
+    )
+
+    foreach ($filePath in $Tier2AdmittedFiles) {
         $tier2SessionId = [System.IO.Path]::GetFileNameWithoutExtension($filePath)
         $tier2SlugDir = Split-Path -Parent $filePath
         $tier2Lines = @(Get-Content -Path $filePath -Encoding utf8 -ErrorAction SilentlyContinue)
@@ -824,7 +884,7 @@ function Invoke-CostTranscriptWalk {
             }
 
             if ($parsedEvent['type'] -ne 'assistant') { continue }
-            if (-not (script:Test-CostWalkerAssistantMatchesStrictFilter -TranscriptEvent $parsedEvent -NormalizedParentCwd $normalizedParentCwd -Branch $Branch)) { continue }
+            if (-not (script:Test-CostWalkerAssistantMatchesStrictFilter -TranscriptEvent $parsedEvent -NormalizedParentCwd $NormalizedParentCwd -Branch $Branch)) { continue }
 
             if ($null -ne $CorroborationWindowStart -or $null -ne $CorroborationWindowEnd) {
                 $eventTimestamp = $null
@@ -834,11 +894,9 @@ function Invoke-CostTranscriptWalk {
                 if ($null -ne $CorroborationWindowEnd -and $eventTimestamp -gt $CorroborationWindowEnd) { continue }
             }
 
-            script:Add-CostWalkerAssistantEventAndSubagents -Included $included -TranscriptEvent $parsedEvent -SlugDir $tier2SlugDir -SessionId $tier2SessionId -SeenKeys $seenDedupKeys
+            script:Add-CostWalkerAssistantEventAndSubagents -Included $Included -TranscriptEvent $parsedEvent -SlugDir $tier2SlugDir -SessionId $tier2SessionId -SeenKeys $SeenDedupKeys
         }
     }
-
-    return $included
 }
 
 function Get-CostWalkerCurrentSessionId {

--- a/.github/scripts/lib/cost-walker.ps1
+++ b/.github/scripts/lib/cost-walker.ps1
@@ -126,6 +126,14 @@ function script:Add-CostWalkerAssistantEventAndSubagents {
         documented on Get-CostWalkerCurrentSessionId). An event with no uuid is
         never deduped (always added) — this preserves pre-#825 behavior for
         synthetic/test events that omit it.
+
+        L12 (issue #825 post-review fix): a duplicate PARENT event only skips its
+        own insertion into $Included — the subagent traversal below always runs,
+        even for a dedup no-op parent. A duplicate copy of the same session
+        directory can hold a `subagents/` file the first-processed copy's
+        directory lacks (or vice versa); returning early on the parent dedup hit
+        used to skip that copy's entire subagent traversal, silently losing those
+        subagent cost events.
     #>
     param(
         [Parameter(Mandatory)]$Included,
@@ -136,15 +144,24 @@ function script:Add-CostWalkerAssistantEventAndSubagents {
     )
 
     $eventUuid = [string]$TranscriptEvent['uuid']
+    # An event with no uuid is never deduped — always treated as a fresh parent.
+    $addParent = $true
     if (-not [string]::IsNullOrEmpty($eventUuid)) {
         $dedupKey = "$SessionId|$eventUuid"
-        if ($SeenKeys.Contains($dedupKey)) { return }
-        [void]$SeenKeys.Add($dedupKey)
+        # HashSet.Add() returns $false when the key was already present, $true when
+        # newly added — a single atomic membership-test-and-insert, replacing the
+        # prior Contains()-then-separate-Add() pair whose early `return` on a
+        # duplicate skipped the subagent traversal below along with the parent.
+        $addParent = $SeenKeys.Add($dedupKey)
     }
 
-    $Included.Add($TranscriptEvent)
+    if ($addParent) {
+        $Included.Add($TranscriptEvent)
+    }
 
-    # Traverse subagent transcripts for included Agent tool_use dispatches.
+    # Traverse subagent transcripts for included Agent tool_use dispatches — runs
+    # unconditionally so a duplicate parent's own subagent directory is still
+    # walked (see L12 note above).
     $messageContent = $TranscriptEvent['message']?['content']
     if ($null -eq $messageContent) { return }
 
@@ -157,7 +174,7 @@ function script:Add-CostWalkerAssistantEventAndSubagents {
             if ($null -ne $toolUseId) {
                 $subagPath = Join-Path $SlugDir 'subagents' "agent-$toolUseId.jsonl"
                 if (Test-Path -LiteralPath $subagPath) {
-                    $subLines = @(Get-Content -Path $subagPath -Encoding utf8 -ErrorAction SilentlyContinue)
+                    $subLines = @(Get-Content -LiteralPath $subagPath -Encoding utf8 -ErrorAction SilentlyContinue)
                     foreach ($subLine in $subLines) {
                         $subTrimmed = $subLine.Trim()
                         if ([string]::IsNullOrEmpty($subTrimmed)) { continue }
@@ -360,10 +377,10 @@ function script:Get-CostWalkerFirstEventCwd {
     param([Parameter(Mandatory)][string]$SlugDirPath)
 
     $firstCwd = $null
-    $jsonls = @(Get-ChildItem -Path $SlugDirPath -Filter '*.jsonl' -File -ErrorAction SilentlyContinue | Select-Object -First 5)
+    $jsonls = @(Get-ChildItem -LiteralPath $SlugDirPath -Filter '*.jsonl' -File -ErrorAction SilentlyContinue | Select-Object -First 5)
     foreach ($jf in $jsonls) {
         if ($null -ne $firstCwd) { break }
-        $lines = @(Get-Content -Path $jf.FullName -Encoding utf8 -ErrorAction SilentlyContinue | Select-Object -First 20)
+        $lines = @(Get-Content -LiteralPath $jf.FullName -Encoding utf8 -ErrorAction SilentlyContinue | Select-Object -First 20)
         foreach ($ln in $lines) {
             $ev = script:ConvertFrom-CostWalkerJsonLine -Line $ln
             if ($null -eq $ev) { continue }
@@ -443,9 +460,9 @@ function script:Test-CostWalkerDirHasBranchMatchFile {
     )
 
     $matchedFiles = [System.Collections.Generic.List[string]]::new()
-    $jsonlFiles = @(Get-ChildItem -Path $SlugDirPath -Filter '*.jsonl' -File -ErrorAction SilentlyContinue)
+    $jsonlFiles = @(Get-ChildItem -LiteralPath $SlugDirPath -Filter '*.jsonl' -File -ErrorAction SilentlyContinue)
     foreach ($file in $jsonlFiles) {
-        $lines = @(Get-Content -Path $file.FullName -Encoding utf8 -ErrorAction SilentlyContinue)
+        $lines = @(Get-Content -LiteralPath $file.FullName -Encoding utf8 -ErrorAction SilentlyContinue)
         foreach ($line in $lines) {
             $ev = script:ConvertFrom-CostWalkerJsonLine -Line $line
             if ($null -eq $ev) { continue }
@@ -470,13 +487,79 @@ function script:Test-CostWalkerFileHasIssueMarker {
         [Parameter(Mandatory)][int]$IssueNumber
     )
 
-    $lines = @(Get-Content -Path $FilePath -Encoding utf8 -ErrorAction SilentlyContinue)
+    $lines = @(Get-Content -LiteralPath $FilePath -Encoding utf8 -ErrorAction SilentlyContinue)
     foreach ($line in $lines) {
         $ev = script:ConvertFrom-CostWalkerJsonLine -Line $line
         if ($null -eq $ev -or $ev['type'] -ne 'user') { continue }
         $marker = script:Get-CostWalkerPhaseMarker -TranscriptEvent $ev
         if ($null -ne $marker -and $marker.IssueId -eq $IssueNumber) { return $true }
     }
+    return $false
+}
+
+function script:Test-CostWalkerFileEvidenceIdentityMismatch {
+    <#
+    .SYNOPSIS
+        Scans a Tier-2 candidate file's own recorded event cwd values for a
+        positive, verifiable repo-identity mismatch against $TargetIdentity
+        (issue #825 post-review fix, L14).
+    .DESCRIPTION
+        The Tier-2 M9 trigger only requires the directory's FIRST recorded cwd
+        to be absent from disk — it says nothing about every OTHER event in the
+        same file. This scans every distinct, non-sentinel cwd recorded in the
+        file and, for any that still exists on disk, resolves its git remote
+        identity. If any resolves and differs from $TargetIdentity, the file's
+        own evidence proves it does not belong to the target repository, and the
+        primary (own-marker) corroboration path must not admit it on that
+        evidence alone — closing the gap where a deleted-cwd candidate sharing
+        the same branch name and issue-marker number, but originating from a
+        DIFFERENT repository, could otherwise be admitted and cross-attributed.
+
+        "Where determinable" (the finding's framing): most Tier-2 candidates
+        have no OTHER existing cwd anywhere in the file (the typical case — the
+        whole worktree/session was deleted), so this returns $false (no proven
+        mismatch, not "no evidence of a match") and the existing own-marker
+        corroboration path is unaffected. This is intentionally NOT a
+        directory-name/slug check — Tier-2 admits arbitrarily-named directories
+        by design (ladder case 6); this only fires on a POSITIVE, git-resolved
+        contradiction.
+    .OUTPUTS
+        [bool] $true only when at least one recorded cwd in the file exists on
+        disk AND resolves to a git identity different from $TargetIdentity.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$FilePath,
+        [Parameter(Mandatory)][string]$TargetIdentity
+    )
+
+    $lines = @(Get-Content -LiteralPath $FilePath -Encoding utf8 -ErrorAction SilentlyContinue)
+    $checkedCwds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($line in $lines) {
+        $ev = script:ConvertFrom-CostWalkerJsonLine -Line $line
+        if ($null -eq $ev) { continue }
+
+        $cwd = [string]$ev['cwd']
+        if ([string]::IsNullOrEmpty($cwd) -or -not $checkedCwds.Add($cwd)) { continue }
+
+        if (-not [string]::IsNullOrEmpty($script:CostWalkerCopilotOtelCwdPrefix) -and
+            $cwd.StartsWith($script:CostWalkerCopilotOtelCwdPrefix, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+
+        if (-not (Test-Path -LiteralPath $cwd -ErrorAction SilentlyContinue)) { continue }
+
+        $candidateIdentity = $null
+        try {
+            $rawUrl = @(& git -C $cwd remote get-url origin 2>$null) | Select-Object -First 1
+            if ($global:LASTEXITCODE -eq 0) {
+                $candidateIdentity = script:Resolve-CostWalkerRepoIdentity -RawUrl ([string]$rawUrl)
+            }
+        } catch { }
+
+        if ($null -ne $candidateIdentity -and $candidateIdentity -ne $TargetIdentity) {
+            return $true
+        }
+    }
+
     return $false
 }
 
@@ -509,6 +592,12 @@ function script:Get-CostWalkerCorroboratedFallbackAdmission {
         it had at least one branch-matched file and NONE of those files achieved
         corroboration — a directory that admits at least one file is not counted as
         rejected even if it also has non-corroborated siblings.
+
+        L14 (issue #825 post-review fix): the primary (own-marker) signal above has
+        no repo-identity tie by itself — see
+        script:Test-CostWalkerFileEvidenceIdentityMismatch, consulted before trusting
+        own-marker corroboration, for the guard that rejects a file whose own
+        evidence positively proves a different repository identity.
     .OUTPUTS
         [hashtable] @{ AdmittedFiles = [List[string]]; RejectedDirCount = [int] }
     #>
@@ -538,7 +627,7 @@ function script:Get-CostWalkerCorroboratedFallbackAdmission {
         $firstCwd = script:Get-CostWalkerFirstEventCwd -SlugDirPath $dir.FullName
         if ($null -eq $firstCwd) { continue }  # no usable cwd recorded at all; skip silently
 
-        if (Test-Path -LiteralPath $firstCwd) {
+        if (Test-Path -LiteralPath $firstCwd -ErrorAction SilentlyContinue) {
             # M9: cwd present — not the strict Tier-2 trigger. Tier 1 already made the
             # terminal (mismatched identity) or fail-closed (unresolvable identity) call
             # for this directory; Tier 2 never reconsiders it.
@@ -554,12 +643,23 @@ function script:Get-CostWalkerCorroboratedFallbackAdmission {
 
             $corroborated = script:Test-CostWalkerFileHasIssueMarker -FilePath $filePath -IssueNumber $resolvedIssueNumber
 
+            # L14 (issue #825 post-review fix): the primary (own-marker) corroboration
+            # signal above has no repo-identity tie of its own — branch name and issue
+            # marker are both coincidentally reproducible from a different repository.
+            # When this file's OWN evidence (a non-first, still-extant recorded cwd)
+            # positively proves a different repo identity, the primary path must not
+            # admit on marker-only evidence; fall through to the M14 sibling check below
+            # exactly as if the marker had never corroborated at all.
+            if ($corroborated -and (script:Test-CostWalkerFileEvidenceIdentityMismatch -FilePath $filePath -TargetIdentity $TargetIdentity)) {
+                $corroborated = $false
+            }
+
             if (-not $corroborated) {
                 # M14: cross-file corroboration via a sibling identity-matched (Tier-1)
                 # transcript of the SAME session (same file BaseName / session id).
                 foreach ($tier1Dir in $Tier1AdmittedDirs) {
                     $siblingPath = Join-Path $tier1Dir "$sessionId.jsonl"
-                    if ((Test-Path -LiteralPath $siblingPath -PathType Leaf) -and
+                    if ((Test-Path -LiteralPath $siblingPath -PathType Leaf -ErrorAction SilentlyContinue) -and
                         (script:Test-CostWalkerFileHasIssueMarker -FilePath $siblingPath -IssueNumber $resolvedIssueNumber)) {
                         $corroborated = $true
                         break
@@ -911,7 +1011,7 @@ function script:Invoke-CostWalkerTier2Walk {
     foreach ($filePath in $Tier2AdmittedFiles) {
         $tier2SessionId = [System.IO.Path]::GetFileNameWithoutExtension($filePath)
         $tier2SlugDir = Split-Path -Parent $filePath
-        $tier2Lines = @(Get-Content -Path $filePath -Encoding utf8 -ErrorAction SilentlyContinue)
+        $tier2Lines = @(Get-Content -LiteralPath $filePath -Encoding utf8 -ErrorAction SilentlyContinue)
 
         foreach ($line in $tier2Lines) {
             $trimmed = $line.Trim()

--- a/.github/scripts/lib/cost-walker.ps1
+++ b/.github/scripts/lib/cost-walker.ps1
@@ -108,11 +108,34 @@ function script:Test-CostWalkerAssistantMatchesStrictFilter {
 }
 
 function script:Add-CostWalkerAssistantEventAndSubagents {
+    <#
+    .SYNOPSIS
+        Adds an admitted assistant event (and its subagent transcript events) to
+        the walk's result list, applying the composite dedup key.
+    .DESCRIPTION
+        M7 (issue #825 s1): events are attributed once across ALL admitted slug
+        dirs using a composite `session_id` + event `uuid` key (never `session_id`
+        alone, which would under-count a legitimately split spanning session that
+        reuses the same file BaseName but has distinct event uuids). SessionId is
+        the originating JSONL file's own BaseName (the session id convention
+        documented on Get-CostWalkerCurrentSessionId). An event with no uuid is
+        never deduped (always added) — this preserves pre-#825 behavior for
+        synthetic/test events that omit it.
+    #>
     param(
         [Parameter(Mandatory)]$Included,
         [Parameter(Mandatory)]$TranscriptEvent,
-        [Parameter(Mandatory)][string]$SlugDir
+        [Parameter(Mandatory)][string]$SlugDir,
+        [Parameter(Mandatory)][string]$SessionId,
+        [Parameter(Mandatory)]$SeenKeys
     )
+
+    $eventUuid = [string]$TranscriptEvent['uuid']
+    if (-not [string]::IsNullOrEmpty($eventUuid)) {
+        $dedupKey = "$SessionId|$eventUuid"
+        if ($SeenKeys.Contains($dedupKey)) { return }
+        [void]$SeenKeys.Add($dedupKey)
+    }
 
     $Included.Add($TranscriptEvent)
 
@@ -135,6 +158,12 @@ function script:Add-CostWalkerAssistantEventAndSubagents {
                         if ([string]::IsNullOrEmpty($subTrimmed)) { continue }
                         try {
                             $subagEvent = $subTrimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+                            $subUuid = [string]$subagEvent['uuid']
+                            if (-not [string]::IsNullOrEmpty($subUuid)) {
+                                $subKey = "$SessionId|$subUuid"
+                                if ($SeenKeys.Contains($subKey)) { continue }
+                                [void]$SeenKeys.Add($subKey)
+                            }
                             $Included.Add($subagEvent)
                         }
                         catch {
@@ -267,6 +296,61 @@ function script:Resolve-CostWalkerRepoIdentity {
     return $u
 }
 
+function script:Get-CostWalkerTargetIdentity {
+    <#
+    .SYNOPSIS
+        Resolves the target (ledger) repo's identity from its git remote (issue #825
+        s1 extraction — shared by Get-IdentityMatchedSlugDirs and the Tier-2
+        corroborated-fallback resolver so both agree on what "matches" means).
+    .OUTPUTS
+        [string] normalized 'host/path' identity, or $null when unresolvable.
+    #>
+    param([Parameter(Mandatory)][string]$RepoRoot)
+
+    try {
+        $rawUrl = @(& git -C $RepoRoot remote get-url origin 2>$null) | Select-Object -First 1
+        if ($global:LASTEXITCODE -eq 0) {
+            return script:Resolve-CostWalkerRepoIdentity -RawUrl ([string]$rawUrl)
+        }
+    } catch { }
+    return $null
+}
+
+function script:Get-CostWalkerFirstEventCwd {
+    <#
+    .SYNOPSIS
+        Finds the first non-empty, non-sentinel cwd recorded by any event in a slug
+        directory's JSONL files (issue #825 s1 extraction — shared by
+        Get-IdentityMatchedSlugDirs and the Tier-2 corroborated-fallback resolver).
+    .OUTPUTS
+        [string] the first usable cwd, or $null when no JSONL file in the directory
+        records one.
+    #>
+    param([Parameter(Mandatory)][string]$SlugDirPath)
+
+    $firstCwd = $null
+    $jsonls = @(Get-ChildItem -Path $SlugDirPath -Filter '*.jsonl' -File -ErrorAction SilentlyContinue | Select-Object -First 5)
+    foreach ($jf in $jsonls) {
+        if ($null -ne $firstCwd) { break }
+        $lines = @(Get-Content -Path $jf.FullName -Encoding utf8 -ErrorAction SilentlyContinue | Select-Object -First 20)
+        foreach ($ln in $lines) {
+            $trimmed = $ln.Trim()
+            if ([string]::IsNullOrEmpty($trimmed)) { continue }
+            try {
+                $ev = $trimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+                if (-not [string]::IsNullOrEmpty([string]$ev['cwd'])) {
+                    $cwd = [string]$ev['cwd']
+                    if (-not $cwd.StartsWith($script:CostWalkerCopilotOtelCwdPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                        $firstCwd = $cwd
+                        break
+                    }
+                }
+            } catch { }
+        }
+    }
+    return $firstCwd
+}
+
 function script:Get-IdentityMatchedSlugDirs {
     param(
         [Parameter(Mandatory)][string]$ProjectsRoot,
@@ -274,13 +358,7 @@ function script:Get-IdentityMatchedSlugDirs {
     )
 
     # Resolve target repo identity once from the ledger's repo root.
-    $targetIdentity = $null
-    try {
-        $rawUrl = @(& git -C $RepoRoot remote get-url origin 2>$null) | Select-Object -First 1
-        if ($global:LASTEXITCODE -eq 0) {
-            $targetIdentity = script:Resolve-CostWalkerRepoIdentity -RawUrl ([string]$rawUrl)
-        }
-    } catch { }
+    $targetIdentity = script:Get-CostWalkerTargetIdentity -RepoRoot $RepoRoot
 
     if ($null -eq $targetIdentity) {
         # Can't resolve target identity — fail-closed: return empty list, no slug dirs admitted.
@@ -292,26 +370,7 @@ function script:Get-IdentityMatchedSlugDirs {
     $allDirs = @(Get-ChildItem -Path $ProjectsRoot -Directory -ErrorAction SilentlyContinue)
     foreach ($dir in $allDirs) {
         # Find the first event with a cwd field in any JSONL file in this slug dir.
-        $firstCwd = $null
-        $jsonls = @(Get-ChildItem -Path $dir.FullName -Filter '*.jsonl' -File -ErrorAction SilentlyContinue | Select-Object -First 5)
-        foreach ($jf in $jsonls) {
-            if ($null -ne $firstCwd) { break }
-            $lines = @(Get-Content -Path $jf.FullName -Encoding utf8 -ErrorAction SilentlyContinue | Select-Object -First 20)
-            foreach ($ln in $lines) {
-                $trimmed = $ln.Trim()
-                if ([string]::IsNullOrEmpty($trimmed)) { continue }
-                try {
-                    $ev = $trimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop
-                    if (-not [string]::IsNullOrEmpty([string]$ev['cwd'])) {
-                        $cwd = [string]$ev['cwd']
-                        if (-not $cwd.StartsWith($script:CostWalkerCopilotOtelCwdPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
-                            $firstCwd = $cwd
-                            break
-                        }
-                    }
-                } catch { }
-            }
-        }
+        $firstCwd = script:Get-CostWalkerFirstEventCwd -SlugDirPath $dir.FullName
 
         if ($null -eq $firstCwd) { continue }  # fail-closed: no usable cwd found
 
@@ -335,6 +394,164 @@ function script:Get-IdentityMatchedSlugDirs {
     return $matched
 }
 
+function script:Test-CostWalkerDirHasBranchMatchFile {
+    <#
+    .SYNOPSIS
+        Lists JSONL files within a slug directory that contain at least one
+        'assistant' event whose gitBranch equals the target branch (issue #825 s1,
+        Tier-2 corroborated-fallback trust ladder — signal (i)).
+    .OUTPUTS
+        [System.Collections.Generic.List[string]] full paths of matching files.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$SlugDirPath,
+        [Parameter(Mandatory)][string]$Branch
+    )
+
+    $matchedFiles = [System.Collections.Generic.List[string]]::new()
+    $jsonlFiles = @(Get-ChildItem -Path $SlugDirPath -Filter '*.jsonl' -File -ErrorAction SilentlyContinue)
+    foreach ($file in $jsonlFiles) {
+        $lines = @(Get-Content -Path $file.FullName -Encoding utf8 -ErrorAction SilentlyContinue)
+        foreach ($line in $lines) {
+            $trimmed = $line.Trim()
+            if ([string]::IsNullOrEmpty($trimmed)) { continue }
+            $ev = $null
+            try { $ev = $trimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop } catch { continue }
+            if ($ev['type'] -eq 'assistant' -and $null -ne $ev['gitBranch'] -and [string]$ev['gitBranch'] -eq $Branch) {
+                $matchedFiles.Add($file.FullName)
+                break
+            }
+        }
+    }
+    return $matchedFiles
+}
+
+function script:Test-CostWalkerFileHasIssueMarker {
+    <#
+    .SYNOPSIS
+        Reports whether a JSONL file contains a phase marker (<command-args>) naming
+        the given issue number (issue #825 s1, Tier-2 corroborated-fallback trust
+        ladder — signal (ii)).
+    #>
+    param(
+        [Parameter(Mandatory)][string]$FilePath,
+        [Parameter(Mandatory)][int]$IssueNumber
+    )
+
+    $lines = @(Get-Content -Path $FilePath -Encoding utf8 -ErrorAction SilentlyContinue)
+    foreach ($line in $lines) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrEmpty($trimmed)) { continue }
+        $ev = $null
+        try { $ev = $trimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop } catch { continue }
+        if ($ev['type'] -ne 'user') { continue }
+        $marker = script:Get-CostWalkerPhaseMarker -TranscriptEvent $ev
+        if ($null -ne $marker -and $marker.IssueId -eq $IssueNumber) { return $true }
+    }
+    return $false
+}
+
+function script:Get-CostWalkerCorroboratedFallbackAdmission {
+    <#
+    .SYNOPSIS
+        Resolves the Tier-2 corroborated-fallback admission set (issue #825 s1,
+        plan-issue-825 Step 1). Opt-in behind -AdmitCorroboratedFallback on
+        Invoke-CostTranscriptWalk; Tier 1 (script:Get-IdentityMatchedSlugDirs) is
+        never touched or reconsidered by this function.
+    .DESCRIPTION
+        Strict cwd-absent trigger (M9): a candidate slug directory is only eligible
+        for Tier-2 admission when its recorded first-event cwd does NOT exist on
+        disk. A directory whose cwd exists but resolves to a mismatched or
+        unresolvable identity was already excluded (terminally, or fail-closed) by
+        Tier 1 and is never reconsidered here — that is the "positively-mismatched
+        identity -> terminal reject, probe-miss -> fail-closed" split from the plan.
+
+        For each cwd-absent candidate directory, files with at least one
+        branch-matched assistant event (signal (i)) are corroboration candidates. A
+        candidate file is admitted only when it also satisfies signal (ii): its own
+        phase markers name the target issue, OR (M14 cross-file corroboration) a
+        sibling file with the SAME BaseName (the same session id) inside an
+        already-admitted Tier-1 directory names the target issue. Same-file/
+        same-session scoping (M11) means an unrelated co-located session's phase
+        marker in the same directory never corroborates a different session's
+        branch-matched file.
+
+        A directory contributes to the returned rejected-dir count (M6) only when
+        it had at least one branch-matched file and NONE of those files achieved
+        corroboration — a directory that admits at least one file is not counted as
+        rejected even if it also has non-corroborated siblings.
+    .OUTPUTS
+        [hashtable] @{ AdmittedFiles = [List[string]]; RejectedDirCount = [int] }
+    #>
+    param(
+        [Parameter(Mandatory)][string]$ProjectsRoot,
+        [AllowNull()][string]$TargetIdentity,
+        [Parameter(Mandatory)]$Tier1AdmittedDirs,
+        [Parameter(Mandatory)][string]$Branch,
+        [Nullable[int]]$IssueNumber
+    )
+
+    $admittedFiles = [System.Collections.Generic.List[string]]::new()
+    $rejectedDirCount = 0
+
+    if ([string]::IsNullOrEmpty($TargetIdentity) -or $null -eq $IssueNumber -or [int]$IssueNumber -le 0) {
+        # No resolvable target identity or no issue to corroborate against: Tier 2 admits
+        # nothing (fail-closed) rather than guessing.
+        return @{ AdmittedFiles = $admittedFiles; RejectedDirCount = $rejectedDirCount }
+    }
+
+    $resolvedIssueNumber = [int]$IssueNumber
+    $allDirs = @(Get-ChildItem -Path $ProjectsRoot -Directory -ErrorAction SilentlyContinue)
+
+    foreach ($dir in $allDirs) {
+        if ($Tier1AdmittedDirs.Contains($dir.FullName)) { continue }
+
+        $firstCwd = script:Get-CostWalkerFirstEventCwd -SlugDirPath $dir.FullName
+        if ($null -eq $firstCwd) { continue }  # no usable cwd recorded at all; skip silently
+
+        if (Test-Path -LiteralPath $firstCwd) {
+            # M9: cwd present — not the strict Tier-2 trigger. Tier 1 already made the
+            # terminal (mismatched identity) or fail-closed (unresolvable identity) call
+            # for this directory; Tier 2 never reconsiders it.
+            continue
+        }
+
+        $branchMatchedFiles = script:Test-CostWalkerDirHasBranchMatchFile -SlugDirPath $dir.FullName -Branch $Branch
+        if ($branchMatchedFiles.Count -eq 0) { continue }  # never branch-matched; not a rejection candidate
+
+        $dirAdmittedAny = $false
+        foreach ($filePath in $branchMatchedFiles) {
+            $sessionId = [System.IO.Path]::GetFileNameWithoutExtension($filePath)
+
+            $corroborated = script:Test-CostWalkerFileHasIssueMarker -FilePath $filePath -IssueNumber $resolvedIssueNumber
+
+            if (-not $corroborated) {
+                # M14: cross-file corroboration via a sibling identity-matched (Tier-1)
+                # transcript of the SAME session (same file BaseName / session id).
+                foreach ($tier1Dir in $Tier1AdmittedDirs) {
+                    $siblingPath = Join-Path $tier1Dir "$sessionId.jsonl"
+                    if ((Test-Path -LiteralPath $siblingPath -PathType Leaf) -and
+                        (script:Test-CostWalkerFileHasIssueMarker -FilePath $siblingPath -IssueNumber $resolvedIssueNumber)) {
+                        $corroborated = $true
+                        break
+                    }
+                }
+            }
+
+            if ($corroborated) {
+                $admittedFiles.Add($filePath)
+                $dirAdmittedAny = $true
+            }
+        }
+
+        if (-not $dirAdmittedAny) {
+            $rejectedDirCount++
+        }
+    }
+
+    return @{ AdmittedFiles = $admittedFiles; RejectedDirCount = $rejectedDirCount }
+}
+
 function script:Get-CostWalkerCandidateSlugDirs {
     <#
     .SYNOPSIS
@@ -351,6 +568,15 @@ function script:Get-CostWalkerCandidateSlugDirs {
         RepoRoot, while letting a caller that HAS a distinct RepoRoot (e.g. a
         worktree checkout) get the same identity resolution
         Invoke-CostTranscriptWalk itself always used.
+
+        M23 (issue #825 s1 plan note): the worktree-slug glob branch below admits a
+        directory purely because its NAME matches "$Slug--claude-worktrees-*" — a
+        weaker, name-derived gate than the identity check above — and it stays
+        as-is because it is backward-compat scaffolding for worktree slugs whose
+        first-event cwd may not point at the main repo root; the opt-in Tier-2
+        corroborated-fallback ladder (script:Get-CostWalkerCorroboratedFallbackAdmission)
+        is the actual hardened path for admitting a slug dir whose identity can no
+        longer be verified.
     .OUTPUTS
         [System.Collections.Generic.List[string]]
     #>
@@ -418,6 +644,27 @@ function Invoke-CostTranscriptWalk {
     .PARAMETER IssueNumber
         Optional GitHub issue number. When supplied, enables upstream phase-marker windowing
         and admits only assistant events inside matching issue windows on main/empty branches.
+    .PARAMETER AdmitCorroboratedFallback
+        Issue #825 s1. Opt-in switch (default off — the live PR-create path keeps its
+        pre-#825 fail-closed behavior, M10). When set, enables the Tier-2
+        corroborated-fallback trust ladder: a slug dir whose recorded first-event cwd no
+        longer exists on disk (e.g. a deleted sibling worktree) is admitted anyway when
+        BOTH its gitBranch events match -Branch and its (or a same-session sibling's)
+        phase markers name -IssueNumber. See
+        script:Get-CostWalkerCorroboratedFallbackAdmission for the full ladder contract.
+    .PARAMETER CorroborationWindowStart
+    .PARAMETER CorroborationWindowEnd
+        Issue #825 s1, M8. Optional bounds on Tier-2-admitted events only (Tier 1 is
+        unbounded, unchanged): an admitted Tier-2 event whose timestamp falls outside
+        [CorroborationWindowStart, CorroborationWindowEnd] is excluded, defeating
+        same-repo reused-branch collisions outside the PR's actual
+        first-branch-appearance -> merge lifetime. A $null bound is not enforced.
+    .PARAMETER RejectedDirCountVar
+        Issue #825 s1, M6. Optional [ref] output — when supplied, its .Value is set to
+        the count of Tier-2 branch-matched candidate directories that were rejected for
+        failing corroboration. Always 0 when -AdmitCorroboratedFallback is not set. This
+        is an additive, backward-compatible extension of the return contract: the
+        function's own output stream (the events themselves) is unchanged.
     #>
     [CmdletBinding()]
     param(
@@ -426,7 +673,11 @@ function Invoke-CostTranscriptWalk {
         [Parameter(Mandatory)][string]$ParentCwd,
         [string]$ProjectsRoot = '',
         [Nullable[int]]$IssueNumber = $null,
-        [string]$RepoRoot = ''
+        [string]$RepoRoot = '',
+        [switch]$AdmitCorroboratedFallback,
+        [Nullable[datetime]]$CorroborationWindowStart = $null,
+        [Nullable[datetime]]$CorroborationWindowEnd = $null,
+        [ref]$RejectedDirCountVar
     )
 
     if (-not $ProjectsRoot) {
@@ -439,13 +690,31 @@ function Invoke-CostTranscriptWalk {
     $targetIssueNumber = if ($phaseMarkerMode) { [int]$IssueNumber } else { $null }
 
     $included = [System.Collections.Generic.List[object]]::new()
+    # M7: composite session_id+uuid dedup guard, shared across every admitted dir/tier.
+    $seenDedupKeys = [System.Collections.Generic.HashSet[string]]::new()
 
     # Collect all slug directories to search (D2 identity match + worktree glob + primary-slug
     # backward-compat fallback — shared with Get-CostWalkerCurrentSessionId via
     # script:Get-CostWalkerCandidateSlugDirs so the two callers can never diverge).
     $slugDirs = script:Get-CostWalkerCandidateSlugDirs -ProjectsRoot $ProjectsRoot -RepoRoot $RepoRoot -ParentCwd $ParentCwd -Slug $Slug
 
-    if ($slugDirs.Count -eq 0) {
+    # Issue #825 s1: resolve the opt-in Tier-2 corroborated-fallback admission set BEFORE the
+    # main Tier-1 walk loop below (which is otherwise completely unmodified — Tier 1 stays
+    # unchanged per the plan's non-goal). Tier-2-admitted files are walked in their own block
+    # after Tier 1, using the corroboration + merge-window predicate instead of Tier 1's.
+    $rejectedDirCount = 0
+    $tier2AdmittedFiles = [System.Collections.Generic.List[string]]::new()
+    if ($AdmitCorroboratedFallback) {
+        $resolvedRepoRootForIdentity = if (-not [string]::IsNullOrWhiteSpace($RepoRoot)) { $RepoRoot } else { $ParentCwd }
+        $tier2TargetIdentity = script:Get-CostWalkerTargetIdentity -RepoRoot $resolvedRepoRootForIdentity
+        $tier1AdmittedSet = [System.Collections.Generic.HashSet[string]]::new([string[]]@($slugDirs), [System.StringComparer]::OrdinalIgnoreCase)
+        $tier2Admission = script:Get-CostWalkerCorroboratedFallbackAdmission -ProjectsRoot $ProjectsRoot -TargetIdentity $tier2TargetIdentity -Tier1AdmittedDirs $tier1AdmittedSet -Branch $Branch -IssueNumber $IssueNumber
+        $tier2AdmittedFiles = $tier2Admission.AdmittedFiles
+        $rejectedDirCount = $tier2Admission.RejectedDirCount
+    }
+    if ($null -ne $RejectedDirCountVar) { $RejectedDirCountVar.Value = $rejectedDirCount }
+
+    if ($slugDirs.Count -eq 0 -and $tier2AdmittedFiles.Count -eq 0) {
         return $included
     }
 
@@ -455,6 +724,7 @@ function Invoke-CostTranscriptWalk {
 
         foreach ($file in $jsonlFiles) {
             $lines = @(Get-Content -Path $file.FullName -Encoding utf8 -ErrorAction SilentlyContinue)
+            $sessionId = $file.BaseName
             $currentWindowIssue = $null
             $currentWindowPortHint = $null
             foreach ($line in $lines) {
@@ -487,7 +757,7 @@ function Invoke-CostTranscriptWalk {
 
                     if ($eventType -eq 'assistant') {
                         if (script:Test-CostWalkerAssistantMatchesStrictFilter -TranscriptEvent $parsedEvent -NormalizedParentCwd $normalizedParentCwd -Branch $Branch) {
-                            script:Add-CostWalkerAssistantEventAndSubagents -Included $included -TranscriptEvent $parsedEvent -SlugDir $slugDir
+                            script:Add-CostWalkerAssistantEventAndSubagents -Included $included -TranscriptEvent $parsedEvent -SlugDir $slugDir -SessionId $sessionId -SeenKeys $seenDedupKeys
                             continue
                         }
 
@@ -496,7 +766,7 @@ function Invoke-CostTranscriptWalk {
                         if (-not (script:Test-CostWalkerPhaseMarkerBranchAllowed -Branch $parsedEvent['gitBranch'])) { continue }
 
                         $parsedEvent['_phase_marker_port'] = $currentWindowPortHint
-                        script:Add-CostWalkerAssistantEventAndSubagents -Included $included -TranscriptEvent $parsedEvent -SlugDir $slugDir
+                        script:Add-CostWalkerAssistantEventAndSubagents -Included $included -TranscriptEvent $parsedEvent -SlugDir $slugDir -SessionId $sessionId -SeenKeys $seenDedupKeys
                     }
                     elseif ($null -eq $eventType) {
                         Write-Warning "cost-walker: event with null type in $($file.FullName) — skipping"
@@ -515,7 +785,7 @@ function Invoke-CostTranscriptWalk {
                     if (-not (script:Test-CostWalkerAssistantMatchesStrictFilter -TranscriptEvent $parsedEvent -NormalizedParentCwd $normalizedParentCwd -Branch $Branch)) { continue }
 
                     # Event passes filter — include it and traverse Agent subagents.
-                    script:Add-CostWalkerAssistantEventAndSubagents -Included $included -TranscriptEvent $parsedEvent -SlugDir $slugDir
+                    script:Add-CostWalkerAssistantEventAndSubagents -Included $included -TranscriptEvent $parsedEvent -SlugDir $slugDir -SessionId $sessionId -SeenKeys $seenDedupKeys
                 }
                 elseif ($null -eq $eventType) {
                     Write-Warning "cost-walker: event with null type in $($file.FullName) — skipping"
@@ -528,6 +798,43 @@ function Invoke-CostTranscriptWalk {
                     Write-Warning "cost-walker: unknown event type '$eventType' in $($file.FullName) — skipping"
                 }
             }
+        }
+    }
+
+    # Issue #825 s1: walk the Tier-2 corroborated-fallback admitted files (opt-in, empty unless
+    # -AdmitCorroboratedFallback was set). Uses the same branch-only per-event predicate as Tier
+    # 1 (script:Test-CostWalkerAssistantMatchesStrictFilter) plus the M8 merge-window bound,
+    # which never applies to Tier 1.
+    foreach ($filePath in $tier2AdmittedFiles) {
+        $tier2SessionId = [System.IO.Path]::GetFileNameWithoutExtension($filePath)
+        $tier2SlugDir = Split-Path -Parent $filePath
+        $tier2Lines = @(Get-Content -Path $filePath -Encoding utf8 -ErrorAction SilentlyContinue)
+
+        foreach ($line in $tier2Lines) {
+            $trimmed = $line.Trim()
+            if ([string]::IsNullOrEmpty($trimmed)) { continue }
+
+            $parsedEvent = $null
+            try {
+                $parsedEvent = $trimmed | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+            }
+            catch {
+                Write-Warning "cost-walker: failed to parse JSON line in ${filePath}: $_"
+                continue
+            }
+
+            if ($parsedEvent['type'] -ne 'assistant') { continue }
+            if (-not (script:Test-CostWalkerAssistantMatchesStrictFilter -TranscriptEvent $parsedEvent -NormalizedParentCwd $normalizedParentCwd -Branch $Branch)) { continue }
+
+            if ($null -ne $CorroborationWindowStart -or $null -ne $CorroborationWindowEnd) {
+                $eventTimestamp = $null
+                try { $eventTimestamp = [datetime]$parsedEvent['timestamp'] } catch { }
+                if ($null -eq $eventTimestamp) { continue }  # M8: unparseable timestamp inside a bounded walk is excluded, not assumed in-window
+                if ($null -ne $CorroborationWindowStart -and $eventTimestamp -lt $CorroborationWindowStart) { continue }
+                if ($null -ne $CorroborationWindowEnd -and $eventTimestamp -gt $CorroborationWindowEnd) { continue }
+            }
+
+            script:Add-CostWalkerAssistantEventAndSubagents -Included $included -TranscriptEvent $parsedEvent -SlugDir $tier2SlugDir -SessionId $tier2SessionId -SeenKeys $seenDedupKeys
         }
     }
 

--- a/.github/scripts/lib/cost-walker.ps1
+++ b/.github/scripts/lib/cost-walker.ps1
@@ -80,7 +80,12 @@ function script:Test-CostWalkerEventCwdMatchesParent {
     $eventCwd = $TranscriptEvent['cwd']
     if ($null -eq $eventCwd) { return $false }
 
-    if (([string]$eventCwd).StartsWith($script:CostWalkerCopilotOtelCwdPrefix, [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
+    # C3 (issue #825 post-review fix): guard against an unmarshaled (null-coerced-to-'')
+    # $script:CostWalkerCopilotOtelCwdPrefix — ''.StartsWith(anything) is $true in .NET,
+    # so an unguarded call here would misclassify every real cwd as the sentinel. A
+    # null/empty prefix must mean "no sentinel matches", not "everything matches".
+    if (-not [string]::IsNullOrEmpty($script:CostWalkerCopilotOtelCwdPrefix) -and
+        ([string]$eventCwd).StartsWith($script:CostWalkerCopilotOtelCwdPrefix, [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
 
     $normalizedEventCwd = Get-NormalizedPath -Path ([string]$eventCwd)
     return $normalizedEventCwd -eq $NormalizedParentCwd
@@ -364,7 +369,13 @@ function script:Get-CostWalkerFirstEventCwd {
             if ($null -eq $ev) { continue }
             if (-not [string]::IsNullOrEmpty([string]$ev['cwd'])) {
                 $cwd = [string]$ev['cwd']
-                if (-not $cwd.StartsWith($script:CostWalkerCopilotOtelCwdPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                # C3 (issue #825 post-review fix): same null/empty-prefix guard as
+                # Test-CostWalkerEventCwdMatchesParent above — an unguarded StartsWith('')
+                # would misclassify every real cwd as the sentinel and this function would
+                # return $null for every candidate.
+                $isSentinelCwd = -not [string]::IsNullOrEmpty($script:CostWalkerCopilotOtelCwdPrefix) -and
+                    $cwd.StartsWith($script:CostWalkerCopilotOtelCwdPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+                if (-not $isSentinelCwd) {
                     $firstCwd = $cwd
                     break
                 }
@@ -683,6 +694,15 @@ function Invoke-CostTranscriptWalk {
         failing corroboration. Always 0 when -AdmitCorroboratedFallback is not set. This
         is an additive, backward-compatible extension of the return contract: the
         function's own output stream (the events themselves) is unchanged.
+    .PARAMETER Tier2IssueNumber
+        Issue #825 post-review fix (C2). Optional override for the issue number fed
+        specifically into the Tier-2 corroboration gate
+        (script:Get-CostWalkerCorroboratedFallbackAdmission), kept independent from
+        -IssueNumber's phase-marker windowing use. -IssueNumber is resolved with a
+        PR-body fallback upstream (author-controllable free text), which is acceptable
+        for windowing but must never drive the trust-ladder's corroboration signal.
+        When omitted, falls back to -IssueNumber (preserves pre-fix behavior for callers
+        that do not supply this).
     #>
     [CmdletBinding()]
     param(
@@ -695,11 +715,23 @@ function Invoke-CostTranscriptWalk {
         [switch]$AdmitCorroboratedFallback,
         [Nullable[datetime]]$CorroborationWindowStart = $null,
         [Nullable[datetime]]$CorroborationWindowEnd = $null,
-        [ref]$RejectedDirCountVar
+        [ref]$RejectedDirCountVar,
+        [Nullable[int]]$Tier2IssueNumber = $null
     )
 
     if (-not $ProjectsRoot) {
-        $ProjectsRoot = Join-Path ([System.Environment]::GetFolderPath('UserProfile')) '.claude' 'projects'
+        # C8 (issue #825 post-review fix): honor the same test-only override
+        # cost-fcl-helpers.ps1's script:Test-FCLClaudeProjectsRootAbsent already
+        # respects, so a caller (e.g. Invoke-CostAttributionRepair via
+        # Invoke-CostSessionRender) can point an end-to-end test at a temp
+        # projects root instead of the real user profile.
+        $testProjectsRootOverride = [Environment]::GetEnvironmentVariable('FRAME_CREDIT_LEDGER_TEST_CLAUDE_PROJECTS_ROOT', 'Process')
+        $ProjectsRoot = if (-not [string]::IsNullOrWhiteSpace($testProjectsRootOverride)) {
+            $testProjectsRootOverride
+        }
+        else {
+            Join-Path ([System.Environment]::GetFolderPath('UserProfile')) '.claude' 'projects'
+        }
     }
 
     # Normalize the caller's CWD once for all comparisons
@@ -726,7 +758,18 @@ function Invoke-CostTranscriptWalk {
         $resolvedRepoRootForIdentity = if (-not [string]::IsNullOrWhiteSpace($RepoRoot)) { $RepoRoot } else { $ParentCwd }
         $tier2TargetIdentity = script:Get-CostWalkerTargetIdentity -RepoRoot $resolvedRepoRootForIdentity
         $tier1AdmittedSet = [System.Collections.Generic.HashSet[string]]::new([string[]]@($slugDirs), [System.StringComparer]::OrdinalIgnoreCase)
-        $tier2Admission = script:Get-CostWalkerCorroboratedFallbackAdmission -ProjectsRoot $ProjectsRoot -TargetIdentity $tier2TargetIdentity -Tier1AdmittedDirs $tier1AdmittedSet -Branch $Branch -IssueNumber $IssueNumber
+        # C2 (issue #825 post-review fix): the Tier-2 corroboration gate uses
+        # Tier2IssueNumber (branch-prefix-only, never PR-body-derived) whenever the
+        # caller explicitly supplies it — including an explicit $null, which means
+        # "I resolved this branch-only and got nothing; do NOT fall back to the
+        # (possibly PR-body-derived) -IssueNumber". Falling back to -IssueNumber only
+        # happens for callers that predate this parameter entirely (never mention it),
+        # via ContainsKey rather than a null check — a null-check-only fallback would
+        # silently re-admit the exact PR-body-derived value this fix exists to reject
+        # whenever a caller resolves Tier2IssueNumber to $null (branch didn't match)
+        # and still threads that resolved $null through explicitly.
+        $tier2EffectiveIssueNumber = if ($PSBoundParameters.ContainsKey('Tier2IssueNumber')) { $Tier2IssueNumber } else { $IssueNumber }
+        $tier2Admission = script:Get-CostWalkerCorroboratedFallbackAdmission -ProjectsRoot $ProjectsRoot -TargetIdentity $tier2TargetIdentity -Tier1AdmittedDirs $tier1AdmittedSet -Branch $Branch -IssueNumber $tier2EffectiveIssueNumber
         $tier2AdmittedFiles = $tier2Admission.AdmittedFiles
         $rejectedDirCount = $tier2Admission.RejectedDirCount
     }


### PR DESCRIPTION
## Summary

Repairs orchestrated PRs that render an empty "no session activity" cost block, scoped (per the plan stress-test decision) to the high-value core:

1. **Opt-in discovery trust ladder** in `cost-walker.ps1` ╬ô├ç├╢ a Tier-2 corroborated-fallback (behind `-AdmitCorroboratedFallback`, **off by default** so the live PR-create path is unchanged) that admits transcripts from *deleted* worktrees only on strict cwd-absent + branch-match + branch-prefix issue-marker + within the PR's merge-time window, with cross-file corroboration, a composite `session_id`+`uuid` dedup key, and a rejected-dir count in the return.
2. **Honest 3-state empty-block render** in `cost-pattern-renderer.ps1` + `cost-session-render.ps1` ╬ô├ç├╢ drops the retired **#488** pointer, names the real loss modes, and renders CI / no-local-data / genuinely-empty distinctly via a caller-computed `-RenderContext`; adds a coverage annotation on populated blocks.
3. **Targeted re-attribution entry point** `Invoke-CostAttributionRepair -Pr N` in `cost-baseline-harvest.ps1` ╬ô├ç├╢ resolves the PR's *real* head ref (never the CI-written `branch: HEAD`), re-walks with the fallback on, and upserts populated-beats-empty with an honest completeness label. A standalone function, **not** an extension of the automatic candidate loop (that path ╬ô├ç├╢ passive self-healing ╬ô├ç├╢ is deferred to #841).

The one-time AC1b denominator audit was run and attached to #825. Root cause was pinned during design (AC1). The PR-create-path defect stays deferred to #840; the automatic startup-drain stays deferred to #841.

Closes #825

## Changed files

- `.github/scripts/lib/cost-walker.ps1` ╬ô├ç├╢ opt-in Tier-2 trust ladder, composite dedup, rejected-dir count, extracted helpers
- `.github/scripts/lib/cost-pattern-renderer.ps1` ╬ô├ç├╢ 3-state honest render, coverage annotation, #488 removed
- `.github/scripts/lib/cost-session-render.ps1` ╬ô├ç├╢ RenderContext + window + fallback threading; overridable cost budget
- `.github/scripts/lib/cost-baseline-harvest.ps1` ╬ô├ç├╢ `Invoke-CostAttributionRepair`; empty-section splice guard
- `.github/scripts/lib/cost-fcl-helpers.ps1` ╬ô├ç├╢ `[AllowEmptyString()]` on Copilot-absent render path (Γö£├╣2)
- `.github/scripts/Tests/{cost-walker,cost-pattern-renderer,cost-baseline-harvest,frame-credit-ledger-degraded-telemetry}.Tests.ps1` ╬ô├ç├╢ unit + regression pins

9 files, +2241 / ╬ô├¬├å78.

## Validation evidence

`Invoke-Pester` over the cost / fcl / degraded-telemetry suite (18 files): **463 passed / 0 failed / 15 skipped** (skips are pre-existing environment-dependent). `rg -n '488' cost-pattern-renderer.ps1` ╬ô├Ñ├å empty (AC4). Scope check (`git diff --name-status main..HEAD`) ╬ô├Ñ├å all changes confined to cost-pipeline lib + tests.

## Review Mode

Full review pipeline completed: 5 prosecution passes (2 generalist + 3 specialist), 1 defense pass, 1 judge pass ╬ô├ç├╢ followed by a post-fix targeted prosecution + defense pass, plus three CE-Gate-surfaced fix cycles each with a post-fix prosecution/defense.

## CE Gate result

**╬ô┬ú├á CE Gate passed after fix ╬ô├ç├╢ intent match: strong** (evidence: automated-runner 3/4, live-interaction 1/4)

Design intent ╬ô├ç├╢ *measurement trust over silent exclusion; an empty block must be honest about why it might be empty* ╬ô├ç├╢ is strongly met.

| ID | Type | Class | Result | Evidence | Source |
| --- | --- | --- | --- | --- | --- |
| S1 | Functional | [auto] | ╬ô┬ú├á Passed | 10-case walker ladder incl. deleted-worktree-corroborated admit | Runner |
| S2 | Functional | [auto] | ╬ô┬ú├á Passed | mid-session-branch + branch/body issue-mismatch reject fixtures | Runner |
| S3 | Functional | [auto] | ╬ô┬ú├á Passed | 3 render-state tests; **verified live** ╬ô├ç├╢ #814/#815 now show the honest message, no #488 | Runner + live |
| S4 | Intent | [manual] | ╬ô┬ú├á Passed after fix | live re-walk of real #814/#815 surfaced & fixed 3 defects; honest-empty path now non-destructive; live comments restored | EO/live |

**S4 caught three real defects that every mock-based test and the adversarial code review missed** ╬ô├ç├╢ all fixed in-PR and regression-pinned:
- **Data loss (critical)**: the repair spliced an *empty* section over the real block (deleting it) when the walk found events but exhausted the cost budget before composing ╬ô├ç├╢ the guard checked event count, not section content. Fixed: gate on a non-empty section; distinct honest "exhausted render budget" signal.
- **Inoperable budget**: the 19s cost budget was hardcoded ╬ô├Ñ├å unrenderable on a large local profile. Fixed: `FRAME_CREDIT_LEDGER_TEST_COST_BUDGET_SECONDS` override.
- **Copilot-absent throw (Γö£├╣2)**: `[Parameter(Mandatory)][string]` rejected the empty Copilot-OTEL path on any Copilot-absent machine ╬ô├Ñ├å silent empty render. Fixed: `[AllowEmptyString()]`.

**Known limitation (not a code defect):** producing a *populated* block for the two specific historical PRs #814/#815 on the maintainer's machine currently yields zero events, because a long active session grows the shared transcript slug and starves the walk of time to reach the older buried events. This is a walk-performance limitation on a live-growing profile, tracked with #841's perf concerns; the honesty intent and the mechanism itself (unit-proven) are unaffected.

## Adversarial Review Scores

| Stage | Prosecutor | Defense | Judge rulings |
| --- | --- | --- | --- |
| Code Review | 45 pts (7 sustained) | 15 pts net | 15 rulings (7 sustained, 8 defense-sustained) |
| Post-fix Review | 0 sustained (1 advisory closed inline) | clean | verified no regressions |
| CE Review (live) | 3 defects (via live S4 exercise) | ╬ô├ç├╢ | all 3 fixed + regression-pinned |

## Pipeline Metrics

- Implementation: 4 slices (s1 trust ladder, s2 render, s3 targeted repair, s4 audit) + refactor pass.
- Review: 1 standard 5-pass code review ╬ô├Ñ├å 7 judge-sustained findings fixed ╬ô├Ñ├å post-fix prosecution/defense clean ╬ô├Ñ├å 1 advisory (C4 test-coverage) closed inline.
- CE Gate: 3 additional live-surfaced defects fixed.
- Deferrals: #840 (PR-create path), #841 (automatic startup-drain).

Γëí╞Æ├▒├╗ Generated with [Claude Code](https://claude.com/claude-code)


<!-- pipeline-metrics
pr_number: 845
branch: feature/issue-825-branch-attribution-gap
metrics_version: 4
frame_version: 1
credits:
  - port: implement-code
    adapter: skills/implementation-discipline/adapters/implement-code-adapter.md
    status: passed
    evidence: Trust ladder (s1) + honest render (s2) + Invoke-CostAttributionRepair (s3, terminal) + 3 CE-Gate fixes; 463/0/15 cost-* + fcl suite green.
    terminal-step-id: 3
  - port: implement-test
    adapter: skills/test-driven-development/SKILL.md
    status: passed
    evidence: Walker ladder (10 cases), render 3-state, harvest end-to-end + regression pins; 463/0/15.
    terminal-step-id: 3
  - port: review
    adapter: standard
    status: passed
    run_index: 1
    evidence: '5-pass prosecution -> defense -> judge: 15 findings, 7 sustained + fixed, post-fix prosecution/defense clean.; judge ruling: passed, 7 finding(s) sustained; integrity: 1,2,3,4,5 passes, status passed'
    terminal-step-id: 5
  - port: ce-gate-cli
    status: passed
    evidence: 'CE Gate passed after fix; S4 live re-walk of #814/#815 surfaced+fixed 3 defects; intent match strong (honesty).'
    terminal-step-id: 6
  - port: experience
    adapter: work-adapter
    status: passed
    evidence: 'issue #825; experience completion marker posted'
  - port: design
    adapter: work-adapter
    status: passed
    evidence: 'issue #825; design completion marker posted'
  - port: plan
    adapter: work-adapter
    status: passed
    evidence: 'issue #825; plan completion marker posted'
  - port: orchestration
    adapter: scope-classification
    status: passed
    evidence: 'issue #825; scope-classification announced (deterministic rubric)'
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added targeted repair for incomplete cost-attribution results on merged pull requests.
  * Added clearer environment-aware diagnostics for unavailable or incomplete session data.
  * Added support for corroborating transcript activity across eligible session sources.

* **Bug Fixes**
  * Prevented duplicate event counting and accidental overwrites during concurrent updates.
  * Improved handling of missing telemetry, empty results, and unavailable local session data.
  * Corrected branch and time-window attribution to improve Tier-2 cost accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->