### PR TITLE
chore(control-tower): drop closed umbrella #732 from the tracking list

### DIFF
--- a/Documents/Planning/sequence.yaml
+++ b/Documents/Planning/sequence.yaml
@@ -4,4 +4,4 @@
 schema_version: 2
 control_tower: 704
 recently_closed_days: 14
-umbrellas: [761, 571, 732, 343, 693, 674, 662, 476, 830, 801]
+umbrellas: [761, 571, 343, 693, 674, 662, 476, 830, 801]


### PR DESCRIPTION
#732 (umbrella: *Remove the contribution barrier for occasional human readers*) is **closed** — its last child #751 shipped. This removes it from the hand-curated `umbrellas:` list in `Documents/Planning/sequence.yaml` so the portfolio control tower tracks only active epics.

- Only `#732` removed; every other listed umbrella (#761, #571, #343, #693, #674, #662, #476, #830, #801) is still OPEN.
- One-line planning-config edit; the `[n, n, …]` format is preserved so `ConvertFrom-SequenceSpec`'s strict regex still parses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Update sequence planning configuration to drop closed umbrella #732 from the umbrellas list while preserving the existing format.